### PR TITLE
U-series (DIBBs) date math completed for gravimetric tracer.

### DIFF
--- a/src/main/java/org/earthtime/ETReduxFrame.java
+++ b/src/main/java/org/earthtime/ETReduxFrame.java
@@ -3386,15 +3386,10 @@ public class ETReduxFrame extends javax.swing.JFrame implements ReportPainterI, 
     private void interpretSampleDates_buttonActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_interpretSampleDates_buttonActionPerformed
         // Dec 2015 experiment with customization of skins
         if (theSample.getIsotopeStyle().compareToIgnoreCase("UTh") == 0) {
-            TopsoilEvolutionPlot topsoilEvolutionChart = new TopsoilEvolutionPlot();
+            TopsoilEvolutionPlot topsoilEvolutionChart = TopsoilEvolutionPlot.getInstance();
             topsoilEvolutionChart.setSelectedFractions(theSample.getFractions());
             topsoilEvolutionChart.preparePanel();
             topsoilEvolutionChart.showPanel();
-
-//            TopsoilEvolutionPlot topsoilEvolutionChart2 = new TopsoilEvolutionPlot();
-//            topsoilEvolutionChart2.setSelectedFractions(theSample.getFractions());
-//            topsoilEvolutionChart2.preparePanel();
-//            topsoilEvolutionChart2.showPanel();
         } else {
 
             manageSampleDateInterpretation(//

--- a/src/main/java/org/earthtime/Tripoli/dataViews/overlayViews/TripoliSessionRawDataView.java
+++ b/src/main/java/org/earthtime/Tripoli/dataViews/overlayViews/TripoliSessionRawDataView.java
@@ -62,6 +62,7 @@ import org.earthtime.Tripoli.fractions.TripoliFraction;
 import org.earthtime.Tripoli.sessions.TripoliSessionFractionationCalculatorInterface;
 import org.earthtime.Tripoli.sessions.TripoliSessionInterface;
 import org.earthtime.UPb_Redux.ReduxConstants;
+import org.earthtime.UPb_Redux.dialogs.sessionManagers.SessionAnalysisWorkflowManagerInterface;
 import org.earthtime.UPb_Redux.fractions.FractionsFilterInterface;
 import org.earthtime.dataDictionaries.DataPresentationModeEnum;
 import org.earthtime.dataDictionaries.FractionLayoutViewStylesEnum;
@@ -128,6 +129,7 @@ public class TripoliSessionRawDataView extends AbstractRawDataView implements Tr
     private final JLayeredPane tripoliSessionDataHeader_pane;
     private final JLayeredPane tripoliSessionDataControls_pane;
     private AbstractRawDataView dataPresentationModeChooserPanel;
+    private SessionAnalysisWorkflowManagerInterface sessionAnalysisWorkflowManager;
 
     /**
      *
@@ -142,19 +144,18 @@ public class TripoliSessionRawDataView extends AbstractRawDataView implements Tr
      * @param tripoliSessionDataHeader_pane
      * @param tripoliSessionDataControls_pane
      * @param scrollBounds
+     * @param sessionAnalysisWorkflowManager the value of sessionAnalysisWorkflowManager
      */
     public TripoliSessionRawDataView(//
-            ETReduxFrame myUPbReduxFrame,
-            TripoliSessionInterface tripoliSession,//
-            Constructor dataModelViewConstructor,//
-            Method rawDataSourceMethod,//
+            ETReduxFrame myUPbReduxFrame, TripoliSessionInterface tripoliSession, //
+            Constructor dataModelViewConstructor, Method rawDataSourceMethod, //
             FractionLayoutViewStylesEnum fractionLayoutViewStyle, //
-            JSlider yAxisZoomSlider, //
-            JSlider xAxisZoomSlider, //
-            JLayeredPane tripoliSessionRawDataViewYAxis,//
+            JSlider yAxisZoomSlider, JSlider xAxisZoomSlider, //
+            JLayeredPane tripoliSessionRawDataViewYAxis, //
             JLayeredPane tripoliSessionDataHeader_pane, //
             JLayeredPane tripoliSessionDataControls_pane,//
-            Rectangle scrollBounds) {
+            Rectangle scrollBounds, //
+            SessionAnalysisWorkflowManagerInterface sessionAnalysisWorkflowManager) {
         super(scrollBounds);
 
         uPbReduxFrame = myUPbReduxFrame;
@@ -186,6 +187,8 @@ public class TripoliSessionRawDataView extends AbstractRawDataView implements Tr
         this.zoomSlidersIndependent = true;
 
         this.sessionFractionationCalculator = null;
+        
+        this.sessionAnalysisWorkflowManager = sessionAnalysisWorkflowManager;
 
         setBackground(new Color(204, 204, 204));
 
@@ -371,6 +374,7 @@ public class TripoliSessionRawDataView extends AbstractRawDataView implements Tr
                     theOtherSlider.setValue(value);
                 }
                 ((AbstractRawDataView) sampleSessionDataView).refreshPanel();
+                sessionAnalysisWorkflowManager.revalidateScrollPane();
             }
         }
     }
@@ -411,6 +415,7 @@ public class TripoliSessionRawDataView extends AbstractRawDataView implements Tr
                     theOtherSlider.setValue(value);
                 }
                 ((AbstractRawDataView) sampleSessionDataView).refreshPanel();
+                sessionAnalysisWorkflowManager.revalidateScrollPane();
             }
         }
     }

--- a/src/main/java/org/earthtime/Tripoli/dataViews/overlayViews/TripoliSessionRawDataView.java
+++ b/src/main/java/org/earthtime/Tripoli/dataViews/overlayViews/TripoliSessionRawDataView.java
@@ -147,7 +147,8 @@ public class TripoliSessionRawDataView extends AbstractRawDataView implements Tr
      * @param sessionAnalysisWorkflowManager the value of sessionAnalysisWorkflowManager
      */
     public TripoliSessionRawDataView(//
-            ETReduxFrame myUPbReduxFrame, TripoliSessionInterface tripoliSession, //
+            ETReduxFrame myUPbReduxFrame, //
+            TripoliSessionInterface tripoliSession, //
             Constructor dataModelViewConstructor, Method rawDataSourceMethod, //
             FractionLayoutViewStylesEnum fractionLayoutViewStyle, //
             JSlider yAxisZoomSlider, JSlider xAxisZoomSlider, //
@@ -158,7 +159,7 @@ public class TripoliSessionRawDataView extends AbstractRawDataView implements Tr
             SessionAnalysisWorkflowManagerInterface sessionAnalysisWorkflowManager) {
         super(scrollBounds);
 
-        uPbReduxFrame = myUPbReduxFrame;
+        this.uPbReduxFrame = myUPbReduxFrame;
         this.tripoliSession = tripoliSession;
         this.fractionSelectionType = FractionSelectionTypeEnum.STANDARD;
         this.fractionIncludedType = IncludedTypeEnum.ALL;

--- a/src/main/java/org/earthtime/UPb_Redux/dialogs/projectManagers/exportManagers/GeochronProjectExportManager.java
+++ b/src/main/java/org/earthtime/UPb_Redux/dialogs/projectManagers/exportManagers/GeochronProjectExportManager.java
@@ -30,7 +30,6 @@ import javax.swing.JCheckBox;
 import javax.swing.JLayeredPane;
 import javax.swing.JPanel;
 import javax.swing.event.HyperlinkEvent;
-import javax.swing.event.HyperlinkListener;
 import org.earthtime.UPb_Redux.user.ReduxPersistentState;
 import org.earthtime.archivingTools.GeochronAliquotManager;
 import org.earthtime.archivingTools.IEDACredentialsValidator;
@@ -151,17 +150,12 @@ public final class GeochronProjectExportManager extends DialogEditor {
         aliquotsLayeredPane.setPreferredSize(new Dimension(1100, topMarginForSampleDetails + (row + 1) * 100));
         aliquotsLayeredPane.validate();
 
-        instructionsTextPane.addHyperlinkListener(new HyperlinkListener() {
-            @Override
-            public void hyperlinkUpdate(HyperlinkEvent e) {
-                if (e.getEventType() == HyperlinkEvent.EventType.ACTIVATED) {
-                    if (Desktop.isDesktopSupported()) {
-                        try {
-                            Desktop.getDesktop().browse(e.getURL().toURI());
-                        } catch (IOException | URISyntaxException e1) {
-                            // TODO Auto-generated catch block
-                            e1.printStackTrace();
-                        }
+        instructionsTextPane.addHyperlinkListener((HyperlinkEvent e) -> {
+            if (e.getEventType() == HyperlinkEvent.EventType.ACTIVATED) {
+                if (Desktop.isDesktopSupported()) {
+                    try {
+                        Desktop.getDesktop().browse(e.getURL().toURI());
+                    } catch (IOException | URISyntaxException e1) {
                     }
                 }
             }
@@ -322,7 +316,7 @@ public final class GeochronProjectExportManager extends DialogEditor {
     }//GEN-LAST:event_validateGeochronAndSesarCredentials_buttonActionPerformed
 
     private void formWindowClosing(java.awt.event.WindowEvent evt) {//GEN-FIRST:event_formWindowClosing
-        parent.loadAndShowReportTableData();
+        //parent.loadAndShowReportTableData();
     }//GEN-LAST:event_formWindowClosing
 
     // Variables declaration - do not modify//GEN-BEGIN:variables

--- a/src/main/java/org/earthtime/UPb_Redux/dialogs/sessionManagers/SessionAnalysisWorkflowManagerInterface.java
+++ b/src/main/java/org/earthtime/UPb_Redux/dialogs/sessionManagers/SessionAnalysisWorkflowManagerInterface.java
@@ -44,4 +44,6 @@ public interface SessionAnalysisWorkflowManagerInterface {
      *
      */
     public void setupTripoliSessionRawDataView();
+    
+    public void revalidateScrollPane();
 }

--- a/src/main/java/org/earthtime/UPb_Redux/dialogs/sessionManagers/SessionAnalysisWorkflowManagerLAICPMS.java
+++ b/src/main/java/org/earthtime/UPb_Redux/dialogs/sessionManagers/SessionAnalysisWorkflowManagerLAICPMS.java
@@ -183,6 +183,7 @@ public class SessionAnalysisWorkflowManagerLAICPMS extends DialogEditor //
 
             // create data viewing pane
             tripoliSessionRawDataView = new TripoliSessionRawDataView( //
+                    //
                     uPbReduxFrame,//
                     tripoliSession,//
                     dataModelViewConstructorFactory(RawIntensitiesDataView.class.getName()),//
@@ -193,7 +194,7 @@ public class SessionAnalysisWorkflowManagerLAICPMS extends DialogEditor //
                     tripoliSessionRawDataViewYAxis, //
                     tripoliSessionDataHeader_pane,//
                     tripoliSessionDataControls_pane, //
-                    tripoliSessionDataView_scrollPane.getBounds());
+                    tripoliSessionDataView_scrollPane.getBounds(), this);
 
             // set sampleFractionationCalculator
             ((TripoliSessionRawDataView) tripoliSessionRawDataView).setSessionFractionationCalculator(tripoliSession);
@@ -1746,6 +1747,11 @@ private void removeAllIndividualYAxisPanes_buttonActionPerformed(java.awt.event.
      */
     public void setTripoliSession(TripoliSessionInterface tripoliSession) {
         this.tripoliSession = tripoliSession;
+    }
+
+    @Override
+    public void revalidateScrollPane() {
+            tripoliSessionDataView_scrollPane.revalidate();
     }
 
 }

--- a/src/main/java/org/earthtime/UPb_Redux/dialogs/sessionManagers/SessionAnalysisWorkflowManagerSHRIMP.java
+++ b/src/main/java/org/earthtime/UPb_Redux/dialogs/sessionManagers/SessionAnalysisWorkflowManagerSHRIMP.java
@@ -184,6 +184,7 @@ public class SessionAnalysisWorkflowManagerSHRIMP extends DialogEditor //
 
             // create data viewing pane
             tripoliSessionRawDataView = new TripoliSessionRawDataView( //
+                    //
                     uPbReduxFrame,//
                     tripoliSession,//
                     dataModelViewConstructorFactory(RawIntensitiesDataView.class.getName()),//
@@ -194,7 +195,7 @@ public class SessionAnalysisWorkflowManagerSHRIMP extends DialogEditor //
                     tripoliSessionRawDataViewYAxis, //
                     tripoliSessionDataHeader_pane,//
                     tripoliSessionDataControls_pane, //
-                    tripoliSessionDataView_scrollPane.getBounds());
+                    tripoliSessionDataView_scrollPane.getBounds(), this);
 
             // set sampleFractionationCalculator
             ((TripoliSessionRawDataView) tripoliSessionRawDataView).setSessionFractionationCalculator(tripoliSession);
@@ -1750,6 +1751,11 @@ private void removeAllIndividualYAxisPanes_buttonActionPerformed(java.awt.event.
      */
     public void setTripoliSession(TripoliSessionInterface tripoliSession) {
         this.tripoliSession = tripoliSession;
+    }
+
+    @Override
+    public void revalidateScrollPane() {
+            tripoliSessionDataView_scrollPane.revalidate();
     }
 
 }

--- a/src/main/java/org/earthtime/UPb_Redux/reports/ReportCategory.java
+++ b/src/main/java/org/earthtime/UPb_Redux/reports/ReportCategory.java
@@ -74,7 +74,7 @@ public class ReportCategory implements ReportCategoryInterface {
         String displayName1 = specs[index][0];
         ReportColumnInterface retVal = new ReportColumn(//
                 displayName1, //specs[index][0], // displayname1
-                specs[index][1], // displayname2
+                specs[index][1].equalsIgnoreCase("delta") ? " \u03B4" : specs[index][1], // displayname2
                 specs[index][2], // displayname3
                 index, // positionIndex
                 specs[index][3], // units

--- a/src/main/java/org/earthtime/UPb_Redux/reports/ReportColumnXMLConverter.java
+++ b/src/main/java/org/earthtime/UPb_Redux/reports/ReportColumnXMLConverter.java
@@ -91,7 +91,13 @@ public class ReportColumnXMLConverter implements Converter {
         writer.endNode();
 
         writer.startNode("displayName2");
-        writer.setValue(reportColumn.getDisplayName2());
+        String displayName2 = reportColumn.getDisplayName2();
+        // test for delta
+        if (displayName2.contains("\u03B4")) {
+            writer.setValue("LOWERCASEDELTA");
+        } else {
+            writer.setValue(reportColumn.getDisplayName2());
+        }
         writer.endNode();
 
         writer.startNode("displayName3");
@@ -118,16 +124,16 @@ public class ReportColumnXMLConverter implements Converter {
         if (reportColumn.getUncertaintyColumn() != null) {
             ReportColumnInterface myReportColumn = reportColumn.getUncertaintyColumn();
             // repaired jan 2016 to restore report columns  after serialization
-            String displayName2 = myReportColumn.getDisplayName2();
+            displayName2 = myReportColumn.getDisplayName2();
             String displayName3 = myReportColumn.getDisplayName3();
-            
+
             if (displayName3.contains("%")) {
                 myReportColumn.setDisplayName3("PLUSMINUS2SIGMA%");
             } else {
                 myReportColumn.setDisplayName2("PLUSMINUS2SIGMA");
             }
             context.convertAnother(reportColumn.getUncertaintyColumn());
-            
+
             // restore
             myReportColumn.setDisplayName2(displayName2);
             myReportColumn.setDisplayName3(displayName3);
@@ -196,7 +202,13 @@ public class ReportColumnXMLConverter implements Converter {
         reader.moveUp();
 
         reader.moveDown();
-        reportColumn.setDisplayName2(reader.getValue());
+        String displayName2 = reader.getValue();
+        // test for delta
+        if (displayName2.contains("LOWERCASEDELTA")) {
+            reportColumn.setDisplayName2(" \u03B4");
+        } else {
+            reportColumn.setDisplayName2(displayName2);
+        }
         reader.moveUp();
 
         reader.moveDown();

--- a/src/main/java/org/earthtime/UPb_Redux/reports/ReportSettings.java
+++ b/src/main/java/org/earthtime/UPb_Redux/reports/ReportSettings.java
@@ -45,7 +45,7 @@ public class ReportSettings implements
      * version number is advanced so that any existing analysis will update its
      * report models upon opening in ET_Redux.
      */
-    private static transient int CURRENT_VERSION_REPORT_SETTINGS = 327;
+    private static transient int CURRENT_VERSION_REPORT_SETTINGS = 332;
 
     // Fields
     private String name;
@@ -96,7 +96,7 @@ public class ReportSettings implements
                         "Dates",
                         isotypeStyleIsUPb
                                 ? ReportSpecifications.ReportCategory_Dates//
-                                : ReportSpecifications.ReportCategory_Dates, isotypeStyleIsUPb);
+                                : ReportSpecifications.ReportCategory_DatesUTh, true);
 
         this.datesPbcCorrCategory
                 = new ReportCategory(//

--- a/src/main/java/org/earthtime/UPb_Redux/reports/ReportSettings.java
+++ b/src/main/java/org/earthtime/UPb_Redux/reports/ReportSettings.java
@@ -45,7 +45,7 @@ public class ReportSettings implements
      * version number is advanced so that any existing analysis will update its
      * report models upon opening in ET_Redux.
      */
-    private static transient int CURRENT_VERSION_REPORT_SETTINGS = 333;
+    private static transient int CURRENT_VERSION_REPORT_SETTINGS = 338;
 
     // Fields
     private String name;
@@ -560,6 +560,7 @@ public class ReportSettings implements
     /**
      * @return the reportSettingsXMLSchemaURL
      */
+    @Override
     public String getReportSettingsXMLSchemaURL() {
         return reportSettingsXMLSchemaURL;
     }

--- a/src/main/java/org/earthtime/UPb_Redux/reports/ReportSettings.java
+++ b/src/main/java/org/earthtime/UPb_Redux/reports/ReportSettings.java
@@ -45,7 +45,7 @@ public class ReportSettings implements
      * version number is advanced so that any existing analysis will update its
      * report models upon opening in ET_Redux.
      */
-    private static transient int CURRENT_VERSION_REPORT_SETTINGS = 332;
+    private static transient int CURRENT_VERSION_REPORT_SETTINGS = 333;
 
     // Fields
     private String name;

--- a/src/main/java/org/earthtime/UTh_Redux/dateInterpretation/TopsoilEvolutionPlot.java
+++ b/src/main/java/org/earthtime/UTh_Redux/dateInterpretation/TopsoilEvolutionPlot.java
@@ -15,9 +15,12 @@
  */
 package org.earthtime.UTh_Redux.dateInterpretation;
 
-import javafx.fxml.FXML;
-import javafx.scene.control.ToolBar;
-import javafx.scene.layout.HBox;
+import java.awt.Container;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Vector;
+import javax.swing.JComponent;
+import javax.swing.WindowConstants;
 import org.cirdles.topsoil.dataset.Dataset;
 import org.cirdles.topsoil.dataset.RawData;
 import org.cirdles.topsoil.dataset.SimpleDataset;
@@ -33,31 +36,21 @@ import org.earthtime.UTh_Redux.fractions.UThLegacyFractionI;
 import org.earthtime.dataDictionaries.UThAnalysisMeasures;
 import org.earthtime.fractions.ETFractionInterface;
 
-import javax.swing.JComponent;
-import javax.swing.WindowConstants;
-import java.awt.Container;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Vector;
-
 /**
  *
  * @author bowring
  */
-public class TopsoilEvolutionPlot{// extends CustomVBox<TopsoilEvolutionChart> {
+public final class TopsoilEvolutionPlot {
 
+    private static final TopsoilEvolutionPlot instance = new TopsoilEvolutionPlot();
     private Vector<ETFractionInterface> selectedFractions;
-    private Plot myChart;
-    private List<Field<?>> myFields;
+    private final Plot myChart;
+    private final List<Field<?>> myFields;
     private JComponent plotAsComponent;
+    private final EvolutionChartDialog topsoilEvolutionChartDialog;
+    private Container contentPane;
 
-    @FXML
-    private HBox chartAndConfig;
-    @FXML
-    private ToolBar chartToolBar;
-
-    public TopsoilEvolutionPlot() {
-        //super(self -> self.myChart = new EvolutionChart());
+    private TopsoilEvolutionPlot() {
         myChart = new EvolutionPlot();
 
         myFields = new ArrayList<>();
@@ -67,66 +60,33 @@ public class TopsoilEvolutionPlot{// extends CustomVBox<TopsoilEvolutionChart> {
         myFields.add(new NumberField(UThAnalysisMeasures.ar234U_238Ufc.getName() + "-2sigma"));
         myFields.add(new NumberField("rho"));
 
-    }
-
-    public void showPanel() {
-
-//        Button fitData = new Button("Fit data");
-//        fitData.setOnAction(mouseEvent -> {
-//            ((JavaScriptChart) myChart).fitData();
-//        });
-//
-//        chartToolBar.getItems().addAll(fitData);
-//
-//        try {
-//            chartAndConfig.getChildren().setAll(
-//                    myChart.displayAsNode(),
-//                    myChart.getPropertiesPanel().displayAsNode());
-//        } catch (UnsupportedOperationException ex) {
-//            chartAndConfig.getChildren().setAll(
-//                    myChart.displayAsNode());
-//        }
-//
-//        Scene scene = new Scene(this, 1200, 800);
-//
-//        Stage chartStage = new Stage();
-//        chartStage.setScene(scene);
-//        chartStage.show();
-
-        class EvolutionChartDialog extends javax.swing.JFrame {
-
-            public EvolutionChartDialog(javax.swing.JFrame owner, boolean modal) {
-                super();
-            }
-        }
-
-        EvolutionChartDialog testTopsoilDialogDialog = new EvolutionChartDialog(null, true);
-        testTopsoilDialogDialog.setDefaultCloseOperation(WindowConstants.HIDE_ON_CLOSE);
-        testTopsoilDialogDialog.setBounds( //
+        topsoilEvolutionChartDialog = new EvolutionChartDialog(null, true);
+        topsoilEvolutionChartDialog.setDefaultCloseOperation(WindowConstants.HIDE_ON_CLOSE);
+        topsoilEvolutionChartDialog.setBounds( //
                 400,
                 100,
                 820,
                 640);
 
-        Container contentPane = testTopsoilDialogDialog.getContentPane();
-
+        contentPane = topsoilEvolutionChartDialog.getContentPane();
         plotAsComponent = myChart.displayAsJComponent();
-        plotAsComponent.createToolTip().setTipText("TESTING");
         contentPane.add(plotAsComponent);
+    }
 
-//        ET_JButton fitDataButton = new ET_JButton("Fit Data");
-//        fitDataButton.setBounds(10, 10, 50, 25);
-//        fitDataButton.addActionListener(new ActionListener() {
-//            @Override
-//            public void actionPerformed(ActionEvent e) {
-//                ((JavaScriptChart) myChart).fitData();
-//            }
-//        });
-//
-//        plotAsComponent.add(fitDataButton);
+    private class EvolutionChartDialog extends javax.swing.JFrame {
 
-        testTopsoilDialogDialog.setVisible(true);
+        public EvolutionChartDialog(javax.swing.JFrame owner, boolean modal) {
+            super();
+        }
+    }
 
+    public static TopsoilEvolutionPlot getInstance() {
+        return instance;
+    }
+
+    public void showPanel() {
+        plotAsComponent.repaint();
+        topsoilEvolutionChartDialog.setVisible(true);
     }
 
     public void preparePanel() {
@@ -134,22 +94,24 @@ public class TopsoilEvolutionPlot{// extends CustomVBox<TopsoilEvolutionChart> {
         List<Entry> myEntries = new ArrayList<>();
 
         for (int i = 0; i < selectedFractions.size(); i++) {
-            UThLegacyFractionI fraction = (UThLegacyFractionI) selectedFractions.get(i);
-            Entry dataEntry = new SimpleEntry();
-            dataEntry.set((Field<? super Double>) myFields.get(0), //
-                    fraction.getLegacyActivityRatioByName(UThAnalysisMeasures.ar230Th_238Ufc.getName())//
-                    .getValue().doubleValue());
-            dataEntry.set((Field<? super Double>) myFields.get(1), //
-                    fraction.getLegacyActivityRatioByName(UThAnalysisMeasures.ar230Th_238Ufc.getName())//
-                    .getOneSigmaAbs().doubleValue() * 2.0);
-            dataEntry.set((Field<? super Double>) myFields.get(2), //
-                    fraction.getLegacyActivityRatioByName(UThAnalysisMeasures.ar234U_238Ufc.getName())//
-                    .getValue().doubleValue());
-            dataEntry.set((Field<? super Double>) myFields.get(3), //
-                    fraction.getLegacyActivityRatioByName(UThAnalysisMeasures.ar234U_238Ufc.getName())//
-                    .getOneSigmaAbs().doubleValue() * 2.0);
-            dataEntry.set((Field<? super Double>) myFields.get(4), 0.0);
-            myEntries.add(dataEntry);
+            if (!selectedFractions.get(i).isRejected()) {
+                UThLegacyFractionI fraction = (UThLegacyFractionI) selectedFractions.get(i);
+                Entry dataEntry = new SimpleEntry();
+                dataEntry.set((Field<? super Double>) myFields.get(0), //
+                        fraction.getLegacyActivityRatioByName(UThAnalysisMeasures.ar230Th_238Ufc.getName())//
+                        .getValue().doubleValue());
+                dataEntry.set((Field<? super Double>) myFields.get(1), //
+                        fraction.getLegacyActivityRatioByName(UThAnalysisMeasures.ar230Th_238Ufc.getName())//
+                        .getOneSigmaAbs().doubleValue() * 2.0);
+                dataEntry.set((Field<? super Double>) myFields.get(2), //
+                        fraction.getLegacyActivityRatioByName(UThAnalysisMeasures.ar234U_238Ufc.getName())//
+                        .getValue().doubleValue());
+                dataEntry.set((Field<? super Double>) myFields.get(3), //
+                        fraction.getLegacyActivityRatioByName(UThAnalysisMeasures.ar234U_238Ufc.getName())//
+                        .getOneSigmaAbs().doubleValue() * 2.0);
+                dataEntry.set((Field<? super Double>) myFields.get(4), 0.0);
+                myEntries.add(dataEntry);
+            }
         }
         RawData rawData = new RawData(myFields, myEntries);
 

--- a/src/main/java/org/earthtime/UTh_Redux/fractions/fractionReduction/UThFractionReducer.java
+++ b/src/main/java/org/earthtime/UTh_Redux/fractions/fractionReduction/UThFractionReducer.java
@@ -410,7 +410,15 @@ public class UThFractionReducer extends FractionReducer {
                 .setValue(ar234_238corrected);
         fraction.getAnalysisMeasure(UThAnalysisMeasures.ar234U_238Ufc.getName())//
                 .setOneSigma(ar234_238correctedOneSigmaABS);
-
+        
+        ValueModel delta234U = new ValueModel(//
+                UThFractionationCorrectedIsotopicRatios.delta234U.getName(), //
+                BigDecimal.ZERO, ///
+                "ABS", //
+                BigDecimal.ZERO, //
+                BigDecimal.ZERO);
+        fraction.setRadiogenicIsotopeRatioByName(UThFractionationCorrectedIsotopicRatios.delta234U.getName(), delta234U);
+        
     }
 
     private static Matrix exponentialGUTh(Double t) {

--- a/src/main/java/org/earthtime/archivingTools/forSESAR/SesarSample.java
+++ b/src/main/java/org/earthtime/archivingTools/forSESAR/SesarSample.java
@@ -167,9 +167,12 @@ public class SesarSample {
 
     private static File retrieveXMLFileFromSesarForIGSN(String igsn) {
 
+        String productionService = "http://app.geosamples.org/webservices/display.php?igsn=";
+        String testService = "http://sesardev.geoinfogeochem.org/webservices/display.php?igsn=";
+
         File retVal = null;
         String tempSESARcontents
-                = URIHelper.getTextFromURI("http://app.geosamples.org/webservices/display.php?igsn=" + igsn);
+                = URIHelper.getTextFromURI(testService + igsn);
 
         if (tempSESARcontents.length() > 0) {
             // write this to a file
@@ -227,6 +230,9 @@ public class SesarSample {
     }
 
     public String uploadAndRegisterSesarSample() {
+        String productionServiceV1 = "http://app.geosamples.org/webservices/uploadservice.php";
+        String productionServiceV2 = "http://app.geosamples.org/webservices/upload.php";
+        String testServiceV2 = "http://sesardev.geoinfogeochem.org/webservices/upload.php";
 
         String content = serializeForUploadToSesar();
 
@@ -239,7 +245,7 @@ public class SesarSample {
         org.w3c.dom.Document doc = null;
         try {
             response = ClientHttpRequest.post(//
-                    new URL("http://app.geosamples.org/webservices/uploadservice.php"),//
+                    new URL(testServiceV2),//
                     dataToPost);
 
             DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();

--- a/src/main/java/org/earthtime/dataDictionaries/RadDates.java
+++ b/src/main/java/org/earthtime/dataDictionaries/RadDates.java
@@ -110,7 +110,8 @@ public enum RadDates {
     /**
      *
      */
-    bestAge_PbcCorr( "bestAge_PbcCorr" );
+    bestAge_PbcCorr( "bestAge_PbcCorr" ),
+    dateCorr("dateCorr");
 
 
     private String name;

--- a/src/main/java/org/earthtime/dataDictionaries/ReportSpecifications.java
+++ b/src/main/java/org/earthtime/dataDictionaries/ReportSpecifications.java
@@ -100,8 +100,7 @@ public class ReportSpecifications {
         },
         {"", "Th/U", "(magma)", "", "getAnalysisMeasure", AnalysisMeasures.rTh_Umagma.getName(), "",
             "FN-11", "false", "true", "3", "", "Th/U magma", "true", "false"
-        },
-    };
+        },};
 
     // Report column order =
     //  displayName1, displayName2, displayName3, units, retrieveMethodName, retrieveParameterName, uncertaintyType,
@@ -175,10 +174,8 @@ public class ReportSpecifications {
             "", "false", "true", "3", "", "Correlation coefficient", "true", "true"
         }
     };
-    
-    
-    
-        // Report column order =
+
+    // Report column order =
     //  displayName1, displayName2, displayName3, units, retrieveMethodName, retrieveParameterName, uncertaintyType,
     //     footnoteSpec, visible, useArbitrary? for value, digitcount value, unct visible (if required), description where needed,
     //     needsLead, needsUranium
@@ -209,13 +206,7 @@ public class ReportSpecifications {
         },
         {"", "r207Pb/", "206Pbfc", "", "getRadiogenicIsotopeRatioByName", UThFractionationCorrectedIsotopicRatios.r207Pb_206Pbfc.getName(), "PCT",
             "", "false", "false", "2", "true", "", "false", "false"
-        },
-        
-    };
-
-    
-    
-    
+        },};
 
     // Report column order =
     //  displayName1, displayName2, displayName3, units, retrieveMethodName, retrieveParameterName, uncertaintyType,
@@ -285,10 +276,9 @@ public class ReportSpecifications {
         },
         {"", "best", "date", "Ma", "getRadiogenicIsotopeDateByName", RadDates.bestAge.getName(), "ABS",
             "", "false", "false", "2", "true", "best date", "true", "true"
-        },
-    };
-    
-        // Report column order =
+        },};
+
+    // Report column order =
     //  displayName1, displayName2, displayName3, units, retrieveMethodName, retrieveParameterName, uncertaintyType,
     //     footnoteSpec, visible, useArbitrary? for value, digitcount value, unct visible (if required), description where needed,
     //     needsLead, needsUranium
@@ -299,6 +289,9 @@ public class ReportSpecifications {
         {"", "Corr", "Date", "ka", "getRadiogenicIsotopeDateByName", RadDates.dateCorr.getName(), "ABS",
             "", "true", "false", "2", "true", "", "false", "false"
         },
+        {"", "delta", "234U", "", "getRadiogenicIsotopeRatioByName", UThFractionationCorrectedIsotopicRatios.delta234U.getName(), "ABS",
+            "", "true", "false", "2", "true", "", "false", "false"
+        }
     };
 
     // Report column order =

--- a/src/main/java/org/earthtime/dataDictionaries/ReportSpecifications.java
+++ b/src/main/java/org/earthtime/dataDictionaries/ReportSpecifications.java
@@ -121,7 +121,7 @@ public class ReportSpecifications {
             "FN-18&FN-19", "false", "true", "3", "true", "[230Th/232Th] activity ratio", "false", "false"
         },
         {"[232Th/", "238U]", "", "*1e5", "getAnalysisMeasure", UThAnalysisMeasures.ar232Th_238Ufc.getName(), "ABS",
-            "FN-19&FN-17", "true", "true", "3", "true", "[232Th/238U] activity ratio", "false", "false"
+            "FN-19&FN-17", "false", "true", "3", "true", "[232Th/238U] activity ratio", "false", "false"
         },
         {"", "[230Th/", "238U]", "", "getAnalysisMeasure", UThAnalysisMeasures.ar230Th_238Ufc.getName(), "ABS",
             "FN-18&FN-17", "true", "false", "3", "true", "[230Th/238U] activity ratio", "false", "false"

--- a/src/main/java/org/earthtime/dataDictionaries/ReportSpecifications.java
+++ b/src/main/java/org/earthtime/dataDictionaries/ReportSpecifications.java
@@ -196,19 +196,19 @@ public class ReportSpecifications {
             "", "true", "false", "2", "true", "", "false", "false"
         },
         {"", "r230Th/", "232Thfc", "", "getRadiogenicIsotopeRatioByName", UThFractionationCorrectedIsotopicRatios.r230Th_232Thfc.getName(), "PCT",
-            "", "true", "false", "2", "true", "", "false", "false"
+            "", "false", "false", "2", "true", "", "false", "false"
         },
         {"", "r228Ra/", "226Rafc", "", "getRadiogenicIsotopeRatioByName", UThFractionationCorrectedIsotopicRatios.r228Ra_226Rafc.getName(), "PCT",
-            "", "true", "false", "2", "true", "", "false", "false"
+            "", "false", "false", "2", "true", "", "false", "false"
         },
         {"", "r231Pa/", "233Pafc", "", "getRadiogenicIsotopeRatioByName", UThFractionationCorrectedIsotopicRatios.r231Pa_233Pafc.getName(), "PCT",
-            "", "true", "false", "2", "true", "", "false", "false"
+            "", "false", "false", "2", "true", "", "false", "false"
         },
         {"", "r238U/", "206Pbfc", "", "getRadiogenicIsotopeRatioByName", UThFractionationCorrectedIsotopicRatios.r238U_206Pbfc.getName(), "PCT",
-            "", "true", "false", "2", "true", "", "false", "false"
+            "", "false", "false", "2", "true", "", "false", "false"
         },
         {"", "r207Pb/", "206Pbfc", "", "getRadiogenicIsotopeRatioByName", UThFractionationCorrectedIsotopicRatios.r207Pb_206Pbfc.getName(), "PCT",
-            "", "true", "false", "2", "true", "", "false", "false"
+            "", "false", "false", "2", "true", "", "false", "false"
         },
         
     };
@@ -285,7 +285,20 @@ public class ReportSpecifications {
         },
         {"", "best", "date", "Ma", "getRadiogenicIsotopeDateByName", RadDates.bestAge.getName(), "ABS",
             "", "false", "false", "2", "true", "best date", "true", "true"
-        }
+        },
+    };
+    
+        // Report column order =
+    //  displayName1, displayName2, displayName3, units, retrieveMethodName, retrieveParameterName, uncertaintyType,
+    //     footnoteSpec, visible, useArbitrary? for value, digitcount value, unct visible (if required), description where needed,
+    //     needsLead, needsUranium
+    /**
+     *
+     */
+    public static final String[][] ReportCategory_DatesUTh = new String[][]{
+        {"", "Corr", "Date", "ka", "getRadiogenicIsotopeDateByName", RadDates.dateCorr.getName(), "ABS",
+            "", "true", "false", "2", "true", "", "false", "false"
+        },
     };
 
     // Report column order =

--- a/src/main/java/org/earthtime/dataDictionaries/UThFractionationCorrectedIsotopicRatios.java
+++ b/src/main/java/org/earthtime/dataDictionaries/UThFractionationCorrectedIsotopicRatios.java
@@ -51,7 +51,9 @@ public enum UThFractionationCorrectedIsotopicRatios {
     /**
      * 
      */
-    r207Pb_206Pbfc( "r207Pb_206Pbfc" );
+    r207Pb_206Pbfc( "r207Pb_206Pbfc" ),
+    delta234U("delta234U")
+    ;
 
 
     private String name;

--- a/src/main/java/org/earthtime/fractions/fractionReduction/FractionReducer.java
+++ b/src/main/java/org/earthtime/fractions/fractionReduction/FractionReducer.java
@@ -35,6 +35,12 @@ public abstract class FractionReducer {
     protected static ValueModel lambda234;
     protected static ValueModel lambda235;
     protected static ValueModel lambda238;
+    protected static double lambda230D;
+    protected static double lambda231D;
+    protected static double lambda232D;
+    protected static double lambda234D;
+    protected static double lambda235D;
+    protected static double lambda238D;
     protected static ValueModel gmol204;
     protected static ValueModel gmol206;
     protected static ValueModel gmol207;
@@ -58,6 +64,14 @@ public abstract class FractionReducer {
             lambda234 = physicalConstantsModel.getDatumByName(Lambdas.lambda234.getName()).copy();
             lambda235 = physicalConstantsModel.getDatumByName(Lambdas.lambda235.getName()).copy();
             lambda238 = physicalConstantsModel.getDatumByName(Lambdas.lambda238.getName()).copy();
+
+            lambda230D = lambda230.getValue().doubleValue();
+            lambda231D = lambda231.getValue().doubleValue();
+            lambda232D = lambda232.getValue().doubleValue();
+            lambda234D = lambda234.getValue().doubleValue();
+            lambda235D = lambda235.getValue().doubleValue();
+            lambda238D = lambda238.getValue().doubleValue();
+
         }
 
     }

--- a/src/main/java/org/earthtime/reduxLabData/ReduxLabData.java
+++ b/src/main/java/org/earthtime/reduxLabData/ReduxLabData.java
@@ -345,10 +345,7 @@ public final class ReduxLabData implements Serializable {
      */
     public static ReduxLabData getInstance() {
         if (instance == null) {
-            instance = (ReduxLabData) ETSerializer.GetSerializedObjectFromFile(ReduxLabData.getMySerializedName());
-            if (instance == null) {
-                instance = new ReduxLabData();
-            }
+            instance = new ReduxLabData();
         }
         return instance;
     }
@@ -433,11 +430,9 @@ public final class ReduxLabData implements Serializable {
             addTracer(TracerUPbModel.getNoneInstance());
             defaultLabTracer = getFirstTracer();
         } else // detect if legacy default is none and change if possible
-        {
-            if (defaultLabTracer.equals(getNoneTracer())) {
+         if (defaultLabTracer.equals(getNoneTracer())) {
                 defaultLabTracer = getFirstTracer();
             }
-        }
         return defaultLabTracer;
     }
 
@@ -553,11 +548,9 @@ public final class ReduxLabData implements Serializable {
             addAlphaUModel(new ValueModel(ReduxConstants.NONE));
             setDefaultLabAlphaUModel(getFirstAlphaUModel());
         } else // detect if legacy default is none and change if possible
-        {
-            if (defaultLabAlphaUModel.equals(getNoneAlphaUModel())) {
+         if (defaultLabAlphaUModel.equals(getNoneAlphaUModel())) {
                 setDefaultLabAlphaUModel(getFirstAlphaUModel());
             }
-        }
         return defaultLabAlphaUModel;
     }
 
@@ -662,11 +655,9 @@ public final class ReduxLabData implements Serializable {
             addAlphaPbModel(new ValueModel(ReduxConstants.NONE));
             setDefaultLabAlphaPbModel(getFirstAlphaPbModel());
         } else // detect if legacy default is none and change if possible
-        {
-            if (defaultLabAlphaPbModel.equals(getNoneAlphaPbModel())) {
+         if (defaultLabAlphaPbModel.equals(getNoneAlphaPbModel())) {
                 setDefaultLabAlphaPbModel(getFirstAlphaPbModel());
             }
-        }
         return defaultLabAlphaPbModel;
     }
 
@@ -773,11 +764,9 @@ public final class ReduxLabData implements Serializable {
             addBlank(PbBlankICModel.getNoneInstance());
             setDefaultLabPbBlank(getFirstPbBlank());
         } else // detect if legacy default is none and change if possible
-        {
-            if (defaultLabPbBlank.equals(getNonePbBlankModel())) {
+         if (defaultLabPbBlank.equals(getNonePbBlankModel())) {
                 setDefaultLabPbBlank(getFirstPbBlank());
             }
-        }
         return defaultLabPbBlank;
     }
 
@@ -897,11 +886,9 @@ public final class ReduxLabData implements Serializable {
 
             defaultLabInitialPbModel = getFirstInitialPbModel();
         } else // detect if legacy default is none and change if possible
-        {
-            if (defaultLabInitialPbModel.equals(getNoneInitialPbModel())) {
+         if (defaultLabInitialPbModel.equals(getNoneInitialPbModel())) {
                 defaultLabInitialPbModel = getFirstInitialPbModel();
             }
-        }
         return defaultLabInitialPbModel;
     }
 
@@ -1017,9 +1004,11 @@ public final class ReduxLabData implements Serializable {
                 addPhysicalConstantsModel(PhysicalConstantsModel.getNoneInstance());
                 defaultPhysicalConstantsModel = getFirstPhysicalConstantsModel();
             } else // detect if legacy default is none and change if possible
-             if (defaultPhysicalConstantsModel.equals(getNonePhysicalConstantsModel())) {
+            {
+                if (defaultPhysicalConstantsModel.equals(getNonePhysicalConstantsModel())) {
                     defaultPhysicalConstantsModel = getFirstPhysicalConstantsModel();
                 }
+            }
         } catch (BadLabDataException badLabDataException) {
             new ETWarningDialog(badLabDataException).setVisible(true);
         }
@@ -1268,11 +1257,9 @@ public final class ReduxLabData implements Serializable {
             addRareEarthElementModel(RareEarthElementsModel.getNoneInstance());
             defaultRareEarthElementModel = getFirstRareEarthElementModel();
         } else // detect if legacy default is none and change if possible
-        {
-            if (defaultRareEarthElementModel.equals(getNoneRareEarthElementModel())) {
+         if (defaultRareEarthElementModel.equals(getNoneRareEarthElementModel())) {
                 defaultRareEarthElementModel = getFirstRareEarthElementModel();
             }
-        }
         return defaultRareEarthElementModel;
     }
 
@@ -1377,11 +1364,9 @@ public final class ReduxLabData implements Serializable {
             addDetritalUraniumAndThoriumModel(DetritalUraniumAndThoriumModel.getNoneInstance());
             defaultDetritalUraniumAndThoriumModel = getFirstDetritalUraniumAndThoriumModel();
         } else // detect if legacy default is none and change if possible
-        {
-            if (defaultDetritalUraniumAndThoriumModel.equals(getNoneDetritalUraniumAndThoriumModel())) {
+         if (defaultDetritalUraniumAndThoriumModel.equals(getNoneDetritalUraniumAndThoriumModel())) {
                 defaultDetritalUraniumAndThoriumModel = getFirstDetritalUraniumAndThoriumModel();
             }
-        }
         return defaultDetritalUraniumAndThoriumModel;
     }
 

--- a/src/main/java/org/earthtime/reportViews/ReportAliquotFractionsView.java
+++ b/src/main/java/org/earthtime/reportViews/ReportAliquotFractionsView.java
@@ -68,7 +68,6 @@ import org.apache.batik.transcoder.TranscodingHints;
 import org.apache.fop.svg.PDFTranscoder;
 import org.earthtime.ETReduxFrame;
 import org.earthtime.UPb_Redux.ReduxConstants;
-import org.earthtime.UPb_Redux.aliquots.UPbReduxAliquot;
 import org.earthtime.UPb_Redux.dialogs.fractionManagers.FractionNotesDialog;
 import org.earthtime.UPb_Redux.filters.SVGFileFilter;
 import org.earthtime.UPb_Redux.fractions.UPbReduxFractions.UPbFraction;
@@ -1091,7 +1090,7 @@ public class ReportAliquotFractionsView extends JLayeredPane implements ReportUp
                         } else {
                             boolean isRejected = !((ETFractionInterface) verticalPixelFractionMap.get(row).rowObject).isRejected();
                             ((ETFractionInterface) verticalPixelFractionMap.get(row).rowObject).setRejected(isRejected);
-                            // dec 2015
+                            // dec 2015 for tripoli fractions
                             try {
                                 ((UPbFractionI) verticalPixelFractionMap.get(row).rowObject).getTripoliFraction().setIncluded(!isRejected);
                             } catch (Exception noTF) {
@@ -1105,7 +1104,7 @@ public class ReportAliquotFractionsView extends JLayeredPane implements ReportUp
                         if (e.getModifiers() == InputEvent.BUTTON1_MASK) {
                             parentFrame.editAliquotByProjectType(((AliquotInterface) verticalPixelFractionMap.get(row).rowObject));
                         } else {
-                            AliquotInterface.toggleAliquotFractionsRejectedStatus(((UPbReduxAliquot) verticalPixelFractionMap.get(row).rowObject));
+                            AliquotInterface.toggleAliquotFractionsRejectedStatus(((ReduxAliquotInterface) verticalPixelFractionMap.get(row).rowObject));
                             parent.updateReportTable(false);
                         }
 

--- a/src/main/java/org/earthtime/samples/SampleInterface.java
+++ b/src/main/java/org/earthtime/samples/SampleInterface.java
@@ -1169,7 +1169,7 @@ public interface SampleInterface {
     public default Vector<ETFractionInterface> getFractionsRejected() {
         Vector<ETFractionInterface> retval = new Vector<>();
 
-        getFractions().stream().filter((f) -> (((ETFractionInterface) f).isRejected())).forEach((f) -> {
+        getFractions().stream().filter((f) -> (f.isRejected())).forEach((f) -> {
             retval.add(f);
         });
 

--- a/src/test/java/org/earthtime/dataDictionaries/RadDatesTest.java
+++ b/src/test/java/org/earthtime/dataDictionaries/RadDatesTest.java
@@ -95,8 +95,8 @@ public class RadDatesTest {
         assertEquals("age208_232r",list[13]);
         assertEquals("bestAge",list[14]);
         assertEquals("bestAge_PbcCorr",list[15]);
-        assertEquals("percentDiscordance",list[16]);
-        assertEquals("percentDiscordance_PbcCorr",list[17]);
+        assertEquals("percentDiscordance",list[17]);
+        assertEquals("percentDiscordance_PbcCorr",list[18]);
         
     }    
             


### PR DESCRIPTION
U-series dates completed for gravimetric tracer including new columns for the report table for detrital-corrected date and delta234U with uncertainties.  Minor improvements to Shrimp raw data manager.

Note to @johnzeringue - I have solved the pesky intermittent behavior of Topsoil integrated into ET_Redux and not displaying the evolution plot reliably.  See this class: org.earthtime.UTh_Redux.dateInterpretation.TopsoilEvolutionPlot.  The key I think was instantiating a static attribute for the swing Frame.  Now it would be great if Topsoil would clear the plot every time the plot gets new data.  What happens now in ET_Redux is that with when I reject points, the plot renders the new selection correctly but leaves orphaned the rejected ellipses, so that when panning they remain stationary.  To try this follow the instructions [here](https://github.com/CIRDLES/ET_Redux/wiki/Development-for-U-series) to load the data, then once the data is displayed in the report table, click the sample dates button (bottom right) to launch evolution plot.  Then reject some fractions using right mouse click over their names, and click sample dates again, and then pan and you will see this effect.