### PR TITLE
Added IntelliJ files to `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,10 @@ target
 nbactions.xml
 dependency-reduced-pom.xml
 
+# IntelliJ
+.idea/
+*.iml
+
 # Generated
 *.txt
 *.html


### PR DESCRIPTION
Ensured IntelliJ project files won't find their way into the project by
adding `.idea/` and `*.iml` to the `.gitignore`.