### PR TITLE
Prevented tests from taking window focus on OS X

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -228,6 +228,8 @@
                         <include>**/*Test.java</include>
                         <include>**/*IT.java</include>
                     </includes>
+
+                    <argLine>-Djava.awt.headless=true</argLine>
                 </configuration>
             </plugin>
             <plugin>


### PR DESCRIPTION
Prevented tests from taking window focus on OS X by explicitly requiring
them to be headless in the POM.