### PR TITLE
hotfix to handle resources cases local class file vs jar file

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
     <groupId>org.cirdles</groupId>
     <artifactId>ET_Redux</artifactId>
     <name>ET_Redux</name>
-    <version>3.2.0</version>
+    <version>3.2.1</version>
     <description>Successor to U-Pb_Redux</description>
     <url>https://cirdles.org</url>
     <inceptionYear>2006</inceptionYear>

--- a/src/main/java/org/earthtime/ETRedux.java
+++ b/src/main/java/org/earthtime/ETRedux.java
@@ -21,12 +21,11 @@
 package org.earthtime;
 
 import java.awt.Font;
+import java.io.BufferedReader;
 import java.io.File;
-import java.io.FileNotFoundException;
-import java.net.URL;
-import java.util.Scanner;
-import java.util.logging.Level;
-import java.util.logging.Logger;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
 import javax.help.SwingHelpUtilities;
 import javax.swing.ToolTipManager;
 import javax.swing.UIManager;
@@ -34,7 +33,6 @@ import org.earthtime.UPb_Redux.exceptions.BadLabDataException;
 import org.earthtime.UPb_Redux.user.ReduxPersistentState;
 import org.earthtime.UPb_Redux.utilities.JHelpAction;
 import org.earthtime.exceptions.ETWarningDialog;
-import org.earthtime.ratioDataModels.mineralStandardModels.MineralStandardUPbModel;
 
 /**
  *
@@ -48,12 +46,12 @@ public class ETRedux {
     /**
      * Version 3.0.0 initiates switch to ET_Redux from U-Pb_Redux
      */
-    public static String VERSION;// = "3.x.0";
+    public static String VERSION = "version";
 
     /**
      *
      */
-    public static String RELEASE_DATE;// = "June 2015";
+    public static String RELEASE_DATE = "date";
 
     /**
      * Creates a new instance of UPbRedux
@@ -62,22 +60,19 @@ public class ETRedux {
      */
     public ETRedux(File reduxFile) //throws3 IOException, InvalidPreferencesFormatException 
     {
-        // get version number written by pom.xml
-        URL versionFileURL = MineralStandardUPbModel.class.getClassLoader().getResource("version.txt");
-        File versionFile = new File(versionFileURL.getPath());
-
-        try ( //first use a Scanner to get headers of 4 lines
-                // http://en.wikipedia.org/wiki/Windows-1252
-                Scanner scanner = new Scanner(versionFile, "CP1252")) {
-            String[] versionText = scanner.nextLine().split("=");
+        try {
+            // get version number written by pom.xml
+            InputStream versionFileStreamL = ETRedux.class.getClassLoader().getResourceAsStream("version.txt");
+            BufferedReader reader = new BufferedReader(new InputStreamReader(versionFileStreamL));
+            StringBuilder out = new StringBuilder();
+            String line;
+            
+            String[] versionText = reader.readLine().split("=");
             VERSION = versionText[1];
-
-            String[] versionDate = scanner.nextLine().split("=");
+            
+            String[] versionDate = reader.readLine().split("=");
             RELEASE_DATE = versionDate[1];
-
-            scanner.close();
-        } catch (FileNotFoundException ex) {
-            Logger.getLogger(ETRedux.class.getName()).log(Level.SEVERE, null, ex);
+        } catch (IOException iOException) {
         }
 
         // get redux persistent state file
@@ -116,7 +111,7 @@ public class ETRedux {
         // installer etc ref
         // http://www.centerkey.com/mac/java/
     }
-        // installer etc ref
+    // installer etc ref
     // http://www.centerkey.com/mac/java/
 
     /**

--- a/src/main/java/org/earthtime/UPb_Redux/fractions/AnalysisFraction.java
+++ b/src/main/java/org/earthtime/UPb_Redux/fractions/AnalysisFraction.java
@@ -23,7 +23,11 @@ package org.earthtime.UPb_Redux.fractions;
 import com.thoughtworks.xstream.XStream;
 import com.thoughtworks.xstream.converters.ConversionException;
 import com.thoughtworks.xstream.io.xml.DomDriver;
-import java.io.*;
+import java.io.BufferedReader;
+import java.io.FileNotFoundException;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.io.PrintWriter;
 import org.earthtime.UPb_Redux.ReduxConstants;
 import org.earthtime.UPb_Redux.fractions.UPbReduxFractions.UPbFraction;
 import org.earthtime.UPb_Redux.fractions.UPbReduxFractions.fractionReduction.UPbFractionReducer;
@@ -34,10 +38,10 @@ import org.earthtime.UPb_Redux.valueModels.MeasuredRatioModelXMLConverter;
 import org.earthtime.UPb_Redux.valueModels.ValueModel;
 import org.earthtime.UPb_Redux.valueModels.ValueModelXMLConverter;
 import org.earthtime.XMLExceptions.BadOrMissingXMLSchemaException;
+import org.earthtime.archivingTools.URIHelper;
 import org.earthtime.exceptions.ETException;
 import org.earthtime.ratioDataModels.initialPbModelsET.InitialPbModelET;
 import org.earthtime.ratioDataModels.initialPbModelsET.InitialPbModelETXMLConverter;
-import org.earthtime.archivingTools.URIHelper;
 import org.earthtime.xmlUtilities.XMLSerializationI;
 
 /**
@@ -180,12 +184,12 @@ public class AnalysisFraction extends Fraction implements
                     throw new ETException( null, e.getMessage() );
                 }
 
-                System.out.println( "This is your AnalysisFraction that was just read successfully:\n" );
-
-                String xml2 = getXStreamWriter().toXML( myFraction );
-
-                System.out.println( xml2 );
-                System.out.flush();
+//                System.out.println( "This is your AnalysisFraction that was just read successfully:\n" );
+//
+//                String xml2 = getXStreamWriter().toXML( myFraction );
+//
+//                System.out.println( xml2 );
+//                System.out.flush();
             } else {
                 throw new ETException( null, "XML data file does not conform to schema." );
             }

--- a/src/main/java/org/earthtime/UPb_Redux/initialPbModels/InitialPbModel.java
+++ b/src/main/java/org/earthtime/UPb_Redux/initialPbModels/InitialPbModel.java
@@ -23,7 +23,12 @@ package org.earthtime.UPb_Redux.initialPbModels;
 import com.thoughtworks.xstream.XStream;
 import com.thoughtworks.xstream.converters.ConversionException;
 import com.thoughtworks.xstream.io.xml.DomDriver;
-import java.io.*;
+import java.io.BufferedReader;
+import java.io.FileNotFoundException;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.io.Serializable;
 import java.math.BigDecimal;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -34,12 +39,12 @@ import org.earthtime.UPb_Redux.user.UPbReduxConfigurator;
 import org.earthtime.UPb_Redux.valueModels.ValueModel;
 import org.earthtime.UPb_Redux.valueModels.ValueModelXMLConverter;
 import org.earthtime.XMLExceptions.BadOrMissingXMLSchemaException;
-import org.earthtime.exceptions.ETException;
+import org.earthtime.archivingTools.URIHelper;
 import org.earthtime.dataDictionaries.DataDictionary;
+import org.earthtime.exceptions.ETException;
 import org.earthtime.ratioDataModels.AbstractRatiosDataModel;
 import org.earthtime.ratioDataModels.initialPbModelsET.InitialPbModelET;
 import org.earthtime.utilities.DateHelpers;
-import org.earthtime.archivingTools.URIHelper;
 import org.earthtime.xmlUtilities.XMLSerializationI;
 
 /**
@@ -520,12 +525,12 @@ public class InitialPbModel implements
                     throw new ETException( null, e.getMessage() );
                 }
 
-                System.out.println( "This is your InitialPbModel that was just read successfully:\n" );
-
-                String xml2 = getXStreamWriter().toXML( myInitialPbModel );
-
-                System.out.println( xml2 );
-                System.out.flush();
+//                System.out.println( "This is your InitialPbModel that was just read successfully:\n" );
+//
+//                String xml2 = getXStreamWriter().toXML( myInitialPbModel );
+//
+//                System.out.println( xml2 );
+//                System.out.flush();
             }
 
         } else {

--- a/src/main/java/org/earthtime/UPb_Redux/mineralStandardModels/MineralStandardModel.java
+++ b/src/main/java/org/earthtime/UPb_Redux/mineralStandardModels/MineralStandardModel.java
@@ -39,13 +39,13 @@ import org.earthtime.UPb_Redux.valueModels.ValueModelReferenced;
 import org.earthtime.UPb_Redux.valueModels.ValueModelReferencedXMLConverter;
 import org.earthtime.UPb_Redux.valueModels.ValueModelXMLConverter;
 import org.earthtime.XMLExceptions.BadOrMissingXMLSchemaException;
+import org.earthtime.archivingTools.URIHelper;
 import org.earthtime.dataDictionaries.DataDictionary;
 import org.earthtime.exceptions.ETException;
 import org.earthtime.ratioDataModels.AbstractRatiosDataModel;
 import org.earthtime.ratioDataModels.initialPbModelsET.InitialPbModelET;
 import org.earthtime.ratioDataModels.mineralStandardModels.MineralStandardUPbModel;
 import org.earthtime.utilities.DateHelpers;
-import org.earthtime.archivingTools.URIHelper;
 import org.earthtime.xmlUtilities.XMLSerializationI;
 
 /**
@@ -379,6 +379,7 @@ public class MineralStandardModel implements
      * @throws ETException
      * @throws BadOrMissingXMLSchemaException
      */
+    @Override
     public Object readXMLObject ( String filename, boolean doValidate )
             throws FileNotFoundException,
             ETException,
@@ -404,12 +405,6 @@ public class MineralStandardModel implements
                     throw new ETException( null, e.getMessage() );
                 }
 
-                System.out.println( "This is your MineralStandardModel that was just read successfully:\n" );
-
-                String xml2 = getXStreamWriter().toXML( myMineralStandardModel );
-
-                System.out.println( xml2 );
-                System.out.flush();
             } else {
                 throw new FileNotFoundException( "Badly formed or unvalidated XML data file." );
             }

--- a/src/main/java/org/earthtime/UPb_Redux/pbBlanks/PbBlank.java
+++ b/src/main/java/org/earthtime/UPb_Redux/pbBlanks/PbBlank.java
@@ -23,7 +23,12 @@ package org.earthtime.UPb_Redux.pbBlanks;
 import com.thoughtworks.xstream.XStream;
 import com.thoughtworks.xstream.converters.ConversionException;
 import com.thoughtworks.xstream.io.xml.DomDriver;
-import java.io.*;
+import java.io.BufferedReader;
+import java.io.FileNotFoundException;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.io.Serializable;
 import java.math.BigDecimal;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -34,12 +39,12 @@ import org.earthtime.UPb_Redux.user.UPbReduxConfigurator;
 import org.earthtime.UPb_Redux.valueModels.ValueModel;
 import org.earthtime.UPb_Redux.valueModels.ValueModelXMLConverter;
 import org.earthtime.XMLExceptions.BadOrMissingXMLSchemaException;
-import org.earthtime.exceptions.ETException;
+import org.earthtime.archivingTools.URIHelper;
 import org.earthtime.dataDictionaries.DataDictionary;
+import org.earthtime.exceptions.ETException;
 import org.earthtime.ratioDataModels.AbstractRatiosDataModel;
 import org.earthtime.ratioDataModels.pbBlankICModels.PbBlankICModel;
 import org.earthtime.utilities.DateHelpers;
-import org.earthtime.archivingTools.URIHelper;
 import org.earthtime.xmlUtilities.XMLSerializationI;
 
 /**
@@ -671,12 +676,12 @@ public class PbBlank implements
                     throw new ETException( null, e.getMessage() );
                 }
 
-                System.out.println( "This is your PbBlank that was just read successfully:\n" );
+//                System.out.println( "This is your PbBlank that was just read successfully:\n" );
 
-                String xml2 = getXStreamWriter().toXML( retPbBlank );
-
-                System.out.println( xml2 );
-                System.out.flush();
+//                String xml2 = getXStreamWriter().toXML( retPbBlank );
+//
+//                System.out.println( xml2 );
+//                System.out.flush();
             }
 
         } else {

--- a/src/main/java/org/earthtime/UPb_Redux/samples/SESARSampleMetadata.java
+++ b/src/main/java/org/earthtime/UPb_Redux/samples/SESARSampleMetadata.java
@@ -33,8 +33,8 @@ import java.io.Serializable;
 import org.earthtime.UPb_Redux.ReduxConstants;
 import org.earthtime.UPb_Redux.user.UPbReduxConfigurator;
 import org.earthtime.XMLExceptions.BadOrMissingXMLSchemaException;
-import org.earthtime.exceptions.ETException;
 import org.earthtime.archivingTools.URIHelper;
+import org.earthtime.exceptions.ETException;
 import org.earthtime.xmlUtilities.XMLSerializationI;
 
 /**
@@ -286,12 +286,12 @@ public class SESARSampleMetadata
                     throw new ETException(null, e.getMessage());
                 }
 
-                System.out.println("This is your SESARSampleMetadata that was just read successfully:\n");
+//                System.out.println("This is your SESARSampleMetadata that was just read successfully:\n");
 
-                String xml2 = getXStreamWriter().toXML(SESARSampleMetadata);
-
-                System.out.println(xml2);
-                System.out.flush();
+//                String xml2 = getXStreamWriter().toXML(SESARSampleMetadata);
+//
+//                System.out.println(xml2);
+//                System.out.flush();
             } else {
                 throw new ETException( null, "XML data file does not conform to schema." );
             }

--- a/src/main/java/org/earthtime/UPb_Redux/samples/SampleMetaData.java
+++ b/src/main/java/org/earthtime/UPb_Redux/samples/SampleMetaData.java
@@ -32,8 +32,8 @@ import org.earthtime.UPb_Redux.ReduxConstants;
 import org.earthtime.UPb_Redux.fractions.FractionMetaData;
 import org.earthtime.UPb_Redux.user.UPbReduxConfigurator;
 import org.earthtime.XMLExceptions.BadOrMissingXMLSchemaException;
-import org.earthtime.exceptions.ETException;
 import org.earthtime.archivingTools.URIHelper;
+import org.earthtime.exceptions.ETException;
 import org.earthtime.xmlUtilities.XMLSerializationI;
 
 /**
@@ -250,12 +250,12 @@ public class SampleMetaData implements XMLSerializationI {
                     throw new ETException(null, e.getMessage());
                 }
 
-                System.out.println("\nThis is your SampleMetaData that was just read successfully:\n");
+//                System.out.println("\nThis is your SampleMetaData that was just read successfully:\n");
 
-                String xml2 = getXStreamWriter().toXML(mySampleMetaData);
-
-                System.out.println(xml2);
-                System.out.flush();
+//                String xml2 = getXStreamWriter().toXML(mySampleMetaData);
+//
+//                System.out.println(xml2);
+//                System.out.flush();
             }
 
         } else {

--- a/src/main/java/org/earthtime/UPb_Redux/tracers/Tracer.java
+++ b/src/main/java/org/earthtime/UPb_Redux/tracers/Tracer.java
@@ -23,7 +23,12 @@ package org.earthtime.UPb_Redux.tracers;
 import com.thoughtworks.xstream.XStream;
 import com.thoughtworks.xstream.converters.ConversionException;
 import com.thoughtworks.xstream.io.xml.DomDriver;
-import java.io.*;
+import java.io.BufferedReader;
+import java.io.FileNotFoundException;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.io.Serializable;
 import java.text.DateFormat;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
@@ -36,14 +41,14 @@ import org.earthtime.UPb_Redux.user.UPbReduxConfigurator;
 import org.earthtime.UPb_Redux.valueModels.ValueModel;
 import org.earthtime.UPb_Redux.valueModels.ValueModelXMLConverter;
 import org.earthtime.XMLExceptions.BadOrMissingXMLSchemaException;
-import org.earthtime.exceptions.ETException;
+import org.earthtime.archivingTools.URIHelper;
 import org.earthtime.dataDictionaries.DataDictionary;
 import org.earthtime.dataDictionaries.TracerIsotopes;
 import org.earthtime.dataDictionaries.TracerRatiosEnum;
+import org.earthtime.exceptions.ETException;
 import org.earthtime.ratioDataModels.AbstractRatiosDataModel;
 import org.earthtime.ratioDataModels.tracers.TracerUPbModel;
 import org.earthtime.utilities.DateHelpers;
-import org.earthtime.archivingTools.URIHelper;
 import org.earthtime.xmlUtilities.XMLSerializationI;
 
 /**
@@ -939,12 +944,12 @@ public class Tracer implements
                     throw new ETException( null, e.getMessage() );
                 }
 
-                System.out.println( "This is your Tracer that was just read successfully:\n" );
+//                System.out.println( "This is your Tracer that was just read successfully:\n" );
 
-                String xml2 = getXStreamWriter().toXML( myTracer );
-
-                System.out.println( xml2 );
-                System.out.flush();
+//                String xml2 = getXStreamWriter().toXML( myTracer );
+//
+//                System.out.println( xml2 );
+//                System.out.flush();
 
             } else {
                 throw new ETException( null, "Badly formed XML data file." );

--- a/src/main/java/org/earthtime/UPb_Redux/valueModels/MeasuredRatioModel.java
+++ b/src/main/java/org/earthtime/UPb_Redux/valueModels/MeasuredRatioModel.java
@@ -22,12 +22,17 @@ package org.earthtime.UPb_Redux.valueModels;
 
 import com.thoughtworks.xstream.XStream;
 import com.thoughtworks.xstream.converters.ConversionException;
-import java.io.*;
+import java.io.BufferedReader;
+import java.io.FileNotFoundException;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.io.Serializable;
 import java.math.BigDecimal;
 import org.earthtime.UPb_Redux.ReduxConstants;
 import org.earthtime.XMLExceptions.BadOrMissingXMLSchemaException;
-import org.earthtime.exceptions.ETException;
 import org.earthtime.archivingTools.URIHelper;
+import org.earthtime.exceptions.ETException;
 import org.earthtime.xmlUtilities.XMLSerializationI;
 
 /**
@@ -297,12 +302,12 @@ public class MeasuredRatioModel extends ValueModel implements
                     throw new ETException( null, e.getMessage() );
                 }
 
-                System.out.println( "\nThis is your MeasuredRatioModel that was just read successfully:\n" );
+////                System.out.println( "\nThis is your MeasuredRatioModel that was just read successfully:\n" );
 
-                String xml2 = getXStreamWriter().toXML( myValueModel );
-
-                System.out.println( xml2 );
-                System.out.flush();
+//                String xml2 = getXStreamWriter().toXML( myValueModel );
+//
+//                System.out.println( xml2 );
+//                System.out.flush();
             } else {
                 throw new ETException( null, "XML data file does not conform to schema." );
             }

--- a/src/main/java/org/earthtime/UPb_Redux/valueModels/ValueModel.java
+++ b/src/main/java/org/earthtime/UPb_Redux/valueModels/ValueModel.java
@@ -1050,12 +1050,12 @@ public class ValueModel implements
                     throw new ETException(null, e.getMessage());
                 }
 
-                System.out.println("\nThis is your ValueModel that was just read successfully:\n");
+//                System.out.println("\nThis is your ValueModel that was just read successfully:\n");
 
-                String xml2 = getXStreamWriter().toXML(myValueModel);
-
-                System.out.println(xml2);
-                System.out.flush();
+//                String xml2 = getXStreamWriter().toXML(myValueModel);
+//
+//                System.out.println(xml2);
+//                System.out.flush();
             } else {
                 throw new ETException(null, "XML data file does not conform to schema.");
             }

--- a/src/main/java/org/earthtime/UPb_Redux/valueModels/ValueModelReferenced.java
+++ b/src/main/java/org/earthtime/UPb_Redux/valueModels/ValueModelReferenced.java
@@ -31,8 +31,8 @@ import java.io.Serializable;
 import java.math.BigDecimal;
 import org.earthtime.UPb_Redux.ReduxConstants;
 import org.earthtime.XMLExceptions.BadOrMissingXMLSchemaException;
-import org.earthtime.exceptions.ETException;
 import org.earthtime.archivingTools.URIHelper;
+import org.earthtime.exceptions.ETException;
 import org.earthtime.xmlUtilities.XMLSerializationI;
 
 /**
@@ -287,12 +287,12 @@ public class ValueModelReferenced extends ValueModel implements
                     throw new ETException( null, e.getMessage() );
                 }
 
-                System.out.println( "\nThis is your ValueModelReferenced that was just read successfully:\n" );
+//                System.out.println( "\nThis is your ValueModelReferenced that was just read successfully:\n" );
 
-                String xml2 = getXStreamWriter().toXML( myValueModel );
-
-                System.out.println( xml2 );
-                System.out.flush();
+//                String xml2 = getXStreamWriter().toXML( myValueModel );
+//
+//                System.out.println( xml2 );
+//                System.out.flush();
             } else {
                 throw new ETException( null, "XML data file does not conform to schema." );
             }

--- a/src/main/java/org/earthtime/archivingTools/forSESAR/SesarSample.java
+++ b/src/main/java/org/earthtime/archivingTools/forSESAR/SesarSample.java
@@ -210,12 +210,12 @@ public class SesarSample {
                 throw new ETException(null, e.getMessage());
             }
 
-            System.out.println("\nThis is your SesarSample that was just read successfully:\n");
+//            System.out.println("\nThis is your SesarSample that was just read successfully:\n");
 
-            String xml2 = getXStreamWriter().toXML(sesarSample);
-
-            System.out.println(xml2);
-            System.out.flush();
+//            String xml2 = getXStreamWriter().toXML(sesarSample);
+//
+//            System.out.println(xml2);
+//            System.out.flush();
 
         } else {
             throw new FileNotFoundException("Missing XML data file.");

--- a/src/main/java/org/earthtime/physicalConstants/PhysicalConstants.java
+++ b/src/main/java/org/earthtime/physicalConstants/PhysicalConstants.java
@@ -23,7 +23,12 @@ package org.earthtime.physicalConstants;
 import com.thoughtworks.xstream.XStream;
 import com.thoughtworks.xstream.converters.ConversionException;
 import com.thoughtworks.xstream.io.xml.DomDriver;
-import java.io.*;
+import java.io.BufferedReader;
+import java.io.FileNotFoundException;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.io.Serializable;
 import java.math.BigDecimal;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -37,14 +42,14 @@ import org.earthtime.UPb_Redux.valueModels.ValueModelReferenced;
 import org.earthtime.UPb_Redux.valueModels.ValueModelReferencedXMLConverter;
 import org.earthtime.UPb_Redux.valueModels.ValueModelXMLConverter;
 import org.earthtime.XMLExceptions.BadOrMissingXMLSchemaException;
-import org.earthtime.exceptions.ETException;
+import org.earthtime.archivingTools.URIHelper;
 import org.earthtime.dataDictionaries.DataDictionary;
 import org.earthtime.dataDictionaries.Lambdas;
+import org.earthtime.exceptions.ETException;
 import org.earthtime.matrices.matrixModels.CovarianceMatrixModel;
 import org.earthtime.ratioDataModels.AbstractRatiosDataModel;
 import org.earthtime.ratioDataModels.physicalConstantsModels.PhysicalConstantsModel;
 import org.earthtime.utilities.DateHelpers;
-import org.earthtime.archivingTools.URIHelper;
 import org.earthtime.xmlUtilities.XMLSerializationI;
 
 /**
@@ -560,12 +565,12 @@ public class PhysicalConstants implements
                     throw new ETException(null, e.getMessage());
                 }
 
-                System.out.println("This is your PhysicalConstants that was just read successfully:\n");
+//                System.out.println("This is your PhysicalConstants that was just read successfully:\n");
 
-                String xml2 = getXStreamWriter().toXML(myPhysicalConstants);
-
-                System.out.println(xml2);
-                System.out.flush();
+//                String xml2 = getXStreamWriter().toXML(myPhysicalConstants);
+//
+//                System.out.println(xml2);
+//                System.out.flush();
             } else {
                 throw new ETException(null, "Badly formed PhysicalConstants XML data file.");
             }

--- a/src/main/java/org/earthtime/ratioDataModels/AbstractRatiosDataModel.java
+++ b/src/main/java/org/earthtime/ratioDataModels/AbstractRatiosDataModel.java
@@ -303,7 +303,7 @@ public abstract class AbstractRatiosDataModel implements
             initializeBothDataCorrelationM();
             generateBothUnctCovarianceMFromEachUnctCorrelationM();
         } catch (Exception e) {
-            System.out.println(e.getMessage());
+//            System.out.println(e.getMessage());
         }
     }
 
@@ -1089,15 +1089,15 @@ public abstract class AbstractRatiosDataModel implements
 
                 myModelClassInstance.initializeModel();
 
-                System.out.println( //
-                        "This is your " //
-                        + myModelClassInstance.getClass().getSimpleName()//
-                        + " that was just read successfully:\n");
+//                System.out.println( //
+//                        "This is your " //
+//                        + myModelClassInstance.getClass().getSimpleName()//
+//                        + " that was just read successfully:\n");
 
-                String xml2 = xstream.toXML(myModelClassInstance);
-
-                System.out.println(xml2);
-                System.out.flush();
+//                String xml2 = xstream.toXML(myModelClassInstance);
+//
+//                System.out.println(xml2);
+//                System.out.flush();
 
             } else {
                 throw new ETException(null, "XML data file does not conform to schema.");

--- a/src/main/java/org/earthtime/ratioDataModels/mineralStandardModels/MineralStandardUPbModel.java
+++ b/src/main/java/org/earthtime/ratioDataModels/mineralStandardModels/MineralStandardUPbModel.java
@@ -20,24 +20,30 @@
 package org.earthtime.ratioDataModels.mineralStandardModels;
 
 import Jama.Matrix;
+import com.google.common.io.Files;
 import com.thoughtworks.xstream.XStream;
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.FilenameFilter;
 import java.io.IOException;
+import java.io.InputStream;
 import java.math.BigDecimal;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
+import java.util.jar.JarEntry;
+import java.util.jar.JarFile;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import org.earthtime.ETRedux;
 import org.earthtime.UPb_Redux.ReduxConstants;
 import org.earthtime.UPb_Redux.exceptions.BadLabDataException;
 import org.earthtime.UPb_Redux.reduxLabData.ReduxLabData;
@@ -512,36 +518,82 @@ public class MineralStandardUPbModel extends AbstractRatiosDataModel {
     }
 
     private static void loadModelsFromResources() {
-        URL modelsLoc = MineralStandardUPbModel.class.getClassLoader().getResource("org/earthtime/parameterModels/mineralStandardModels");
 
-        File modelsDir = null;
+        //TODO:  this is experimental code
+        String folderPath = "org/earthtime/parameterModels/mineralStandardModels/";
+        URL modelsFolderStream = MineralStandardUPbModel.class.getProtectionDomain().getCodeSource().getLocation();
+
+        File jarFile = null;
+
         try {
-            modelsDir = new File(modelsLoc.toURI());
-            FilenameFilter textFilter = (File dir, String name) -> {
-                return name.toLowerCase().endsWith(".xml");
-            };
-
-            File[] modelFiles = modelsDir.listFiles(textFilter);
-            for (File modelFile : modelFiles) {
-                System.out.println("MODEL FOUND: " + modelFile.getAbsoluteFile());
-                AbstractRatiosDataModel mineralStandardModel = MineralStandardUPbModel.getNoneInstance();
-
-                try {
-                    mineralStandardModel = mineralStandardModel.readXMLObject(modelFile.getCanonicalPath(), true);
-                    modelInstances.put(mineralStandardModel.getNameAndVersion(), mineralStandardModel);
-                    mineralStandardModel.setImmutable(true);
-                } catch (IOException | ETException | BadOrMissingXMLSchemaException ex) {
-                    if (ex instanceof ETException) {
-                        new ETWarningDialog((ETException) ex).setVisible(true);
-                    }
-                    mineralStandardModel = null;
-                }
-
-            }
+            jarFile = new File(modelsFolderStream.toURI());
         } catch (URISyntaxException uRISyntaxException) {
-
         }
 
+        if (jarFile.isFile()) {
+
+            try {
+                JarFile jar = new JarFile(jarFile);
+                Enumeration<JarEntry> entries = jar.entries();
+                while (entries.hasMoreElements()) {
+                    JarEntry entry = entries.nextElement();
+                    String name = entry.getName();
+                    if (name.startsWith(folderPath) && !entry.isDirectory()) {
+                        InputStream versionFileStreamL = ETRedux.class.getClassLoader().getResourceAsStream(name);
+                        byte[] buffer = new byte[versionFileStreamL.available()];
+                        versionFileStreamL.read(buffer);
+
+                        File modelFile = new File("tempModel.tmp");
+                        Files.write(buffer, modelFile);
+
+                        AbstractRatiosDataModel mineralStandardModel = MineralStandardUPbModel.getNoneInstance();
+
+                        try {
+                            mineralStandardModel = mineralStandardModel.readXMLObject(modelFile.getCanonicalPath(), true);
+                            modelInstances.put(mineralStandardModel.getNameAndVersion(), mineralStandardModel);
+                            mineralStandardModel.setImmutable(true);
+                        } catch (IOException | ETException | BadOrMissingXMLSchemaException ex) {
+                            if (ex instanceof ETException) {
+                                new ETWarningDialog((ETException) ex).setVisible(true);
+                            }
+                        }
+                        modelFile.delete();
+                    }
+                }
+                jar.close();
+
+            } catch (IOException iOException) {
+            }
+        } else {
+            // running as java file
+            modelsFolderStream = MineralStandardUPbModel.class.getClassLoader().getResource(folderPath);
+            File modelsDir = null;
+            try {
+                modelsDir = new File(modelsFolderStream.toURI());
+                FilenameFilter textFilter = (File dir, String name) -> {
+                    return name.toLowerCase().endsWith(".xml");
+                };
+
+                File[] modelFiles = modelsDir.listFiles(textFilter);
+                for (File modelFile : modelFiles) {
+                    System.out.println("MODEL FOUND: " + modelFile.getAbsoluteFile());
+                    AbstractRatiosDataModel mineralStandardModel = MineralStandardUPbModel.getNoneInstance();
+
+                    try {
+                        mineralStandardModel = mineralStandardModel.readXMLObject(modelFile.getCanonicalPath(), true);
+                        modelInstances.put(mineralStandardModel.getNameAndVersion(), mineralStandardModel);
+                        mineralStandardModel.setImmutable(true);
+                    } catch (IOException | ETException | BadOrMissingXMLSchemaException ex) {
+                        if (ex instanceof ETException) {
+                            new ETWarningDialog((ETException) ex).setVisible(true);
+                        }
+                    }
+                }
+
+            } catch (URISyntaxException uRISyntaxException) {
+
+            }
+        }
     }
 
     // used for deserialization

--- a/src/main/java/org/earthtime/xmlUtilities/XMLSerializationI.java
+++ b/src/main/java/org/earthtime/xmlUtilities/XMLSerializationI.java
@@ -72,4 +72,5 @@ public interface XMLSerializationI {
      */
     public Object readXMLObject(String filename, boolean doValidate)
     throws FileNotFoundException, ETException, FileNotFoundException, BadOrMissingXMLSchemaException;
+   
 }


### PR DESCRIPTION
This hotfix is needed because resource file locations and form are handled differently for jar files vs locally running class files. Also some housekeeping tha removed System.out.println of deserialized models - beginning to comply with suggestion from @johnzeringue .