### PR TITLE
Surefire plugin now runs tests matching `**/*IT.java`

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -213,6 +213,13 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>2.18.1</version>
+
+                <configuration>
+                    <includes>
+                        <include>**/*Test.java</include>
+                        <include>**/*IT.java</include>
+                    </includes>
+                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
In order to match the Netbeans test naming convention,
using `**/*Test.java` or `**/*IT.java`, the Surefire plugin has been
reconfigured.

Note that `**/Test*.java` and `**/*TestCase.java` are no longer
recognized as tests.