### PR TITLE
Suppress re-rendering of tree in left pane of sample dates. 

### DIFF
--- a/src/main/java/org/earthtime/UPb_Redux/dateInterpretation/concordia/ConcordiaGraphPanel.java
+++ b/src/main/java/org/earthtime/UPb_Redux/dateInterpretation/concordia/ConcordiaGraphPanel.java
@@ -2395,7 +2395,7 @@ public class ConcordiaGraphPanel extends JLayeredPane
 
         if ((evt.getX() >= getLeftMargin())
                 && (evt.getY() >= getTopMargin())
-                && (evt.getY() <= getGraphHeight() + getTopMargin())) {
+                && (evt.getY() <= getGraphHeight() + getTopMargin()) && !changingBestDateDivider) {
 
             setZoomMaxX(evt.getX());
             setZoomMaxY(evt.getY());
@@ -2650,9 +2650,9 @@ public class ConcordiaGraphPanel extends JLayeredPane
         if (currentBestDate > 0.0) {
             // convert to 206_238 ratio
             double bestRatioDivider = Math.expm1(lambda238.getValue().doubleValue() * currentBestDate);
-            if ((x >= mapX(getMinX_Display()) - 30)//
+            if ((x >= mapX(getMinX_Display()) - 20)//
                     &&//
-                    (x <= mapX(getMinX_Display()) + 30)//
+                    (x <= mapX(getMinX_Display()) + 100)//
                     && //
                     (y >= mapY(bestRatioDivider) - 20)//
                     && //

--- a/src/main/java/org/earthtime/UPb_Redux/dialogs/sampleManagers/sampleDateInterpretationManagers/SampleDateInterpretationsManager.java
+++ b/src/main/java/org/earthtime/UPb_Redux/dialogs/sampleManagers/sampleDateInterpretationManagers/SampleDateInterpretationsManager.java
@@ -199,15 +199,17 @@ public class SampleDateInterpretationsManager extends DialogEditor
      */
     public void refreshSampleDateInterpretations(boolean doReScale) {
 
-        dateTreeByAliquot = new SampleTreeAnalysisMode(sample);
-        dateTreeByAliquot.setSampleTreeChange(this);
-        dateTreeByAliquot.buildTree();
-        dateTreeByAliquot_ScrollPane.setViewportView((Component) dateTreeByAliquot);
+        if (doReScale) {
+            dateTreeByAliquot = new SampleTreeAnalysisMode(sample);
+            dateTreeByAliquot.setSampleTreeChange(this);
+            dateTreeByAliquot.buildTree();
+            dateTreeByAliquot_ScrollPane.setViewportView((Component) dateTreeByAliquot);
 
-        dateTreeBySample = new SampleTreeCompilationMode(sample);
-        dateTreeBySample.setSampleTreeChange(this);
-        dateTreeBySample.buildTree();
-        dateTreeBySample_ScrollPane.setViewportView((Component) dateTreeBySample);
+            dateTreeBySample = new SampleTreeCompilationMode(sample);
+            dateTreeBySample.setSampleTreeChange(this);
+            dateTreeBySample.buildTree();
+            dateTreeBySample_ScrollPane.setViewportView((Component) dateTreeBySample);
+        }
 
         ((PlottingDetailsDisplayInterface) concordiaGraphPanel).resetPanel(doReScale);
 


### PR DESCRIPTION
During refresh only operations.