### PR TITLE
Fixed project dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -179,11 +179,6 @@
             <version>4.12</version>
         </dependency>
         <dependency>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-javadoc-plugin</artifactId>
-            <version>2.10.1</version>
-        </dependency>
-        <dependency>
             <groupId>org.apache.xmlgraphics</groupId>
             <artifactId>batik-transcoder</artifactId>
             <version>1.7</version>


### PR DESCRIPTION
Fixed the project's Maven dependencies by removing maven-javadoc-plugin.
The plugin should only exist in the build environment classpath, not at
ET_Redux runtime. It does not need to be listed as a dependency, as it
is already pulled in by its plugin entry.

This issue arose while testing Topsoil integration. It appeared with an
update of Topsoil that added a modern logging framework.
maven-javadoc-plugin's outdated logging libraries were causing classpath
issues.