### PR TITLE
Fixes intercept truncation bug

### DIFF
--- a/src/main/java/org/earthtime/UPb_Redux/dateInterpretation/concordia/ConcordiaGraphPanel.java
+++ b/src/main/java/org/earthtime/UPb_Redux/dateInterpretation/concordia/ConcordiaGraphPanel.java
@@ -167,8 +167,8 @@ public class ConcordiaGraphPanel extends JLayeredPane
 
         setBackground(Color.white);
 
-        selectedFractions = new Vector<Fraction>();
-        excludedFractions = new Vector<Fraction>();
+        selectedFractions = new Vector<>();
+        excludedFractions = new Vector<>();
 
         this.showConcordiaErrorBars = true;
         this.showEllipseCenters = true;
@@ -1513,7 +1513,7 @@ public class ConcordiaGraphPanel extends JLayeredPane
     /**
      *
      */
-    public void determineCurrentALiquot() {
+    public void determineCurrentAliquot() {
         try {
             curAliquot = //
                     sample.getAliquotByNumber(((UPbFractionI) selectedFractions.get(0))//

--- a/src/main/java/org/earthtime/UPb_Redux/dialogs/sampleManagers/sampleDateInterpretationManagers/SampleDateInterpretationsManager.java
+++ b/src/main/java/org/earthtime/UPb_Redux/dialogs/sampleManagers/sampleDateInterpretationManagers/SampleDateInterpretationsManager.java
@@ -2455,7 +2455,7 @@ private void lockUnlockHistogramBinsMouseEntered (java.awt.event.MouseEvent evt)
 
             // may 2014 show best date line
             ((ConcordiaGraphPanel) concordiaGraphPanel).setShowingSingleAliquot(true);
-            ((ConcordiaGraphPanel) concordiaGraphPanel).determineCurrentALiquot();
+            ((ConcordiaGraphPanel) concordiaGraphPanel).determineCurrentAliquot();
 
 ////////            // march 2014 isoplot experiment
 ////////            ((AliquotDetailsDisplayInterface) ConcordiaGraphPanelIsoplot).//
@@ -2481,10 +2481,13 @@ private void lockUnlockHistogramBinsMouseEntered (java.awt.event.MouseEvent evt)
         } else if (nodeInfo instanceof ValueModel) { // sample date model *****************************
             // get aliquot and retrieve subset of fractions for this sample date
             Object aliquotNodeInfo = //
-                    ((DefaultMutableTreeNode) ((DefaultMutableTreeNode) node).getParent()).getUserObject();
+                    ((DefaultMutableTreeNode) ((TreeNode) node).getParent()).getUserObject();
 
             if (graphPanels_TabbedPane.getSelectedIndex() == graphPanels_TabbedPane.indexOfTab("Concordia")) {
 
+                // in case user skipped over choosing aliquot
+                ((ConcordiaGraphPanel) concordiaGraphPanel).determineCurrentAliquot();
+                
                 // check for special case interpretations: lower and upper intercepts
                 ((ConcordiaGraphPanel) concordiaGraphPanel).//
                         setYorkFitLine(((SampleDateModel) nodeInfo).getYorkLineFit());
@@ -2499,7 +2502,7 @@ private void lockUnlockHistogramBinsMouseEntered (java.awt.event.MouseEvent evt)
 
                 // for sample date interpretation, display date title box
                 DateInterpretationBoxPanel dateInterpretationBoxPanel = //
-                        new DateInterpretationBoxPanel(((SampleDateModel) nodeInfo));
+                        new DateInterpretationBoxPanel(((ValueModel) nodeInfo));
 
                 ((ConcordiaGraphPanel) concordiaGraphPanel).//
                         setPreferredDatePanel(dateInterpretationBoxPanel);


### PR DESCRIPTION
Fixes issue #22.  The problem was that if the user had not clicked on the specific aliquot in the left panel before clicking the intercept date interpretation that the concordia panel might have a null current aliquot.