### PR TITLE
Speedup of Live Acquisitions for LaserChron

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ nbproject/
 test_*
 *.ser
 *.zip
+*.log
 
 
 # Misc data files

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
     <groupId>org.cirdles</groupId>
     <artifactId>ET_Redux</artifactId>
     <name>ET_Redux</name>
-    <version>3.5.6</version>
+    <version>3.5.7</version>
     <description>Successor to U-Pb_Redux</description>
     <url>https://cirdles.org</url>
     <inceptionYear>2006</inceptionYear>

--- a/src/main/java/org/earthtime/ETReduxFrame.java
+++ b/src/main/java/org/earthtime/ETReduxFrame.java
@@ -1820,7 +1820,7 @@ public class ETReduxFrame extends javax.swing.JFrame implements ReportPainterI, 
                             PbcCorrectionDetails.zeroAllValues();
                             PbcCorrectionDetails.fraction_ID = fraction.getFractionID();
                             PbcCorrectionDetails.pbcCorrScheme = ((UPbLAICPMSFraction) fraction).getCommonLeadLossCorrectionScheme().getName();
-                            UPbFractionReducer.getInstance().fullFractionReduce((FractionI) fraction, true, false);
+                            UPbFractionReducer.getInstance().fullFractionReduce((FractionI) fraction, true);
                             outputWriter.println(PbcCorrectionDetails.dataString());
 
                             outputWriter.println();

--- a/src/main/java/org/earthtime/ETReduxFrame.java
+++ b/src/main/java/org/earthtime/ETReduxFrame.java
@@ -581,7 +581,7 @@ public class ETReduxFrame extends javax.swing.JFrame implements ReportPainterI, 
 
                 // go straight to data table display
                 myProjectManager = null;
-                initializeProject();
+                initializeProject(false);
 
             } else { // instantiate project manager so processing can be initialited
 
@@ -639,7 +639,7 @@ public class ETReduxFrame extends javax.swing.JFrame implements ReportPainterI, 
         if (theProject != null) {
             myState.getReduxPreferences().setDefaultSampleAnalysisPurpose(theProject.getAnalysisPurpose());
             theProject.saveTheProjectAsSerializedReduxFile();
-            setUpTheProject(false);
+            setUpTheProject(false, false);
         }
     }
 
@@ -653,7 +653,7 @@ public class ETReduxFrame extends javax.swing.JFrame implements ReportPainterI, 
 
         if (selectedFile != null) {
             myState.updateMRUProjectList(selectedFile);
-            setUpTheProject(false);
+            setUpTheProject(false, false);
 
             saveProjectFile_menuItem.setEnabled(false);
 
@@ -672,12 +672,13 @@ public class ETReduxFrame extends javax.swing.JFrame implements ReportPainterI, 
 
     /**
      *
+     * @param inLiveMode the value of inLiveMode
      */
-    public void initializeProject() {
+    public void initializeProject(boolean inLiveMode) {
         theSample = theProject.getSuperSample();
         theSample.setChanged(false);
 
-        setUpTheProject(false);
+        setUpTheProject(false, inLiveMode);
     }
 
     /**
@@ -698,8 +699,9 @@ public class ETReduxFrame extends javax.swing.JFrame implements ReportPainterI, 
     /**
      *
      * @param performReduction
+     * @param inLiveMode the value of inLiveMode
      */
-    public void setUpTheProject(boolean performReduction) {
+    public void setUpTheProject(boolean performReduction, boolean inLiveMode) {
         SampleInterface.registerSampleWithLabData(theSample);
 
         SampleInterface superSample = theProject.getSuperSample();
@@ -726,7 +728,7 @@ public class ETReduxFrame extends javax.swing.JFrame implements ReportPainterI, 
             superSample.setLegacyStatusForReportTable();
         } catch (Exception e) {
         }
-        rebuildFractionDisplays(performReduction);
+        rebuildFractionDisplays(performReduction, inLiveMode);
 
         // set up concordia for use on fraction details window
         //as well as interpret date window and archiving
@@ -775,7 +777,7 @@ public class ETReduxFrame extends javax.swing.JFrame implements ReportPainterI, 
                         ((AbstractProjectOfLegacySamplesDataManagerDialog) myProjectManager).getImportFractionFolderMRU().toString());
 
                 if (!theProject.getProjectSamples().isEmpty()) {
-                    setUpTheProject(false);
+                    setUpTheProject(false, false);
                     try {
                         saveTheProject();
                     } catch (BadLabDataException ex) {
@@ -835,7 +837,7 @@ public class ETReduxFrame extends javax.swing.JFrame implements ReportPainterI, 
         myProjectManager.setVisible(true);
 
         if (!theProject.getProjectSamples().isEmpty()) {
-            setUpTheProject(false);
+            setUpTheProject(false, false);
             try {
                 saveTheProject();
             } catch (BadLabDataException ex) {
@@ -907,7 +909,7 @@ public class ETReduxFrame extends javax.swing.JFrame implements ReportPainterI, 
                 ((AbstractProjectOfLegacySamplesDataManagerDialog) myProjectManager).getImportFractionFolderMRU().toString());
 
         if (!theProject.getProjectSamples().isEmpty()) {
-            setUpTheProject(false);
+            setUpTheProject(false, false);
             try {
                 saveTheProject();
             } catch (BadLabDataException ex) {
@@ -1347,13 +1349,13 @@ public class ETReduxFrame extends javax.swing.JFrame implements ReportPainterI, 
         // this true causes data reduction
         // may 2012 first pass reduction
         if (performReduction) {
-            theSample.reduceSampleData();
+            theSample.reduceSampleData(false);
         }
 
         // feb 2010 added legacyData field to force display when no reduction happening
         theSample.setLegacyStatusForReportTable();
 
-        rebuildFractionDisplays(performReduction);
+        rebuildFractionDisplays(performReduction, false);
 
         // set up concordia for use on fraction details window
         //as well as interpret date window and archiving
@@ -1447,12 +1449,13 @@ public class ETReduxFrame extends javax.swing.JFrame implements ReportPainterI, 
     /**
      *
      * @param performReduction
+     * @param inLiveMode the value of inLiveMode
      */
     @Override
-    public void rebuildFractionDisplays(boolean performReduction) {
+    public void rebuildFractionDisplays(boolean performReduction, boolean inLiveMode) {
         ((TabbedReportViews) getReportTableTabbedPane()).setSample(theSample);
 
-        updateReportTable(performReduction);
+        updateReportTable(performReduction, inLiveMode);
     }
 
     /**
@@ -1460,15 +1463,16 @@ public class ETReduxFrame extends javax.swing.JFrame implements ReportPainterI, 
      */
     @Override
     public void updateReportTable() {
-        updateReportTable(false);
+        updateReportTable(false, false);
     }
 
     /**
      *
      * @param performReduction
+     * @param inLiveMode the value of inLiveMode
      */
     @Override
-    public void updateReportTable(boolean performReduction) {
+    public void updateReportTable(boolean performReduction, boolean inLiveMode) {
         // march 2013
         try {
             UPbFractionReducer.getInstance().setSessionCorrectedUnknownsSummaries(//
@@ -1477,7 +1481,7 @@ public class ETReduxFrame extends javax.swing.JFrame implements ReportPainterI, 
         }
 
         if (performReduction) {
-            theSample.reduceSampleData();
+            theSample.reduceSampleData(inLiveMode);
         }
 
         loadAndShowReportTableData();
@@ -1490,7 +1494,7 @@ public class ETReduxFrame extends javax.swing.JFrame implements ReportPainterI, 
 
 //      updated with rescaling april 2016
         try {
-            ((SampleDateInterpretationsManager) sampleDateInterpDialog).refreshSampleDateInterpretations(false);
+            ((SampleDateInterpretationsManager) sampleDateInterpDialog).refreshSampleDateInterpretations(false, inLiveMode);
         } catch (Exception e) {
         }
     }
@@ -1816,7 +1820,7 @@ public class ETReduxFrame extends javax.swing.JFrame implements ReportPainterI, 
                             PbcCorrectionDetails.zeroAllValues();
                             PbcCorrectionDetails.fraction_ID = fraction.getFractionID();
                             PbcCorrectionDetails.pbcCorrScheme = ((UPbLAICPMSFraction) fraction).getCommonLeadLossCorrectionScheme().getName();
-                            UPbFractionReducer.getInstance().fullFractionReduce((FractionI) fraction, true);
+                            UPbFractionReducer.getInstance().fullFractionReduce((FractionI) fraction, true, false);
                             outputWriter.println(PbcCorrectionDetails.dataString());
 
                             outputWriter.println();
@@ -3427,7 +3431,7 @@ public class ETReduxFrame extends javax.swing.JFrame implements ReportPainterI, 
             interpretSampleDates_button.setEnabled(false);
 
             ((ConcordiaGraphPanel) myConcordiaGraphPanel).setShowTightToEdges(true);
-            ((PlottingDetailsDisplayInterface) myConcordiaGraphPanel).resetPanel(true);
+            ((PlottingDetailsDisplayInterface) myConcordiaGraphPanel).resetPanel(true, false);
 
             if (sampleDateInterpDialog != null) {
                 sampleDateInterpDialog.dispose();
@@ -3496,7 +3500,7 @@ private void LAICPMS_LegacyAnalysis_MC_UA_menuItemActionPerformed(java.awt.event
 }//GEN-LAST:event_LAICPMS_LegacyAnalysis_MC_UA_menuItemActionPerformed
 
 private void reduceAll_buttonActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_reduceAll_buttonActionPerformed
-    updateReportTable(true);
+    updateReportTable(true, false);
 }//GEN-LAST:event_reduceAll_buttonActionPerformed
 
 private void reportResultsTableAsStringsInExcel_menuItemActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_reportResultsTableAsStringsInExcel_menuItemActionPerformed
@@ -3507,14 +3511,14 @@ private void loadReportSettingsModelFromLocalXMLFileActionPerformed(java.awt.eve
     myState.setMRUReportSettingsModelFolder(//
             setReportSettingsModelFromXMLFile(myState.getMRUReportSettingsModelFolder()));
 
-    updateReportTable(false);
+    updateReportTable(false, false);
 
 }//GEN-LAST:event_loadReportSettingsModelFromLocalXMLFileActionPerformed
 
 private void editCurrentReportSettingsModel_menuItemActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_editCurrentReportSettingsModel_menuItemActionPerformed
 
     ReportSettingsInterface.EditReportSettings(theSample.getReportSettingsModel(), this);
-    updateReportTable(false);
+    updateReportTable(false, false);
 }//GEN-LAST:event_editCurrentReportSettingsModel_menuItemActionPerformed
 
 private void reportResultsTableAsPDF_menuItemActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_reportResultsTableAsPDF_menuItemActionPerformed
@@ -3653,7 +3657,7 @@ private void startStopLiveUpdate_buttonActionPerformed(java.awt.event.ActionEven
             new ETWarningDialog(ex).setVisible(true);
         }
 
-        rebuildFractionDisplays(false);
+        rebuildFractionDisplays(false, false);
     }
 
     /**
@@ -3887,12 +3891,12 @@ private void updateData_buttonActionPerformed(java.awt.event.ActionEvent evt) {/
 
 private void selectAllFractions_menuItemActionPerformed (java.awt.event.ActionEvent evt) {//GEN-FIRST:event_selectAllFractions_menuItemActionPerformed
     theSample.selectAllFractions();
-    updateReportTable(false);
+    updateReportTable(false, false);
 }//GEN-LAST:event_selectAllFractions_menuItemActionPerformed
 
 private void deSelectAllFractions_menuItemActionPerformed (java.awt.event.ActionEvent evt) {//GEN-FIRST:event_deSelectAllFractions_menuItemActionPerformed
     theSample.deSelectAllFractions();
-    updateReportTable(false);
+    updateReportTable(false, false);
 }//GEN-LAST:event_deSelectAllFractions_menuItemActionPerformed
 
 private void credits_menuItemActionPerformed (java.awt.event.ActionEvent evt) {//GEN-FIRST:event_credits_menuItemActionPerformed
@@ -3911,7 +3915,7 @@ private void saveCurrentReportSettingsModelAsLocalXMLFileActionPerformed(java.aw
 private void loadDefaultReportSettingsModelActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_loadDefaultReportSettingsModelActionPerformed
     theSample.restoreDefaultReportSettingsModel();
     theSample.setLegacyStatusForReportTable();
-    updateReportTable(false);
+    updateReportTable(false, false);
 }//GEN-LAST:event_loadDefaultReportSettingsModelActionPerformed
 
 private void writeCSVFileOfLAICPMSLegacyDataSampleFieldNames_SC_WSU_vBActionPerformed (java.awt.event.ActionEvent evt) {//GEN-FIRST:event_writeCSVFileOfLAICPMSLegacyDataSampleFieldNames_SC_WSU_vBActionPerformed
@@ -4018,7 +4022,7 @@ private void LAICPMS_LegacyAnalysis_UH_menuItemActionPerformed (java.awt.event.A
     private void loadEARTHTIMEDefaultReportSettingsModel_menuItemActionPerformed ( java.awt.event.ActionEvent evt ) {//GEN-FIRST:event_loadEARTHTIMEDefaultReportSettingsModel_menuItemActionPerformed
         SampleInterface.loadDefaultEARTHTIMEReportSettingsModel(theSample);
         theSample.setLegacyStatusForReportTable();
-        updateReportTable(false);
+        updateReportTable(false, false);
     }//GEN-LAST:event_loadEARTHTIMEDefaultReportSettingsModel_menuItemActionPerformed
 
     private void exit_menuItemActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_exit_menuItemActionPerformed

--- a/src/main/java/org/earthtime/Tripoli/dataModels/DataModelFitFunctionInterface.java
+++ b/src/main/java/org/earthtime/Tripoli/dataModels/DataModelFitFunctionInterface.java
@@ -34,8 +34,9 @@ public interface DataModelFitFunctionInterface {
      *
      * @param propagateUncertainties the value of propagateUncertainties
      * @param doApplyMaskingArray the value of doApplyMaskingArray
+     * @param inLiveMode
      */
-    public void generateSetOfFitFunctions(boolean propagateUncertainties, boolean doApplyMaskingArray);
+    public void generateSetOfFitFunctions(boolean propagateUncertainties, boolean doApplyMaskingArray, boolean inLiveMode);
 
    // public void generateSelectedFitFunction ();
     /**

--- a/src/main/java/org/earthtime/Tripoli/dataModels/DataModelInterface.java
+++ b/src/main/java/org/earthtime/Tripoli/dataModels/DataModelInterface.java
@@ -67,8 +67,9 @@ public interface DataModelInterface {
      *
      * @param propagateUncertainties
      * @param doApplyMaskingArray the value of doApplyMaskingArray
+     * @param inLiveMode the value of inLiveMode
      */
-    public void generateSetOfFitFunctions(boolean propagateUncertainties, boolean doApplyMaskingArray);
+    public void generateSetOfFitFunctions(boolean propagateUncertainties, boolean doApplyMaskingArray, boolean inLiveMode);
 
     /**
      *

--- a/src/main/java/org/earthtime/Tripoli/dataModels/DownholeFractionationDataModel.java
+++ b/src/main/java/org/earthtime/Tripoli/dataModels/DownholeFractionationDataModel.java
@@ -502,7 +502,7 @@ public class DownholeFractionationDataModel implements Serializable, DataModelFi
      * @param doApplyMaskingArray the value of doApplyMaskingArray
      */
     @Override
-    public void generateSetOfFitFunctions(boolean propagateUncertainties, boolean doApplyMaskingArray) {
+    public void generateSetOfFitFunctions(boolean propagateUncertainties, boolean doApplyMaskingArray, boolean inLiveMode) {
 
         if (generateMEANfitFunctionUsingLM()) {
             try {
@@ -510,6 +510,8 @@ public class DownholeFractionationDataModel implements Serializable, DataModelFi
                 generateEXPONENTIALfitFunctionUsingLM();
             } catch (Exception e) {
             }
+            
+            // turned off for now
 //            try {
 //                generateEXPONENTIALfitFunctionUsingLM();
 //            } catch (Exception e) {

--- a/src/main/java/org/earthtime/Tripoli/dataModels/RawIntensityDataModel.java
+++ b/src/main/java/org/earthtime/Tripoli/dataModels/RawIntensityDataModel.java
@@ -631,7 +631,7 @@ public class RawIntensityDataModel //
     }
 
     @Override
-    public void generateSetOfFitFunctions(boolean propagateUncertainties, boolean doApplyMaskingArray) {
+    public void generateSetOfFitFunctions(boolean propagateUncertainties, boolean doApplyMaskingArray, boolean inLiveMode) {
 
         // June 2013 copied from RawRatioDataModel feb 2013 new strategy to do only once
         // also MEAN returns false if it had to use an arithmentic mean and stops further processing

--- a/src/main/java/org/earthtime/Tripoli/dataModels/RawRatioDataModel.java
+++ b/src/main/java/org/earthtime/Tripoli/dataModels/RawRatioDataModel.java
@@ -871,9 +871,10 @@ public class RawRatioDataModel //
      *
      * @param propagateUncertainties the value of propagateUncertainties
      * @param doApplyMaskingArray the value of doApplyMaskingArray
+     * @param inLiveMode the value of inLiveMode
      */
     @Override
-    public void generateSetOfFitFunctions(boolean propagateUncertainties, boolean doApplyMaskingArray) {
+    public void generateSetOfFitFunctions(boolean propagateUncertainties, boolean doApplyMaskingArray, boolean inLiveMode) {
         if (!belowDetection && (usedForFractionationCorrections || usedForCommonLeadCorrections)) {
 
             // april 2014
@@ -954,12 +955,16 @@ public class RawRatioDataModel //
                         logRatioFitFunctionsWithOD.remove(FitFunctionTypeEnum.LINE.getName());
 
                     }
-                    try {
-                        generateEXPONENTIALfitFunctionUsingLM();
-                    } catch (Exception e) {
-                        System.out.println("Exception generating EXPONENTIAL");
-                        logRatioFitFunctionsNoOD.remove(FitFunctionTypeEnum.EXPONENTIAL.getName());
-                        logRatioFitFunctionsWithOD.remove(FitFunctionTypeEnum.EXPONENTIAL.getName());
+
+                    // June 2016 - simplify math in live mode
+                    if (!inLiveMode) {
+                        try {
+                            generateEXPONENTIALfitFunctionUsingLM();
+                        } catch (Exception e) {
+                            System.out.println("Exception generating EXPONENTIAL");
+                            logRatioFitFunctionsNoOD.remove(FitFunctionTypeEnum.EXPONENTIAL.getName());
+                            logRatioFitFunctionsWithOD.remove(FitFunctionTypeEnum.EXPONENTIAL.getName());
+                        }
                     }
                     calculatedInitialFitFunctions = true;
 
@@ -1858,7 +1863,8 @@ public class RawRatioDataModel //
     }
 
     /**
-     * @param uncertaintyOneSigmaAbsRatios the uncertaintyOneSigmaAbsRatios to set
+     * @param uncertaintyOneSigmaAbsRatios the uncertaintyOneSigmaAbsRatios to
+     * set
      */
     public void setUncertaintyOneSigmaAbsRatios(double[] uncertaintyOneSigmaAbsRatios) {
         this.uncertaintyOneSigmaAbsRatios = uncertaintyOneSigmaAbsRatios;

--- a/src/main/java/org/earthtime/Tripoli/dataViews/AbstractRawDataView.java
+++ b/src/main/java/org/earthtime/Tripoli/dataViews/AbstractRawDataView.java
@@ -1155,9 +1155,9 @@ public abstract class AbstractRawDataView extends JLayeredPane implements MouseI
 
         // detecting correct object
         if (sampleSessionDataView == null) {
-            ((TripoliSessionFractionationCalculatorInterface) this).applyCorrections();
+            ((TripoliSessionFractionationCalculatorInterface) this).applyCorrections(false);
         } else {
-            ((TripoliSessionFractionationCalculatorInterface) sampleSessionDataView).applyCorrections();
+            ((TripoliSessionFractionationCalculatorInterface) sampleSessionDataView).applyCorrections(false);
         }
 
         updateReportTableView();

--- a/src/main/java/org/earthtime/Tripoli/dataViews/AbstractRawDataView.java
+++ b/src/main/java/org/earthtime/Tripoli/dataViews/AbstractRawDataView.java
@@ -598,10 +598,11 @@ public abstract class AbstractRawDataView extends JLayeredPane implements MouseI
     /**
      *
      * @param doReScale the value of doReScale
+     * @param inLiveMode the value of inLiveMode
      */
-    public void refreshPanel(boolean doReScale) {
+    public void refreshPanel(boolean doReScale, boolean inLiveMode) {
         try {
-            preparePanel(doReScale);
+            preparePanel(doReScale, inLiveMode);
         } catch (Exception e) {
         }
         validate();
@@ -611,8 +612,9 @@ public abstract class AbstractRawDataView extends JLayeredPane implements MouseI
     /**
      *
      * @param doReScale the value of doReScale
+     * @param inLiveMode the value of inLiveMode
      */
-    public abstract void preparePanel(boolean doReScale);
+    public abstract void preparePanel(boolean doReScale, boolean inLiveMode);
 
     /**
      * @return the graphWidth
@@ -865,7 +867,7 @@ public abstract class AbstractRawDataView extends JLayeredPane implements MouseI
         if (fractionDataViewsContainer != null) {
             for (Component component : fractionDataViewsContainer.getComponents()) {
                 if (component instanceof AbstractRawDataView) {
-                    ((AbstractRawDataView) component).refreshPanel(false);
+                    ((AbstractRawDataView) component).refreshPanel(false, false);
                 }
             }
             //fractionDataViewsContainer.repaint();
@@ -963,12 +965,12 @@ public abstract class AbstractRawDataView extends JLayeredPane implements MouseI
                 // feb 2013 here we differentiate between session and ratios
                 // for ratios,we want data point toggle to only affect fraction and not disturb layout
                 if (rawRatioDataModel instanceof AbstractSessionForStandardDataModel) {
-                    ((AbstractRawDataView) sampleSessionDataView).refreshPanel(true);
+                    ((AbstractRawDataView) sampleSessionDataView).refreshPanel(true, false);
                 } else {
                     for (AbstractRawDataView fractionRawDataView : fractionRawDataViews) {
                         // dec 2015 modified to redo math on downhole unknowns
                         if ((fractionRawDataView instanceof AbstractFitFunctionPresentationView) || (fractionRawDataView instanceof CorrectedRatioDataView)) {
-                            fractionRawDataView.refreshPanel(false);
+                            fractionRawDataView.refreshPanel(false, false);
                             updateReportTable();
                         } else if (fractionRawDataView != null) {
                             // april 2015 added test
@@ -1137,7 +1139,7 @@ public abstract class AbstractRawDataView extends JLayeredPane implements MouseI
 
         tripoliFraction.setShowVerticalLineAtThisIndex(-1);
 
-        ((AbstractRawDataView) sampleSessionDataView).refreshPanel(true);
+        ((AbstractRawDataView) sampleSessionDataView).refreshPanel(true, false);
 
         // feb 2013 standards not put to redux anymore
         try {
@@ -1163,7 +1165,7 @@ public abstract class AbstractRawDataView extends JLayeredPane implements MouseI
         updateReportTableView();
 
         if (sampleSessionDataView instanceof AbstractDataMonitorView) {
-            ((AbstractDataMonitorView) sampleSessionDataView).prepareConcordia();
+            ((AbstractDataMonitorView) sampleSessionDataView).prepareConcordia(false);
         }
     }
 
@@ -1171,7 +1173,7 @@ public abstract class AbstractRawDataView extends JLayeredPane implements MouseI
         if (uPbReduxFrame == null) {
             uPbReduxFrame = ((AbstractRawDataView) sampleSessionDataView).getuPbReduxFrame();
         }
-        uPbReduxFrame.updateReportTable(true);
+        uPbReduxFrame.updateReportTable(true, false);
 
     }
 

--- a/src/main/java/org/earthtime/Tripoli/dataViews/dataMonitorViews/AbstractDataMonitorView.java
+++ b/src/main/java/org/earthtime/Tripoli/dataViews/dataMonitorViews/AbstractDataMonitorView.java
@@ -458,7 +458,7 @@ public class AbstractDataMonitorView extends AbstractRawDataView
         recalcButton.setBounds(leftMargin + 450, topMargin + 660, 120, 25);
         recalcButton.addActionListener((ActionEvent ae) -> {
             try {
-                tripoliSession.interceptCalculatePbcCorrAndRhos();
+                tripoliSession.interceptCalculatePbcCorrAndRhos(true);
             } catch (Exception e) {
             }
             try {

--- a/src/main/java/org/earthtime/Tripoli/dataViews/dataMonitorViews/AbstractDataMonitorView.java
+++ b/src/main/java/org/earthtime/Tripoli/dataViews/dataMonitorViews/AbstractDataMonitorView.java
@@ -294,18 +294,22 @@ public class AbstractDataMonitorView extends AbstractRawDataView
 
         this.removeAll();
 
-        tripoliSession.calculateSessionFitFunctionsForPrimaryStandard();
+        // june 2016 check for ref material
+        if (!tripoliSession.isRefMaterialSessionFittedForLiveMode() || tripoliSession.getTripoliFractions().last().isStandard()) {
+            tripoliSession.calculateSessionFitFunctionsForPrimaryStandard(true);
+            tripoliSession.setRefMaterialSessionFittedForLiveMode(true);
+        }
 
         try {
-            tripoliSession.applyCorrections();
+            tripoliSession.applyCorrections(true);
         } catch (Exception e) {
         }
 
         try {
-            tripoliSession.prepareForReductionAndCommonLeadCorrection();
+            tripoliSession.prepareForReductionAndCommonLeadCorrection(true);
         } catch (Exception e) {
         }
-
+        
         try {
             getuPbReduxFrame().updateReportTable(true);
         } catch (Exception e) {
@@ -684,13 +688,13 @@ public class AbstractDataMonitorView extends AbstractRawDataView
     }
 
     @Override
-    public void calculateSessionFitFunctionsForPrimaryStandard() {
-        tripoliSession.calculateSessionFitFunctionsForPrimaryStandard();
+    public void calculateSessionFitFunctionsForPrimaryStandard(boolean inLiveMode) {
+        tripoliSession.calculateSessionFitFunctionsForPrimaryStandard(inLiveMode);
     }
 
     @Override
-    public void applyCorrections() {
-        tripoliSession.applyCorrections();
+    public void applyCorrections(boolean inLiveMode) {
+        tripoliSession.applyCorrections(inLiveMode);
     }
 
     @Override
@@ -705,7 +709,7 @@ public class AbstractDataMonitorView extends AbstractRawDataView
         MaskingSingleton.getInstance().setRightShadeCount(-1);
 
         rawDataFileHandler.getAndLoadRawIntensityDataFile(//
-                loadDataTask, usingFullPropagation, leftShadeCount, ignoreFirstFractions);
+                loadDataTask, usingFullPropagation, leftShadeCount, ignoreFirstFractions, true);
 
     }
 
@@ -769,8 +773,7 @@ public class AbstractDataMonitorView extends AbstractRawDataView
             tripoliSession.prepareFractionTimeStamps();
             tripoliSession.processRawData(true);
 
-            tripoliSession.postProcessDataForCommonLeadLossPreparation();
-
+//            tripoliSession.postProcessDataForCommonLeadLossPreparation();
             try {
                 loadDataTaskProgressBar.repaint();
 

--- a/src/main/java/org/earthtime/Tripoli/dataViews/dataMonitorViews/AbstractDataMonitorView.java
+++ b/src/main/java/org/earthtime/Tripoli/dataViews/dataMonitorViews/AbstractDataMonitorView.java
@@ -295,7 +295,7 @@ public class AbstractDataMonitorView extends AbstractRawDataView
         this.removeAll();
 
         // june 2016 check for ref material
-        if (!tripoliSession.isRefMaterialSessionFittedForLiveMode() || tripoliSession.getTripoliFractions().last().isStandard()) {
+        if (!tripoliSession.isRefMaterialSessionFittedForLiveMode()) {// || tripoliSession.getTripoliFractions().last().isStandard()) {
             tripoliSession.calculateSessionFitFunctionsForPrimaryStandard(true);
             tripoliSession.setRefMaterialSessionFittedForLiveMode(true);
         }
@@ -309,7 +309,7 @@ public class AbstractDataMonitorView extends AbstractRawDataView
             tripoliSession.prepareForReductionAndCommonLeadCorrection(true);
         } catch (Exception e) {
         }
-        
+
         try {
             getuPbReduxFrame().updateReportTable(true);
         } catch (Exception e) {
@@ -852,6 +852,12 @@ public class AbstractDataMonitorView extends AbstractRawDataView
                 int progress = (Integer) pce.getNewValue();
                 loadDataTaskProgressBar.setValue(progress);
                 loadDataTaskProgressBar.repaint();//.validate();
+            } else if ("refMaterialLoaded".equalsIgnoreCase(pce.getPropertyName())) {
+                try {
+                    tripoliSession.setRefMaterialSessionFittedForLiveMode(false);
+                    System.out.println("ref material loaded <<<<");
+                } catch (Exception e) {
+                }
             }
         }
     }

--- a/src/main/java/org/earthtime/Tripoli/dataViews/dataMonitorViews/AbstractDataMonitorView.java
+++ b/src/main/java/org/earthtime/Tripoli/dataViews/dataMonitorViews/AbstractDataMonitorView.java
@@ -38,9 +38,7 @@ import java.beans.PropertyChangeListener;
 import java.io.File;
 import java.io.IOException;
 import java.math.BigDecimal;
-import java.text.SimpleDateFormat;
 import java.util.ArrayList;
-import java.util.Calendar;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.SortedSet;
@@ -260,17 +258,13 @@ public class AbstractDataMonitorView extends AbstractRawDataView
 
         if (lastMonitoredTime > saveMonitoredTime) {
 
-            Calendar cal = Calendar.getInstance();
-            cal.clear();
-            cal.setTimeInMillis(lastMonitoredTime);
-            SimpleDateFormat date_format = new SimpleDateFormat("MMM dd,yyyy HH:mm:ss");
-
             if (loadDataTask != null) {
                 if (loadDataTask.isDone()) {
                     saveMonitoredTime = lastMonitoredTime;
                     fireLoadDataTask();
                 }
             } else {
+                saveMonitoredTime = lastMonitoredTime;
                 fireLoadDataTask();
             }
         }
@@ -311,15 +305,15 @@ public class AbstractDataMonitorView extends AbstractRawDataView
         }
 
         try {
-            getuPbReduxFrame().updateReportTable(true);
+            getuPbReduxFrame().updateReportTable(true, true);
         } catch (Exception e) {
         }
 
-        preparePanel(true);
+        preparePanel(true, true);
     }
 
     @Override
-    public void preparePanel(boolean doReScale) {
+    public void preparePanel(boolean doReScale, boolean inLiveMode) {
 
         this.removeAll();
 
@@ -351,7 +345,7 @@ public class AbstractDataMonitorView extends AbstractRawDataView
                                         250,//
                                         160));
 
-                rawDataModelView.preparePanel(doReScale);
+                rawDataModelView.preparePanel(doReScale, inLiveMode);
 
                 this.add(rawDataModelView, JLayeredPane.DEFAULT_LAYER);
 
@@ -398,13 +392,13 @@ public class AbstractDataMonitorView extends AbstractRawDataView
                                         250, //
                                         180));
 
-                sessionFitFunctionsPresentationView.preparePanel(doReScale);
+                sessionFitFunctionsPresentationView.preparePanel(doReScale, inLiveMode);
 
                 this.add(sessionFitFunctionsPresentationView, JLayeredPane.DEFAULT_LAYER);
 
                 count++;
             }
-            prepareConcordia();
+            prepareConcordia(inLiveMode);
 
             preparePDF();
 
@@ -454,18 +448,20 @@ public class AbstractDataMonitorView extends AbstractRawDataView
         closeAndReviewButton.setEnabled(true);
         this.add(closeAndReviewButton, LAYER_FIVE);
 
-        ET_JButton recalcButton = new ET_JButton("Re-calculate rhos");
+        ET_JButton recalcButton = new ET_JButton("Update Sessions");
         recalcButton.setBounds(leftMargin + 450, topMargin + 660, 120, 25);
         recalcButton.addActionListener((ActionEvent ae) -> {
             try {
+                tripoliSession.resetAllUPbFractionReduction();
+                tripoliSession.applyCorrections(true);
                 tripoliSession.interceptCalculatePbcCorrAndRhos(true);
             } catch (Exception e) {
             }
             try {
-                getuPbReduxFrame().updateReportTable(true);
+                getuPbReduxFrame().updateReportTable(true, true);
             } catch (Exception e) {
             }
-            preparePanel(true);
+            preparePanel(true, true);
         });
 
         recalcButton.setEnabled(true);
@@ -474,7 +470,7 @@ public class AbstractDataMonitorView extends AbstractRawDataView
         ET_JButton refreshButton = new ET_JButton("Refresh Views");
         refreshButton.setBounds(leftMargin + 570, topMargin + 660, 120, 25);
         refreshButton.addActionListener((ActionEvent ae) -> {
-            preparePanel(true);
+            preparePanel(true, false);
         });
 
         refreshButton.setEnabled(true);
@@ -484,7 +480,7 @@ public class AbstractDataMonitorView extends AbstractRawDataView
         editReportSettingsButton.setBounds(602, topMargin + 600, 120, 25);
         editReportSettingsButton.addActionListener((ActionEvent ae) -> {
             ReportSettingsInterface.EditReportSettings(project.getSuperSample().getReportSettingsModel(), uPbReduxFrame);
-            uPbReduxFrame.updateReportTable(false);
+            uPbReduxFrame.updateReportTable(false, true);
             ((TabbedReportViews) reportTableTabbedPane).prepareTabs();
         });
 
@@ -513,8 +509,9 @@ public class AbstractDataMonitorView extends AbstractRawDataView
 
     /**
      *
+     * @param inLiveMode the value of inLiveMode
      */
-    public void prepareConcordia() {
+    public void prepareConcordia(boolean inLiveMode) {
 
         if (concordiaGraphPanel != null) {
             this.remove(concordiaGraphPanel);
@@ -563,7 +560,7 @@ public class AbstractDataMonitorView extends AbstractRawDataView
 
             ((AliquotDetailsDisplayInterface) concordiaGraphPanel).//
                     setSelectedFractions(selectedFractions);
-            ((PlottingDetailsDisplayInterface) concordiaGraphPanel).resetPanel(true);
+            ((PlottingDetailsDisplayInterface) concordiaGraphPanel).resetPanel(true, inLiveMode);
         } catch (Exception e) {
         }
 
@@ -713,7 +710,7 @@ public class AbstractDataMonitorView extends AbstractRawDataView
 
     }
 
-    private void loadAndShowRawDataFinishUp() {
+    private synchronized void  loadAndShowRawDataFinishUp() {
         SortedSet<TripoliFraction> tripoliFractionsCurrent;
 
         if (savedCountOfFractions == 0) {
@@ -782,11 +779,16 @@ public class AbstractDataMonitorView extends AbstractRawDataView
 
             project.prepareSamplesForRedux();
 
-            getuPbReduxFrame().initializeProject();
+            getuPbReduxFrame().initializeProject(true);
 
             updateDisplays();
         }
 
+    }
+
+    @Override
+    public void resetAllUPbFractionReduction() {
+        throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
     }
 
     private class LoadDataTask extends SwingWorker<Void, Void> {
@@ -808,10 +810,8 @@ public class AbstractDataMonitorView extends AbstractRawDataView
         public Void doInBackground() {
             //Initialize progress property.
             add(loadDataTaskProgressBar);
-            //loadDataTaskProgressBar.setVisible(true);
             loadDataTaskProgressBar.setValue(0);
             loadDataTaskProgressBar.repaint();
-            //setProgress(0);
             repaint();
 
             loadAndShowRawData(usingFullPropagation, leftShadeCount, ignoreFirstFractions);
@@ -823,13 +823,12 @@ public class AbstractDataMonitorView extends AbstractRawDataView
          */
         @Override
         public void done() {
-//            Toolkit.getDefaultToolkit().beep();
+
             remove(loadDataTaskProgressBar);
-            //loadDataTaskProgressBar.setVisible(false);
             loadDataTaskProgressBar.setValue(0);
             loadDataTaskProgressBar.repaint();
-            //setProgress(0);
             repaint();
+
             System.out.println("LOADING TASK DONE !!");
             loadAndShowRawDataFinishUp();
         }
@@ -917,7 +916,6 @@ public class AbstractDataMonitorView extends AbstractRawDataView
         paintInit(g2d);
 
         // draw box around possibly missing pdf
-//        g2d.drawRect(1145, topMargin - 2, 510, 500);
         g2d.drawRect(1350, topMargin + 50, pdfWidth + 5, pdfHeight + 5);
     }
 
@@ -963,16 +961,6 @@ public class AbstractDataMonitorView extends AbstractRawDataView
 
         liveDataScrollPane.setViewportView(this);
 
-        //        javax.swing.GroupLayout layout = new javax.swing.GroupLayout(dataMonitorViewDialog.getContentPane());
-        //        dataMonitorViewDialog.getContentPane().setLayout(layout);
-        //        layout.setHorizontalGroup(
-        //            layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
-        //            .addComponent(liveDataScrollPane)
-        //        );
-        //        layout.setVerticalGroup(
-        //            layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
-        //            .addComponent(liveDataScrollPane)
-        //        );
         dataMonitorViewDialog.add(liveDataScrollPane);
         dataMonitorViewDialog.pack();
 
@@ -1000,10 +988,8 @@ public class AbstractDataMonitorView extends AbstractRawDataView
             }
         });
 
-//        try {
         dataMonitorViewDialog.setVisible(true);
-//        } catch (Exception e) {
-//        }
+
         return dataMonitorViewDialog;
     }
 
@@ -1046,7 +1032,7 @@ public class AbstractDataMonitorView extends AbstractRawDataView
             ((DateProbabilityDensityPanel) probabilityPanel).//
                     setSelectedAliquot(0);
             ((PlottingDetailsDisplayInterface) probabilityPanel).//
-                    refreshPanel(true);
+                    refreshPanel(true, true);
 
         } else if (nodeInfo instanceof AliquotInterface) {
 

--- a/src/main/java/org/earthtime/Tripoli/dataViews/fitFunctionPresentationViews/AbstractFitFunctionPresentationView.java
+++ b/src/main/java/org/earthtime/Tripoli/dataViews/fitFunctionPresentationViews/AbstractFitFunctionPresentationView.java
@@ -269,7 +269,7 @@ public abstract class AbstractFitFunctionPresentationView extends AbstractRawDat
                         rawRatioDataModel.setOverDispersionSelected(((AbstractButton) ae.getSource()).isSelected());
                     }
 
-                    refreshPanel(true);
+                    refreshPanel(true, false);
 
                     updatePlotsWithChanges(targetDataModelView);
 

--- a/src/main/java/org/earthtime/Tripoli/dataViews/fitFunctionPresentationViews/AllFunctionsChoicePanel.java
+++ b/src/main/java/org/earthtime/Tripoli/dataViews/fitFunctionPresentationViews/AllFunctionsChoicePanel.java
@@ -104,7 +104,7 @@ public class AllFunctionsChoicePanel extends AbstractRawDataView {
     }
 
     @Override
-    public void preparePanel(boolean doReScale) {
+    public void preparePanel(boolean doReScale, boolean inLiveMode) {
         this.removeAll();
 
         // arbitrary
@@ -146,7 +146,7 @@ public class AllFunctionsChoicePanel extends AbstractRawDataView {
             // ((AbstractRawDataView) sampleSessionDataView).refreshPanel(true);
 
             for (int i = 0; i < rawDataModelViews.length; i++) {
-                rawDataModelViews[i].refreshPanel(false);
+                rawDataModelViews[i].refreshPanel(false, false);
             }
 //            // be sure changes to unknowns go to data table
 //            if (rawDataModelViews[0] instanceof FitFunctionsOnRatioDataView) {
@@ -186,7 +186,7 @@ public class AllFunctionsChoicePanel extends AbstractRawDataView {
 
 //                ((AbstractRawDataView) sampleSessionDataView).refreshPanel(true);
                 for (int i = 0; i < rawDataModelViews.length; i++) {
-                    rawDataModelViews[i].refreshPanel(false);
+                    rawDataModelViews[i].refreshPanel(false, false);
                 }
                 updateReportTable();
             }

--- a/src/main/java/org/earthtime/Tripoli/dataViews/fitFunctionPresentationViews/DownholeFitFunctionsPresentationView.java
+++ b/src/main/java/org/earthtime/Tripoli/dataViews/fitFunctionPresentationViews/DownholeFitFunctionsPresentationView.java
@@ -67,9 +67,10 @@ public class DownholeFitFunctionsPresentationView extends AbstractFitFunctionPre
     /**
      *
      * @param doReScale the value of doReScale
+     * @param inLiveMode the value of inLiveMode
      */
     @Override
-    public void preparePanel(boolean doReScale) {
+    public void preparePanel(boolean doReScale, boolean inLiveMode) {
 
         removeAll();
         // first restore the data

--- a/src/main/java/org/earthtime/Tripoli/dataViews/fitFunctionPresentationViews/InterceptFitFunctionsPresentationView.java
+++ b/src/main/java/org/earthtime/Tripoli/dataViews/fitFunctionPresentationViews/InterceptFitFunctionsPresentationView.java
@@ -73,9 +73,10 @@ public class InterceptFitFunctionsPresentationView extends AbstractFitFunctionPr
     /**
      *
      * @param doReScale the value of doReScale
+     * @param inLiveMode the value of inLiveMode
      */
     @Override
-    public void preparePanel(boolean doReScale) {
+    public void preparePanel(boolean doReScale, boolean inLiveMode) {
 
         removeAll();
         // first restore the data

--- a/src/main/java/org/earthtime/Tripoli/dataViews/fitFunctionPresentationViews/InterceptFitFunctionsPresentationView.java
+++ b/src/main/java/org/earthtime/Tripoli/dataViews/fitFunctionPresentationViews/InterceptFitFunctionsPresentationView.java
@@ -85,7 +85,7 @@ public class InterceptFitFunctionsPresentationView extends AbstractFitFunctionPr
                 if (targetDataModelView instanceof FitFunctionsOnDownHoleRatioDataView) {
                     ((RawRatioDataModel) rawRatioDataModel).generateFitFunctionsForDownhole();
                 } else {
-                    ((DataModelFitFunctionInterface) rawRatioDataModel).generateSetOfFitFunctions(true, false);
+                    ((DataModelFitFunctionInterface) rawRatioDataModel).generateSetOfFitFunctions(true, false, false);
                 }
             }
         }

--- a/src/main/java/org/earthtime/Tripoli/dataViews/fitFunctionPresentationViews/SessionFitFunctionsPresentationView.java
+++ b/src/main/java/org/earthtime/Tripoli/dataViews/fitFunctionPresentationViews/SessionFitFunctionsPresentationView.java
@@ -78,9 +78,10 @@ public class SessionFitFunctionsPresentationView extends AbstractFitFunctionPres
     /**
      * 
      * @param doReScale the value of doReScale
+     * @param inLiveMode the value of inLiveMode
      */
     @Override
-    public void preparePanel(boolean doReScale) {
+    public void preparePanel(boolean doReScale, boolean inLiveMode) {
         removeAll();
 
         createFitFunctionPanes(sessionForStandardDataModel, true);      

--- a/src/main/java/org/earthtime/Tripoli/dataViews/fitFunctionPresentationViews/SplineOverDispersionChooserPanel.java
+++ b/src/main/java/org/earthtime/Tripoli/dataViews/fitFunctionPresentationViews/SplineOverDispersionChooserPanel.java
@@ -121,7 +121,7 @@ public class SplineOverDispersionChooserPanel extends AbstractRawDataView {
     }
 
     @Override
-    public void preparePanel (boolean doReScale) {
+    public void preparePanel (boolean doReScale, boolean inLiveMode) {
         this.removeAll();
 
         minY = Double.MAX_VALUE;
@@ -172,13 +172,13 @@ public class SplineOverDispersionChooserPanel extends AbstractRawDataView {
                     if ( sampleSessionDataView instanceof SessionOfStandardView ) {
                         currentSplineWithOD = ((SessionOfStandardView) sampleSessionDataView).getSessionForStandardDataModel().getSelectedFitFunction();
                         currentSplineWithOD.copyValuesFrom( splineWithOD );
-                        ((SessionOfStandardView) sampleSessionDataView).refreshPanel(true);
+                        ((SessionOfStandardView) sampleSessionDataView).refreshPanel(true, false);
                         ((SmoothingSplineFitFunctionView) fitFunctionView).refreshXiLabel();
                         ((SmoothingSplineFitFunctionView) fitFunctionView).getPresentationView().repaint();
                     } else if ( sampleSessionDataView instanceof DataViewsOverlay ) {
                         currentSplineWithOD = ((DataViewsOverlay) sampleSessionDataView).getDownholeFractionationDataModel().getSelectedFitFunction();
                         currentSplineWithOD.copyValuesFrom( splineWithOD );
-                        ((DataViewsOverlay) sampleSessionDataView).refreshPanel(true);
+                        ((DataViewsOverlay) sampleSessionDataView).refreshPanel(true, false);
                         ((SmoothingSplineFitFunctionView) fitFunctionView).refreshXiLabel();
                         ((SmoothingSplineFitFunctionView) fitFunctionView).getPresentationView().repaint();
                     }

--- a/src/main/java/org/earthtime/Tripoli/dataViews/fitFunctionViews/SmoothingSplineFitFunctionView.java
+++ b/src/main/java/org/earthtime/Tripoli/dataViews/fitFunctionViews/SmoothingSplineFitFunctionView.java
@@ -107,14 +107,14 @@ public class SmoothingSplineFitFunctionView extends AbstractFitFunctionView {
                     }
 
                     generateSplineOverDispersionChooserPanel(sessionOfStandardsSplinesWithOD);
-                    splineOverDispersionChooserPanel.preparePanel(true);
+                    splineOverDispersionChooserPanel.preparePanel(true, false);
 
                     add(splineOverDispersionChooserPanel);
 
                     if (targetDataModelView instanceof SessionOfStandardView) {
-                        ((AbstractRawDataView) targetDataModelView).refreshPanel(true);
+                        ((AbstractRawDataView) targetDataModelView).refreshPanel(true, false);
                     } else if (targetDataModelView instanceof SessionOfStandardView) {
-                        ((AbstractRawDataView) targetDataModelView).refreshPanel(true);
+                        ((AbstractRawDataView) targetDataModelView).refreshPanel(true, false);
                     }
 
                     functionChoiceRadioButton.doClick();

--- a/src/main/java/org/earthtime/Tripoli/dataViews/overlayViews/DataViewsOverlay.java
+++ b/src/main/java/org/earthtime/Tripoli/dataViews/overlayViews/DataViewsOverlay.java
@@ -260,9 +260,10 @@ public class DataViewsOverlay extends AbstractRawDataView implements FitFunction
     /**
      *
      * @param doReScale the value of doReScale
+     * @param inLiveMode the value of inLiveMode
      */
     @Override
-    public void preparePanel(boolean doReScale) {
+    public void preparePanel(boolean doReScale, boolean inLiveMode) {
         this.removeAll();
 
         setDisplayOffsetY(0.0);
@@ -472,7 +473,7 @@ public class DataViewsOverlay extends AbstractRawDataView implements FitFunction
                                         }
 
                                         // refresh all
-                                        ((AbstractRawDataView) sampleSessionDataView).refreshPanel(true);
+                                        ((AbstractRawDataView) sampleSessionDataView).refreshPanel(true, false);
 
                                         updateReportTable();
                                     }
@@ -498,7 +499,7 @@ public class DataViewsOverlay extends AbstractRawDataView implements FitFunction
                                         }
 
                                         // refresh all
-                                        ((AbstractRawDataView) sampleSessionDataView).refreshPanel(true);
+                                        ((AbstractRawDataView) sampleSessionDataView).refreshPanel(true, false);
 
                                         updateReportTable();
                                     }
@@ -524,7 +525,7 @@ public class DataViewsOverlay extends AbstractRawDataView implements FitFunction
                                         }
 
                                         // refresh all
-                                        ((AbstractRawDataView) sampleSessionDataView).refreshPanel(true);
+                                        ((AbstractRawDataView) sampleSessionDataView).refreshPanel(true, false);
 
                                         updateReportTable();
 

--- a/src/main/java/org/earthtime/Tripoli/dataViews/overlayViews/TripoliSessionRawDataView.java
+++ b/src/main/java/org/earthtime/Tripoli/dataViews/overlayViews/TripoliSessionRawDataView.java
@@ -369,6 +369,11 @@ public class TripoliSessionRawDataView extends AbstractRawDataView implements Tr
         this.selectedSample = selectedSample;
     }
 
+    @Override
+    public void resetAllUPbFractionReduction() {
+        throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+    }
+
     class YAxisZoomChangeListener implements ChangeListener {
 
         JLayeredPane sampleSessionDataView;
@@ -388,7 +393,7 @@ public class TripoliSessionRawDataView extends AbstractRawDataView implements Tr
                 if (!isZoomSlidersIndependent()) {
                     theOtherSlider.setValue(value);
                 }
-                ((AbstractRawDataView) sampleSessionDataView).refreshPanel(true);
+                ((AbstractRawDataView) sampleSessionDataView).refreshPanel(true, false);
                 sessionAnalysisWorkflowManager.revalidateScrollPane();
             }
         }
@@ -429,7 +434,7 @@ public class TripoliSessionRawDataView extends AbstractRawDataView implements Tr
                 if (!isZoomSlidersIndependent()) {
                     theOtherSlider.setValue(value);
                 }
-                ((AbstractRawDataView) sampleSessionDataView).refreshPanel(true);
+                ((AbstractRawDataView) sampleSessionDataView).refreshPanel(true, false);
                 sessionAnalysisWorkflowManager.revalidateScrollPane();
             }
         }
@@ -454,9 +459,10 @@ public class TripoliSessionRawDataView extends AbstractRawDataView implements Tr
     /**
      *
      * @param doReScale the value of doReScale
+     * @param inLiveMode the value of inLiveMode
      */
     @Override
-    public void preparePanel(boolean doReScale) {
+    public void preparePanel(boolean doReScale, boolean inLiveMode) {
 
         // jan 2013 clean up before switching modes log / ratio / alpha
         if (rawDataModelViews != null) {
@@ -581,7 +587,7 @@ public class TripoliSessionRawDataView extends AbstractRawDataView implements Tr
                 // sept 2015
                 rawDataModelView.setShowIncludedDataPoints(SAVED_DATA_USED_FOR_SCALING);
 
-                rawDataModelView.preparePanel(doReScale);
+                rawDataModelView.preparePanel(doReScale, inLiveMode);
 
                 rawDataModelViews[dataModelCountForVerticalLayout][0] = rawDataModelView;
 
@@ -599,7 +605,7 @@ public class TripoliSessionRawDataView extends AbstractRawDataView implements Tr
                                             WIDTH_OF_FIT_FUNCTION_PANES, //
                                             dataModelHeight));
 
-                    sessionFitFunctionsPresentationView.preparePanel(doReScale);
+                    sessionFitFunctionsPresentationView.preparePanel(doReScale, inLiveMode);
 
                     rawDataModelViews[dataModelCountForVerticalLayout][1] = sessionFitFunctionsPresentationView;
 
@@ -642,7 +648,7 @@ public class TripoliSessionRawDataView extends AbstractRawDataView implements Tr
 
                     rawDataModelView.setDataPresentationMode(dataPresentationMode);
 
-                    rawDataModelView.preparePanel(doReScale);
+                    rawDataModelView.preparePanel(doReScale, inLiveMode);
 
                     rawDataModelViews[dataModelCountForVerticalLayout][fractionCountForHorizontalLayout] = rawDataModelView;
 
@@ -836,7 +842,7 @@ public class TripoliSessionRawDataView extends AbstractRawDataView implements Tr
                                 atLeastOneStandard,
                                 isFitFunctionsOnDownHoleRatioDataView);
 
-                universalFitFunctionChooser.preparePanel(doReScale);
+                universalFitFunctionChooser.preparePanel(doReScale,inLiveMode);
                 yAxisPane.add(universalFitFunctionChooser, javax.swing.JLayeredPane.DRAG_LAYER);
             }
             tripoliSessionRawDataViewYAxis.add(yAxisPane, javax.swing.JLayeredPane.DEFAULT_LAYER);
@@ -905,7 +911,7 @@ public class TripoliSessionRawDataView extends AbstractRawDataView implements Tr
 
                 OverlayViewXAxis.setMinX(overallMinX);
                 OverlayViewXAxis.setMaxX(overallMaxX);
-                OverlayViewXAxis.preparePanel(doReScale);
+                OverlayViewXAxis.preparePanel(doReScale, inLiveMode);
 
                 add(OverlayViewXAxis, javax.swing.JLayeredPane.DEFAULT_LAYER);
 
@@ -918,7 +924,7 @@ public class TripoliSessionRawDataView extends AbstractRawDataView implements Tr
                                 tripoliSessionRawDataViewYAxis.getWidth() - 1, //
                                 HEIGHT_OF_OVERLAY_XAXIS_PANES));
 
-                overlayViewXAxisLabel.preparePanel(doReScale);
+                overlayViewXAxisLabel.preparePanel(doReScale, inLiveMode);
 
                 // place overlayViewXAxisLabel in yaxis column
                 tripoliSessionRawDataViewYAxis.add(overlayViewXAxisLabel, javax.swing.JLayeredPane.DEFAULT_LAYER);
@@ -943,7 +949,7 @@ public class TripoliSessionRawDataView extends AbstractRawDataView implements Tr
                                     WIDTH_OF_FIT_FUNCTION_PANES, //
                                     dataModelHeight + HEIGHT_OF_OVERLAY_XAXIS_PANES + residualsHeight - 1));
 
-                    fitFunctionView.preparePanel(doReScale);
+                    fitFunctionView.preparePanel(doReScale, inLiveMode);
                     add(fitFunctionView, javax.swing.JLayeredPane.DEFAULT_LAYER);
 
                     // build fit function residuals panes
@@ -958,7 +964,7 @@ public class TripoliSessionRawDataView extends AbstractRawDataView implements Tr
 
                     fitFunctionResidualsView.setMinX(overallMinX);
                     fitFunctionResidualsView.setMaxX(overallMaxX);
-                    fitFunctionResidualsView.preparePanel(doReScale);
+                    fitFunctionResidualsView.preparePanel(doReScale, inLiveMode);
 
                     add(fitFunctionResidualsView, javax.swing.JLayeredPane.DEFAULT_LAYER);
 
@@ -972,7 +978,7 @@ public class TripoliSessionRawDataView extends AbstractRawDataView implements Tr
                                     tripoliSessionRawDataViewYAxis.getWidth() - 1, //
                                     HEIGHT_OF_FIT_FUNCTION_RESIDUALS_PANES));
 
-                    residualsYAxisLabel.preparePanel(doReScale);
+                    residualsYAxisLabel.preparePanel(doReScale, inLiveMode);
 
                     // place in yaxis column
                     tripoliSessionRawDataViewYAxis.add(residualsYAxisLabel, javax.swing.JLayeredPane.DEFAULT_LAYER);
@@ -987,7 +993,7 @@ public class TripoliSessionRawDataView extends AbstractRawDataView implements Tr
                 rawDataModelViewsOverlay.setMaxX(overallMaxX);
 
                 rawDataModelViewsOverlay.setTics(yAxisTics);
-                rawDataModelViewsOverlay.preparePanel(doReScale);
+                rawDataModelViewsOverlay.preparePanel(doReScale, inLiveMode);
 
                 add(underlay, javax.swing.JLayeredPane.DEFAULT_LAYER);
                 underlay.add(rawDataModelViewsOverlay, javax.swing.JLayeredPane.PALETTE_LAYER);
@@ -1180,7 +1186,7 @@ public class TripoliSessionRawDataView extends AbstractRawDataView implements Tr
                     if ((layeredLocalInterceptFitFunctionsContainer != null)//
                             &&//
                             FRACTION_LAYOUT_VIEW_STYLE.equals(FractionLayoutViewStylesEnum.GRID_INTERCEPT)) {
-                        interceptFitFunctionsPresentationPanesArray[i].preparePanel(doReScale);
+                        interceptFitFunctionsPresentationPanesArray[i].preparePanel(doReScale, inLiveMode);
                         layeredLocalInterceptFitFunctionsContainer.add(interceptFitFunctionsPresentationPanesArray[i], javax.swing.JLayeredPane.DEFAULT_LAYER);
                         interceptFitFunctionsPresentationPanesArray[i].setFractionDataViewsContainer(layeredLocalInterceptFitFunctionsContainer);
                     }
@@ -1224,7 +1230,7 @@ public class TripoliSessionRawDataView extends AbstractRawDataView implements Tr
                                 HEIGHT_OF_FRACTION_INFO_PANELS), //
                         meanOnly);
 
-        dataPresentationModeChooserPanel.preparePanel(true);
+        dataPresentationModeChooserPanel.preparePanel(true, false);
 
         tripoliSessionDataControls_pane.add(dataPresentationModeChooserPanel, javax.swing.JLayeredPane.DRAG_LAYER);
 
@@ -1286,7 +1292,7 @@ public class TripoliSessionRawDataView extends AbstractRawDataView implements Tr
     public void includeAllAquisitions() {
         tripoliSession.includeAllAquisitions();
 
-        refreshPanel(true);
+        refreshPanel(true, false);
     }
 
     /**
@@ -1295,13 +1301,13 @@ public class TripoliSessionRawDataView extends AbstractRawDataView implements Tr
     public void removeAllLocalYAxisPanes() {
         getTripoliSession().clearAllFractionsOfLocalYAxis();
 
-        refreshPanel(true);
+        refreshPanel(true, false);
     }
 
     public void setAllLocalYAxisPanes() {
         getTripoliSession().setAllFractionsOfLocalYAxis();
 
-        refreshPanel(true);
+        refreshPanel(true, false);
     }
 
     /**
@@ -1324,7 +1330,7 @@ public class TripoliSessionRawDataView extends AbstractRawDataView implements Tr
 
         dataModelHeight = 180;
 
-        refreshPanel(true);
+        refreshPanel(true, false);
 
         //cause slider to synch
         synchXAxisZoomSliderValue(sessionModelWidth);

--- a/src/main/java/org/earthtime/Tripoli/dataViews/overlayViews/TripoliSessionRawDataView.java
+++ b/src/main/java/org/earthtime/Tripoli/dataViews/overlayViews/TripoliSessionRawDataView.java
@@ -334,13 +334,13 @@ public class TripoliSessionRawDataView extends AbstractRawDataView implements Tr
     }
 
     @Override
-    public void calculateSessionFitFunctionsForPrimaryStandard() {
-        tripoliSession.calculateSessionFitFunctionsForPrimaryStandard();
+    public void calculateSessionFitFunctionsForPrimaryStandard(boolean inLiveMode) {
+        tripoliSession.calculateSessionFitFunctionsForPrimaryStandard(inLiveMode);
     }
 
     @Override
-    public void applyCorrections() {
-        tripoliSession.applyCorrections();
+    public void applyCorrections(boolean inLiveMode) {
+        tripoliSession.applyCorrections(inLiveMode);
     }
 
     @Override

--- a/src/main/java/org/earthtime/Tripoli/dataViews/simpleViews/DataPresentationModeChooserPanel.java
+++ b/src/main/java/org/earthtime/Tripoli/dataViews/simpleViews/DataPresentationModeChooserPanel.java
@@ -130,7 +130,7 @@ public class DataPresentationModeChooserPanel extends AbstractRawDataView {
     }
 
     @Override
-    public void preparePanel(boolean doReScale) {
+    public void preparePanel(boolean doReScale, boolean inLiveMode) {
         this.removeAll();
 
         // arbitrary
@@ -172,7 +172,7 @@ public class DataPresentationModeChooserPanel extends AbstractRawDataView {
             public void actionPerformed(ActionEvent e) {
 
                 ((AbstractRawDataView) sampleSessionDataView).setDataPresentationMode(myDataPresentationMode);
-                ((AbstractRawDataView) sampleSessionDataView).refreshPanel(true);
+                ((AbstractRawDataView) sampleSessionDataView).refreshPanel(true, false);
 
             }
         });
@@ -185,7 +185,7 @@ public class DataPresentationModeChooserPanel extends AbstractRawDataView {
         AbstractRawDataView maskingShadeControl = //
                 new MaskingShadeControl(new Rectangle(15, 88, 170, 20), myOnPeakNormalizedAquireTimes, sampleSessionDataView);
 
-        maskingShadeControl.preparePanel(true);
+        maskingShadeControl.preparePanel(true, false);
 
         return maskingShadeControl;
     }
@@ -206,7 +206,7 @@ public class DataPresentationModeChooserPanel extends AbstractRawDataView {
                 // jan 2015 force refit after applying shade
                 //see above ((TripoliSessionRawDataView) sampleSessionDataView).getTripoliSession().calculateSessionFitFunctionsForPrimaryStandard();
 
-                ((AbstractRawDataView) sampleSessionDataView).refreshPanel(true);
+                ((AbstractRawDataView) sampleSessionDataView).refreshPanel(true, false);
 
             }
         });
@@ -228,7 +228,7 @@ public class DataPresentationModeChooserPanel extends AbstractRawDataView {
                     ((TripoliSessionRawDataView) sampleSessionDataView).getTripoliSession().setODforAllFractionsAllRatios(setOD);
                 }
 
-                ((AbstractRawDataView) sampleSessionDataView).refreshPanel(true);
+                ((AbstractRawDataView) sampleSessionDataView).refreshPanel(true, false);
             }
         });
 

--- a/src/main/java/org/earthtime/Tripoli/dataViews/simpleViews/FitFunctionResidualsView.java
+++ b/src/main/java/org/earthtime/Tripoli/dataViews/simpleViews/FitFunctionResidualsView.java
@@ -102,9 +102,10 @@ public class FitFunctionResidualsView extends AbstractRawDataView {
     /**
      *
      * @param doReScale the value of doReScale
+     * @param inLiveMode the value of inLiveMode
      */
     @Override
-    public void preparePanel(boolean doReScale) {
+    public void preparePanel(boolean doReScale, boolean inLiveMode) {
 
         this.removeAll();
 

--- a/src/main/java/org/earthtime/Tripoli/dataViews/simpleViews/FractionInfoPanel.java
+++ b/src/main/java/org/earthtime/Tripoli/dataViews/simpleViews/FractionInfoPanel.java
@@ -155,7 +155,7 @@ public class FractionInfoPanel extends AbstractRawDataView {
         ODChoiceButton.setBounds(6, pixelsFromTop, 60, 20);
         ODChoiceButton.addActionListener((ActionEvent ae) -> {
             tripoliFraction.setODforAllRatios(setOD);
-            ((AbstractRawDataView) sampleSessionDataView).refreshPanel(true);
+            ((AbstractRawDataView) sampleSessionDataView).refreshPanel(true, false);
         });
 
         return ODChoiceButton;
@@ -223,7 +223,7 @@ public class FractionInfoPanel extends AbstractRawDataView {
         @Override
         public void actionPerformed(ActionEvent arg0) {
             tripoliFraction.toggleShowLocalYAxis();
-            ((AbstractRawDataView) sampleSessionDataView).refreshPanel(true);
+            ((AbstractRawDataView) sampleSessionDataView).refreshPanel(true, false);
         }
     }
 
@@ -240,16 +240,17 @@ public class FractionInfoPanel extends AbstractRawDataView {
         @Override
         public void actionPerformed(ActionEvent arg0) {
             tripoliFraction.toggleShowLocalInterceptFitFunctionPanel();
-            ((AbstractRawDataView) sampleSessionDataView).refreshPanel(true);
+            ((AbstractRawDataView) sampleSessionDataView).refreshPanel(true, false);
         }
     }
 
     /**
      *
      * @param doReScale the value of doReScale
+     * @param inLiveMode the value of inLiveMode
      */
     @Override
-    public void preparePanel(boolean doReScale) {
+    public void preparePanel(boolean doReScale, boolean inLiveMode) {
 
         this.removeAll();
 

--- a/src/main/java/org/earthtime/Tripoli/dataViews/simpleViews/MaskingShadeControl.java
+++ b/src/main/java/org/earthtime/Tripoli/dataViews/simpleViews/MaskingShadeControl.java
@@ -103,7 +103,7 @@ public class MaskingShadeControl extends AbstractRawDataView implements MaskingS
     }
 
     @Override
-    public void preparePanel(boolean doReScale) {
+    public void preparePanel(boolean doReScale, boolean inLiveMode) {
 
         this.removeAll();
 
@@ -183,7 +183,7 @@ public class MaskingShadeControl extends AbstractRawDataView implements MaskingS
         }
 
         // refresh all
-        ((AbstractRawDataView) sampleSessionDataView).refreshPanel(true);
+        ((AbstractRawDataView) sampleSessionDataView).refreshPanel(true, false);
 
         return (int) mapX(timeIndex);//currentShadeX;//timeIndex;
     }
@@ -205,7 +205,7 @@ public class MaskingShadeControl extends AbstractRawDataView implements MaskingS
         maskingArray.setRightShadeCount(maskingArray.getMaskingArray().length - timeIndex - 1);
 
         // refresh all
-        ((AbstractRawDataView) sampleSessionDataView).refreshPanel(true);
+        ((AbstractRawDataView) sampleSessionDataView).refreshPanel(true, false);
 
         return (int) mapX(timeIndex - 1);//currentShadeX;//timeIndex;
     }

--- a/src/main/java/org/earthtime/Tripoli/dataViews/simpleViews/ResidualsYAxisLabel.java
+++ b/src/main/java/org/earthtime/Tripoli/dataViews/simpleViews/ResidualsYAxisLabel.java
@@ -80,9 +80,10 @@ public class ResidualsYAxisLabel extends AbstractRawDataView implements MaskingS
     /**
      * 
      * @param doReScale the value of doReScale
+     * @param inLiveMode the value of inLiveMode
      */
     @Override
-    public void preparePanel (boolean doReScale) {
+    public void preparePanel (boolean doReScale, boolean inLiveMode) {
 
         this.removeAll();
 

--- a/src/main/java/org/earthtime/Tripoli/dataViews/simpleViews/SessionOfStandardView.java
+++ b/src/main/java/org/earthtime/Tripoli/dataViews/simpleViews/SessionOfStandardView.java
@@ -388,9 +388,10 @@ public class SessionOfStandardView extends AbstractRawDataView implements FitFun
     /**
      *
      * @param doReScale the value of doReScale
+     * @param inLiveMode the value of inLiveMode
      */
     @Override
-    public void preparePanel(boolean doReScale) {
+    public void preparePanel(boolean doReScale, boolean inLiveMode) {
 
         this.removeAll();
 
@@ -487,7 +488,7 @@ public class SessionOfStandardView extends AbstractRawDataView implements FitFun
                             System.out.println(">>>>>>>>>>>>trouble at standard exclude");
                         }
                         // removed may 2016 updateReportTable();
-                        ((AbstractRawDataView) sampleSessionDataView).refreshPanel(true);
+                        ((AbstractRawDataView) sampleSessionDataView).refreshPanel(true, false);
                     }
                 });
                 popup.add(menuItem);
@@ -506,7 +507,7 @@ public class SessionOfStandardView extends AbstractRawDataView implements FitFun
                             System.out.println(">>>>>>>>>>>>trouble at standard include");
                         }
                         // removed may 2016 updateReportTable();
-                        ((AbstractRawDataView) sampleSessionDataView).refreshPanel(true);
+                        ((AbstractRawDataView) sampleSessionDataView).refreshPanel(true, false);
                     }
                 });
                 popup.add(menuItem);

--- a/src/main/java/org/earthtime/Tripoli/dataViews/simpleViews/XAxisOverlayView.java
+++ b/src/main/java/org/earthtime/Tripoli/dataViews/simpleViews/XAxisOverlayView.java
@@ -131,9 +131,10 @@ public class XAxisOverlayView extends AbstractRawDataView implements MaskingShad
     /**
      * 
      * @param doReScale the value of doReScale
+     * @param inLiveMode the value of inLiveMode
      */
     @Override
-    public void preparePanel (boolean doReScale) {
+    public void preparePanel (boolean doReScale, boolean inLiveMode) {
 
         this.removeAll();
 

--- a/src/main/java/org/earthtime/Tripoli/dataViews/simpleViews/XAxisOverlayViewLabel.java
+++ b/src/main/java/org/earthtime/Tripoli/dataViews/simpleViews/XAxisOverlayViewLabel.java
@@ -76,9 +76,10 @@ public class XAxisOverlayViewLabel extends AbstractRawDataView implements Maskin
     /**
      * 
      * @param doReScale the value of doReScale
+     * @param inLiveMode the value of inLiveMode
      */
     @Override
-    public void preparePanel (boolean doReScale) {
+    public void preparePanel (boolean doReScale, boolean inLiveMode) {
 
         this.removeAll();
 

--- a/src/main/java/org/earthtime/Tripoli/dataViews/simpleViews/YAxisView.java
+++ b/src/main/java/org/earthtime/Tripoli/dataViews/simpleViews/YAxisView.java
@@ -176,9 +176,10 @@ public class YAxisView extends AbstractRawDataView {
     /**
      *
      * @param doReScale the value of doReScale
+     * @param inLiveMode the value of inLiveMode
      */
     @Override
-    public void preparePanel(boolean doReScale) {
+    public void preparePanel(boolean doReScale, boolean inLiveMode) {
 
         this.removeAll();
 

--- a/src/main/java/org/earthtime/Tripoli/dataViews/simpleViews/usedByReflection/CorrectedCountsDataViewForShrimp.java
+++ b/src/main/java/org/earthtime/Tripoli/dataViews/simpleViews/usedByReflection/CorrectedCountsDataViewForShrimp.java
@@ -119,9 +119,10 @@ public class CorrectedCountsDataViewForShrimp extends AbstractRawDataView {
     /**
      *
      * @param doReScale the value of doReScale
+     * @param inLiveMode the value of inLiveMode
      */
     @Override
-    public void preparePanel(boolean doReScale) {
+    public void preparePanel(boolean doReScale, boolean inLiveMode) {
 
         this.removeAll();
 

--- a/src/main/java/org/earthtime/Tripoli/dataViews/simpleViews/usedByReflection/CorrectedIntensitiesDataView.java
+++ b/src/main/java/org/earthtime/Tripoli/dataViews/simpleViews/usedByReflection/CorrectedIntensitiesDataView.java
@@ -96,9 +96,10 @@ public class CorrectedIntensitiesDataView extends AbstractRawDataView {
     /**
      *
      * @param doReScale the value of doReScale
+     * @param inLiveMode the value of inLiveMode
      */
     @Override
-    public void preparePanel(boolean doReScale) {
+    public void preparePanel(boolean doReScale, boolean inLiveMode) {
 
         this.removeAll();
 

--- a/src/main/java/org/earthtime/Tripoli/dataViews/simpleViews/usedByReflection/CorrectedRatioDataView.java
+++ b/src/main/java/org/earthtime/Tripoli/dataViews/simpleViews/usedByReflection/CorrectedRatioDataView.java
@@ -147,9 +147,10 @@ public class CorrectedRatioDataView extends AbstractRawDataView {
     /**
      *
      * @param doReScale the value of doReScale
+     * @param inLiveMode the value of inLiveMode
      */
     @Override
-    public void preparePanel(boolean doReScale) {
+    public void preparePanel(boolean doReScale, boolean inLiveMode) {
 
         this.removeAll();
 

--- a/src/main/java/org/earthtime/Tripoli/dataViews/simpleViews/usedByReflection/FitFunctionsOnDownHoleRatioDataView.java
+++ b/src/main/java/org/earthtime/Tripoli/dataViews/simpleViews/usedByReflection/FitFunctionsOnDownHoleRatioDataView.java
@@ -255,9 +255,10 @@ public class FitFunctionsOnDownHoleRatioDataView extends AbstractRawDataView imp
     /**
      *
      * @param doReScale the value of doReScale
+     * @param inLiveMode the value of inLiveMode
      */
     @Override
-    public void preparePanel(boolean doReScale) {
+    public void preparePanel(boolean doReScale, boolean inLiveMode) {
 
         this.removeAll();
 

--- a/src/main/java/org/earthtime/Tripoli/dataViews/simpleViews/usedByReflection/FitFunctionsOnRatioDataView.java
+++ b/src/main/java/org/earthtime/Tripoli/dataViews/simpleViews/usedByReflection/FitFunctionsOnRatioDataView.java
@@ -235,9 +235,10 @@ public class FitFunctionsOnRatioDataView extends AbstractRawDataView implements 
     /**
      *
      * @param doReScale the value of doReScale
+     * @param inLiveMode the value of inLiveMode
      */
     @Override
-    public void preparePanel(boolean doReScale) {
+    public void preparePanel(boolean doReScale, boolean inLiveMode) {
 
         this.removeAll();
 

--- a/src/main/java/org/earthtime/Tripoli/dataViews/simpleViews/usedByReflection/RawCountsDataViewForShrimp.java
+++ b/src/main/java/org/earthtime/Tripoli/dataViews/simpleViews/usedByReflection/RawCountsDataViewForShrimp.java
@@ -119,9 +119,10 @@ public class RawCountsDataViewForShrimp extends AbstractRawDataView {
     /**
      *
      * @param doReScale the value of doReScale
+     * @param inLiveMode the value of inLiveMode
      */
     @Override
-    public void preparePanel(boolean doReScale) {
+    public void preparePanel(boolean doReScale, boolean inLiveMode) {
 
         this.removeAll();
 

--- a/src/main/java/org/earthtime/Tripoli/dataViews/simpleViews/usedByReflection/RawIntensitiesDataView.java
+++ b/src/main/java/org/earthtime/Tripoli/dataViews/simpleViews/usedByReflection/RawIntensitiesDataView.java
@@ -138,9 +138,10 @@ public class RawIntensitiesDataView extends AbstractRawDataView {
     /**
      *
      * @param doReScale the value of doReScale
+     * @param inLiveMode the value of inLiveMode
      */
     @Override
-    public void preparePanel(boolean doReScale) {
+    public void preparePanel(boolean doReScale, boolean inLiveMode) {
 
         this.removeAll();
 

--- a/src/main/java/org/earthtime/Tripoli/dataViews/simpleViews/usedByReflection/RawRatioDataView.java
+++ b/src/main/java/org/earthtime/Tripoli/dataViews/simpleViews/usedByReflection/RawRatioDataView.java
@@ -90,9 +90,10 @@ public class RawRatioDataView extends AbstractRawDataView {
     /**
      *
      * @param doReScale the value of doReScale
+     * @param inLiveMode the value of inLiveMode
      */
     @Override
-    public void preparePanel(boolean doReScale) {
+    public void preparePanel(boolean doReScale, boolean inLiveMode) {
 
         this.removeAll();
 

--- a/src/main/java/org/earthtime/Tripoli/dataViews/simpleViews/usedByReflection/RawRatioDataViewForShrimp.java
+++ b/src/main/java/org/earthtime/Tripoli/dataViews/simpleViews/usedByReflection/RawRatioDataViewForShrimp.java
@@ -136,9 +136,10 @@ public class RawRatioDataViewForShrimp extends AbstractRawDataView {
     /**
      *
      * @param doReScale the value of doReScale
+     * @param inLiveMode the value of inLiveMode
      */
     @Override
-    public void preparePanel(boolean doReScale) {
+    public void preparePanel(boolean doReScale, boolean inLiveMode) {
 
         this.removeAll();
 

--- a/src/main/java/org/earthtime/Tripoli/fractions/TripoliFraction.java
+++ b/src/main/java/org/earthtime/Tripoli/fractions/TripoliFraction.java
@@ -302,7 +302,7 @@ public class TripoliFraction implements //
         System.out.println("Update Intercept Fit Functions Including Pbc for " + fractionID);
         while (ratiosIterator.hasNext()) {
             RawRatioDataModel rr = (RawRatioDataModel) ratiosIterator.next();
-            rr.generateSetOfFitFunctions(false, false);
+            rr.generateSetOfFitFunctions(false, false, false);
         }
 
         // nov 2014 this also sets currentlyFitted = true
@@ -1555,7 +1555,7 @@ public class TripoliFraction implements //
                     }
                 }
                 if (rejectedAPoint) {
-                    rr.generateSetOfFitFunctions(true, false);
+                    rr.generateSetOfFitFunctions(true, false, false);
                     // sep 2015 no common lead for standards in downhole ((RawRatioDataModel) rr).generateFitFunctionsForDownhole();
                 }
             } else {

--- a/src/main/java/org/earthtime/Tripoli/fractions/TripoliFraction.java
+++ b/src/main/java/org/earthtime/Tripoli/fractions/TripoliFraction.java
@@ -3,7 +3,7 @@
  *
  * Created Jul 3, 2011
  *
- * Copyright 2006-2015 James F. Bowring and www.Earth-Time.org
+ * Copyright 2006-2016 James F. Bowring and www.Earth-Time.org
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -387,9 +387,10 @@ public class TripoliFraction implements //
     /**
      *
      * @param fractionationTechnique the value of fractionationTechnique
-     * @return
+     * @param inLiveMode the value of inLiveMode
+     * @return the Jama.Matrix
      */
-    public Matrix calculateUncertaintyPbcCorrections(FractionationTechniquesEnum fractionationTechnique) {
+    public Matrix calculateUncertaintyPbcCorrections(FractionationTechniquesEnum fractionationTechnique, boolean inLiveMode) {
         // nov 2014 additional work for pbc corrections section 6 of paper
         // build a super matrix of all 6 Slogratioxy matrices
         // first need to sum dimensions
@@ -398,7 +399,11 @@ public class TripoliFraction implements //
         SortedSet<DataModelInterface> ratiosSortedSet = new TreeSet<>();
 
         if (fractionationTechnique.compareTo(FractionationTechniquesEnum.INTERCEPT) == 0) {
-            ratiosSortedSet = getRatiosForFractionFitting();
+            if (inLiveMode) {
+                ratiosSortedSet = getNonPbRatiosForFractionFitting();
+            } else {
+                ratiosSortedSet = getRatiosForFractionFitting();
+            }
             for (DataModelInterface rr : ratiosSortedSet) {
                 ((RawRatioDataModel) rr).calculateSlogRatioX_Y();
                 totalColumns += ((RawRatioDataModel) rr).getSlogRatioX_Y(false).getColumnDimension();

--- a/src/main/java/org/earthtime/Tripoli/massSpecSetups/AbstractMassSpecSetup.java
+++ b/src/main/java/org/earthtime/Tripoli/massSpecSetups/AbstractMassSpecSetup.java
@@ -287,7 +287,7 @@ public abstract class AbstractMassSpecSetup implements //
 
         propagateUnctInRatios(usingFullPropagation);
 
-        performInterceptFittingToRatios();
+        performInterceptFittingToRatios(false);
 
         cleanupUnctCalcs();
     }
@@ -304,7 +304,7 @@ public abstract class AbstractMassSpecSetup implements //
 
         initializeVirtualCollectorsWithData(intensitiesScan);
 
-        processFractionRawRatiosStageII(usingFullPropagation, tripoliFraction);
+        processFractionRawRatiosStageII(usingFullPropagation, tripoliFraction, false);
     }
     //
 
@@ -322,7 +322,7 @@ public abstract class AbstractMassSpecSetup implements //
 
         initializeVirtualCollectorsWithData(backgroundAcquisitions, peakAcquisitions, virtualCollectorModelMapToFieldIndexes);
 
-        processFractionRawRatiosStageII(usingFullPropagation, tripoliFraction);
+        processFractionRawRatiosStageII(usingFullPropagation, tripoliFraction, false);
     }
 
     /**
@@ -332,13 +332,14 @@ public abstract class AbstractMassSpecSetup implements //
      * @param peakAcquisitions
      * @param usingFullPropagation
      * @param tripoliFraction
+     * @param inLiveMode the value of inLiveMode
      */
     public void processFractionRawRatiosII(//
-            ArrayList<double[]> backgroundAcquisitions, ArrayList<double[]> peakAcquisitions, boolean usingFullPropagation, TripoliFraction tripoliFraction) {
+            ArrayList<double[]> backgroundAcquisitions, ArrayList<double[]> peakAcquisitions, boolean usingFullPropagation, TripoliFraction tripoliFraction, boolean inLiveMode) {
 
         initializeVirtualCollectorsWithData(backgroundAcquisitions, peakAcquisitions, virtualCollectorModelMapToFieldIndexes);
 
-        processFractionRawRatiosStageII(usingFullPropagation, tripoliFraction);
+        processFractionRawRatiosStageII(usingFullPropagation, tripoliFraction, inLiveMode);
     }
 
     /**
@@ -354,16 +355,17 @@ public abstract class AbstractMassSpecSetup implements //
 
         initializeVirtualCollectorsWithDataTRA(backgroundAcquisitions, peakAcquisitions);
 
-        processFractionRawRatiosStageII(usingFullPropagation, tripoliFraction);
+        processFractionRawRatiosStageII(usingFullPropagation, tripoliFraction, false);
     }
 
     /**
      *
      * @param usingFullPropagation the value of usingFullPropagation
      * @param tripoliFraction the value of tripoliFraction
+     * @param inLiveMode the value of inLiveMode
      */
     public void processFractionRawRatiosStageII(//
-            boolean usingFullPropagation, TripoliFraction tripoliFraction) {
+            boolean usingFullPropagation, TripoliFraction tripoliFraction, boolean inLiveMode) {
         // make fresh set of rawratios with map of collector instances
         boolean isStandard = tripoliFraction.isStandard();
 
@@ -560,7 +562,7 @@ public abstract class AbstractMassSpecSetup implements //
 
         propagateUnctInRatios(usingFullPropagation);//usingFullPropagation);// needed for first pass
 
-        performInterceptFittingToRatios();
+        performInterceptFittingToRatios(inLiveMode);
 
         if (writeReport) {
             outputWriter.println("\n\n11: Sxyod, Slr_X_Y for the three log-ratios   ********************");
@@ -637,10 +639,14 @@ public abstract class AbstractMassSpecSetup implements //
         });
     }
 
-    private void performInterceptFittingToRatios() {
+    /**
+     *
+     * @param inLiveMode the value of inLiveMode
+     */
+    private void performInterceptFittingToRatios(boolean inLiveMode) {
         // generate fit function so can be done with big matrices
         for (DataModelInterface rr : rawRatios) {
-            rr.generateSetOfFitFunctions(false, false);//true);
+            rr.generateSetOfFitFunctions(false, false, inLiveMode);//true);
         }
     }
 
@@ -958,7 +964,7 @@ public abstract class AbstractMassSpecSetup implements //
                 ((RawIntensityDataModel) im).setCorrectedHg202Si(null);
             }
 
-            im.generateSetOfFitFunctions(true, true);
+            im.generateSetOfFitFunctions(true, true, false);
         }
     }
 

--- a/src/main/java/org/earthtime/Tripoli/massSpecSetups/singleCollector/shrimp/ShrimpSetupUPb.java
+++ b/src/main/java/org/earthtime/Tripoli/massSpecSetups/singleCollector/shrimp/ShrimpSetupUPb.java
@@ -306,11 +306,12 @@ public final class ShrimpSetupUPb extends AbstractMassSpecSetup {
 
     @Override
     public void processFractionRawRatiosStageII(//
-            boolean usingFullPropagation, TripoliFraction tripoliFraction) {
+            boolean usingFullPropagation, TripoliFraction tripoliFraction, boolean inLiveMode) {
 
         // SHRIMP software does the math for now
     }
-
+    //
+    
     public void populateRawAndLogRatios(Map<RawRatioNamesSHRIMP, IsotopeRatioModelSHRIMP> isotopeRatioModels) {
         // calculate ratios ****************************************************
         for (DataModelInterface rr : rawRatios) {

--- a/src/main/java/org/earthtime/Tripoli/rawDataFiles/handlers/AbstractRawDataFileHandler.java
+++ b/src/main/java/org/earthtime/Tripoli/rawDataFiles/handlers/AbstractRawDataFileHandler.java
@@ -170,8 +170,9 @@ public abstract class AbstractRawDataFileHandler implements //
      * @param usingFullPropagation the value of usindexngFullPropagatindexon
      * @param leftShadeCount the value of leftShadeCount
      * @param ignoreFirstFractions the value of indexgnoreFindexrstFractindexons
+     * @param inLiveMode the value of inLiveMode
      */
-    public abstract void getAndLoadRawIntensityDataFile(SwingWorker loadDataTask, boolean usingFullPropagation, int leftShadeCount, int ignoreFirstFractions);
+    public abstract void getAndLoadRawIntensityDataFile(SwingWorker loadDataTask, boolean usingFullPropagation, int leftShadeCount, int ignoreFirstFractions, boolean inLiveMode);
 
     /**
      *
@@ -253,9 +254,10 @@ public abstract class AbstractRawDataFileHandler implements //
      * @param usingFullPropagation the value of usindexngFullPropagatindexon
      * @param leftShadeCount the value of leftShadeCount
      * @param ignoreFirstFractions the value of indexgnoreFindexrstFractindexons
-     * @return
+     * @param inLiveMode the value of inLiveMode
+     * @return the java.util.SortedSet<org.earthtime.Tripoli.fractions.TripoliFraction>
      */
-    protected abstract SortedSet<TripoliFraction> loadRawDataFile(SwingWorker loadDataTask, boolean usingFullPropagation, int leftShadeCount, int ignoreFirstFractions);
+    protected abstract SortedSet<TripoliFraction> loadRawDataFile(SwingWorker loadDataTask, boolean usingFullPropagation, int leftShadeCount, int ignoreFirstFractions, boolean inLiveMode);
 
     /**
      * @return the rawDataFindexleTemplate

--- a/src/main/java/org/earthtime/Tripoli/rawDataFiles/handlers/Agilent/KoslerAgilent7700FileHandler.java
+++ b/src/main/java/org/earthtime/Tripoli/rawDataFiles/handlers/Agilent/KoslerAgilent7700FileHandler.java
@@ -92,22 +92,23 @@ public class KoslerAgilent7700FileHandler extends AbstractRawDataFileHandler imp
      * @param usingFullPropagation the value of usingFullPropagation
      * @param leftShadeCount the value of leftShadeCount
      * @param ignoreFirstFractions the value of ignoreFirstFract
+     * @param inLiveMode the value of inLiveMode
      */
     @Override
-    public void getAndLoadRawIntensityDataFile(SwingWorker loadDataTask, boolean usingFullPropagation, int leftShadeCount, int ignoreFirstFractions) {
+    public void getAndLoadRawIntensityDataFile(SwingWorker loadDataTask, boolean usingFullPropagation, int leftShadeCount, int ignoreFirstFractions, boolean inLiveMode) {
 
         // Agilent has folder of csv files plus some xls files
         analysisFiles = rawDataFile.listFiles((File dir, String name) -> (name.toLowerCase().endsWith(".csv")));
 
         if (analysisFiles.length > 0) {
             Arrays.sort(analysisFiles, new FractionFileModifiedComparator());
-            
+
             String onPeakFileContents = URIHelper.getTextFromURI(analysisFiles[0].getAbsolutePath());
             if (isValidRawDataFileType(analysisFiles[0]) //
                     && //
                     areKeyWordsPresent(onPeakFileContents)) {
                 // create fractions from raw data and perform corrections and calculate ratios
-                tripoliFractions = loadRawDataFile(loadDataTask, usingFullPropagation, leftShadeCount, 0);
+                tripoliFractions = loadRawDataFile(loadDataTask, usingFullPropagation, leftShadeCount, 0, inLiveMode);
             }
         } else {
             JOptionPane.showMessageDialog(
@@ -157,11 +158,13 @@ public class KoslerAgilent7700FileHandler extends AbstractRawDataFileHandler imp
      * @param usingFullPropagation the value of usingFullPropagation
      * @param leftShadeCount the value of leftShadeCount
      * @param ignoreFirstFractions the value of ignoreFirstFractions
-     * @return
+     * @param inLiveMode the value of inLiveMode
+     * @return the
+     * java.util.SortedSet<org.earthtime.Tripoli.fractions.TripoliFraction>
      */
     @Override
     protected SortedSet<TripoliFraction> loadRawDataFile(//
-            SwingWorker loadDataTask, boolean usingFullPropagation, int leftShadeCount, int ignoreFirstFractions) {
+            SwingWorker loadDataTask, boolean usingFullPropagation, int leftShadeCount, int ignoreFirstFractions, boolean inLiveMode) {
 
         SortedSet myTripoliFractions = new TreeSet<>();
 
@@ -245,8 +248,7 @@ public class KoslerAgilent7700FileHandler extends AbstractRawDataFileHandler imp
                 }  // i loop
 
                 TripoliFraction tripoliFraction
-                        = //                           
-                        new TripoliFraction( //
+                        = new TripoliFraction( //
                                 fractionID, //
                                 massSpec.getCommonLeadCorrectionHighestLevel(), //
                                 isStandard,

--- a/src/main/java/org/earthtime/Tripoli/rawDataFiles/handlers/Agilent/RittnerAgilent7700FileHandler.java
+++ b/src/main/java/org/earthtime/Tripoli/rawDataFiles/handlers/Agilent/RittnerAgilent7700FileHandler.java
@@ -94,9 +94,10 @@ public class RittnerAgilent7700FileHandler extends AbstractRawDataFileHandler im
      * @param usingFullPropagation the value of usingFullPropagation
      * @param leftShadeCount the value of leftShadeCount
      * @param ignoreFirstFractions the value of ignoreFirstFract
+     * @param inLiveMode the value of inLiveMode
      */
     @Override
-    public void getAndLoadRawIntensityDataFile(SwingWorker loadDataTask, boolean usingFullPropagation, int leftShadeCount, int ignoreFirstFractions) {
+    public void getAndLoadRawIntensityDataFile(SwingWorker loadDataTask, boolean usingFullPropagation, int leftShadeCount, int ignoreFirstFractions, boolean inLiveMode) {
 
         // Agilent has folder of folders plus one samplelist file
         File[] sampleListFile = rawDataFile.listFiles(new FilenameFilter() {
@@ -115,13 +116,13 @@ public class RittnerAgilent7700FileHandler extends AbstractRawDataFileHandler im
 
         if ((sampleListFile.length > 0) && (analysisFiles.length > 0)) {
             Arrays.sort(analysisFiles, new FractionFileModifiedComparator());
-            
+
             String onPeakFileContents = URIHelper.getTextFromURI(sampleListFile[0].getAbsolutePath());
             if (isValidRawDataFileType(sampleListFile[0]) //
                     && //
                     areKeyWordsPresent(onPeakFileContents)) {
                 // create fractions from raw data and perform corrections and calculate ratios
-                loadRawDataFile(loadDataTask, usingFullPropagation, leftShadeCount, 0);
+                loadRawDataFile(loadDataTask, usingFullPropagation, leftShadeCount, 0, inLiveMode);
             }
         } else {
             JOptionPane.showMessageDialog(
@@ -172,10 +173,12 @@ public class RittnerAgilent7700FileHandler extends AbstractRawDataFileHandler im
      * @param usingFullPropagation the value of usingFullPropagation
      * @param leftShadeCount the value of leftShadeCount
      * @param ignoreFirstFractions the value of ignoreFirstFractions
-     * @return
+     * @param inLiveMode the value of inLiveMode
+     * @return the
+     * java.util.SortedSet<org.earthtime.Tripoli.fractions.TripoliFraction>
      */
     @Override
-    protected SortedSet<TripoliFraction> loadRawDataFile(SwingWorker loadDataTask, boolean usingFullPropagation, int leftShadeCount, int ignoreFirstFractions) {
+    protected SortedSet<TripoliFraction> loadRawDataFile(SwingWorker loadDataTask, boolean usingFullPropagation, int leftShadeCount, int ignoreFirstFractions, boolean inLiveMode) {
         tripoliFractions = new TreeSet<>();
 
         // assume we are golden        
@@ -264,11 +267,7 @@ public class RittnerAgilent7700FileHandler extends AbstractRawDataFileHandler im
                     boolean isStandard = isStandardFractionID(fractionID);
 
                     TripoliFraction tripoliFraction
-                            = //                           
-                            new TripoliFraction( //                     
-                                    //                     
-                                    //                     
-                                    //                     
+                            = new TripoliFraction( //                                        
                                     fractionID, //
                                     massSpec.getCommonLeadCorrectionHighestLevel(), //
                                     isStandard,
@@ -289,11 +288,6 @@ public class RittnerAgilent7700FileHandler extends AbstractRawDataFileHandler im
                 }
             }
         }
-
-//        if (tripoliFractions.isEmpty()) {
-//            tripoliFractions = null;
-//        }
-
         return tripoliFractions;
     }
 

--- a/src/main/java/org/earthtime/Tripoli/rawDataFiles/handlers/NuPlasma/LaserChronNUPlasmaMultiCollFaradayFileHandler.java
+++ b/src/main/java/org/earthtime/Tripoli/rawDataFiles/handlers/NuPlasma/LaserChronNUPlasmaMultiCollFaradayFileHandler.java
@@ -26,7 +26,6 @@ import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.Collections;
-import java.util.Comparator;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
@@ -109,13 +108,7 @@ public class LaserChronNUPlasmaMultiCollFaradayFileHandler extends AbstractRawDa
         }
 
         if (validFilesForConcatenation.size() > 1) {
-            Collections.sort(validFilesForConcatenation, new Comparator<File>() {
-
-                @Override
-                public int compare(File f1, File f2) {
-                    return Long.compare(f1.lastModified(), f2.lastModified());
-                }
-            });
+            Collections.sort(validFilesForConcatenation, (File f1, File f2) -> Long.compare(f1.lastModified(), f2.lastModified()));
 
             String concatenatedFileName = "CONCAT_" + validFilesForConcatenation.get(0).getName().replace("." + rawDataFileTemplate.getFileType().getName(), "");
 
@@ -195,13 +188,14 @@ public class LaserChronNUPlasmaMultiCollFaradayFileHandler extends AbstractRawDa
      * @param usingFullPropagation the value of usingFullPropagation
      * @param leftShadeCount the value of leftShadeCount
      * @param ignoreFirstFractions the value of ignoreFirstFractions
+     * @param inLiveMode the value of inLiveMode
      */
     @Override
-    public void getAndLoadRawIntensityDataFile(SwingWorker loadDataTask, boolean usingFullPropagation, int leftShadeCount, int ignoreFirstFractions) {
+    public void getAndLoadRawIntensityDataFile(SwingWorker loadDataTask, boolean usingFullPropagation, int leftShadeCount, int ignoreFirstFractions, boolean inLiveMode) {
 
         if (rawDataFile != null) {
             // create fractions from raw data and perform corrections and calculate ratios
-            loadRawDataFile(loadDataTask, usingFullPropagation, leftShadeCount, ignoreFirstFractions);
+            loadRawDataFile(loadDataTask, usingFullPropagation, leftShadeCount, ignoreFirstFractions, inLiveMode);
         }
 
 //        return rawDataFile;
@@ -242,7 +236,8 @@ public class LaserChronNUPlasmaMultiCollFaradayFileHandler extends AbstractRawDa
 
     /**
      *
-     * @param acquisitionModel
+     * @param acquisition
+     * @return Model
      */
     protected boolean loadDataSetupParametersFromRawDataFileHeader(AbstractAcquisitionModel acquisitionModel) {
         boolean retVal = true;
@@ -331,10 +326,11 @@ public class LaserChronNUPlasmaMultiCollFaradayFileHandler extends AbstractRawDa
      * @param usingFullPropagation the value of usingFullPropagation
      * @param leftShadeCount the value of leftShadeCount
      * @param ignoreFirstFractions the value of ignoreFirstFractions
-     * @return
+     * @param inLiveMode the value of inLiveMode
+     * @return the java.util.SortedSet<org.earthtime.Tripoli.fractions.TripoliFraction>
      */
     @Override
-    protected SortedSet<TripoliFraction> loadRawDataFile(SwingWorker loadDataTask, boolean usingFullPropagation, int leftShadeCount, int ignoreFirstFractions) {
+    protected SortedSet<TripoliFraction> loadRawDataFile(SwingWorker loadDataTask, boolean usingFullPropagation, int leftShadeCount, int ignoreFirstFractions, boolean inLiveMode) {
 
         Calendar calendar = Calendar.getInstance();
         calendar.clear();

--- a/src/main/java/org/earthtime/Tripoli/rawDataFiles/handlers/NuPlasma/LaserChronNUPlasmaMultiCollFaradayTRAFileHandler.java
+++ b/src/main/java/org/earthtime/Tripoli/rawDataFiles/handlers/NuPlasma/LaserChronNUPlasmaMultiCollFaradayTRAFileHandler.java
@@ -196,13 +196,14 @@ public class LaserChronNUPlasmaMultiCollFaradayTRAFileHandler extends AbstractRa
      * @param usingFullPropagation the value of usingFullPropagation
      * @param leftShadeCount the value of leftShadeCount
      * @param ignoreFirstFractions the value of ignoreFirstFractions
+     * @param inLiveMode the value of inLiveMode
      */
     @Override
-    public void getAndLoadRawIntensityDataFile(SwingWorker loadDataTask, boolean usingFullPropagation, int leftShadeCount, int ignoreFirstFractions) {
+    public void getAndLoadRawIntensityDataFile(SwingWorker loadDataTask, boolean usingFullPropagation, int leftShadeCount, int ignoreFirstFractions, boolean inLiveMode) {
 
         if (rawDataFile != null) {
             // create fractions from raw data and perform corrections and calculate ratios
-            loadRawDataFile(loadDataTask, usingFullPropagation, leftShadeCount, ignoreFirstFractions);
+            loadRawDataFile(loadDataTask, usingFullPropagation, leftShadeCount, ignoreFirstFractions, inLiveMode);
         }
 
 //        return rawDataFile;
@@ -340,10 +341,11 @@ public class LaserChronNUPlasmaMultiCollFaradayTRAFileHandler extends AbstractRa
      * @param usingFullPropagation the value of usingFullPropagation
      * @param leftShadeCount the value of leftShadeCount
      * @param ignoreFirstFractions the value of ignoreFirstFractions
-     * @return
+     * @param inLiveMode the value of inLiveMode
+     * @return the java.util.SortedSet<org.earthtime.Tripoli.fractions.TripoliFraction>
      */
     @Override
-    protected SortedSet<TripoliFraction> loadRawDataFile(SwingWorker loadDataTask, boolean usingFullPropagation, int leftShadeCount, int ignoreFirstFractions) {
+    protected SortedSet<TripoliFraction> loadRawDataFile(SwingWorker loadDataTask, boolean usingFullPropagation, int leftShadeCount, int ignoreFirstFractions, boolean inLiveMode) {
 
         Calendar calendar = Calendar.getInstance();
         calendar.clear();

--- a/src/main/java/org/earthtime/Tripoli/rawDataFiles/handlers/NuPlasma/LaserChronNUPlasmaMultiCollIonCounterFileHandler.java
+++ b/src/main/java/org/earthtime/Tripoli/rawDataFiles/handlers/NuPlasma/LaserChronNUPlasmaMultiCollIonCounterFileHandler.java
@@ -121,13 +121,14 @@ public class LaserChronNUPlasmaMultiCollIonCounterFileHandler extends AbstractRa
      * @param usingFullPropagation the value of usingFullPropagation
      * @param leftShadeCount the value of leftShadeCount
      * @param ignoreFirstFractions the value of ignoreFirstFractions
+     * @param inLiveMode the value of inLiveMode
      */
     @Override
-    public void getAndLoadRawIntensityDataFile(SwingWorker loadDataTask, boolean usingFullPropagation, int leftShadeCount, int ignoreFirstFractions) {
+    public void getAndLoadRawIntensityDataFile(SwingWorker loadDataTask, boolean usingFullPropagation, int leftShadeCount, int ignoreFirstFractions, boolean inLiveMode) {
 
         if (rawDataFile != null) {
             // create fractions from raw data and perform corrections and calculate ratios
-            loadRawDataFile(loadDataTask, usingFullPropagation, leftShadeCount, ignoreFirstFractions);
+            loadRawDataFile(loadDataTask, usingFullPropagation, leftShadeCount, ignoreFirstFractions, inLiveMode);
         }
 
 //        return rawDataFile;
@@ -257,10 +258,11 @@ public class LaserChronNUPlasmaMultiCollIonCounterFileHandler extends AbstractRa
      * @param usingFullPropagation the value of usingFullPropagation
      * @param leftShadeCount the value of leftShadeCount
      * @param ignoreFirstFractions the value of ignoreFirstFractions
-     * @return
+     * @param inLiveMode the value of inLiveMode
+     * @return the java.util.SortedSet<org.earthtime.Tripoli.fractions.TripoliFraction>
      */
     @Override
-    protected SortedSet<TripoliFraction> loadRawDataFile(SwingWorker loadDataTask, boolean usingFullPropagation, int leftShadeCount, int ignoreFirstFractions) {
+    protected SortedSet<TripoliFraction> loadRawDataFile(SwingWorker loadDataTask, boolean usingFullPropagation, int leftShadeCount, int ignoreFirstFractions, boolean inLiveMode) {
 
         Calendar calendar = Calendar.getInstance();
         calendar.clear();

--- a/src/main/java/org/earthtime/Tripoli/rawDataFiles/handlers/Thermo/LaserchronElementIIFileHandler.java
+++ b/src/main/java/org/earthtime/Tripoli/rawDataFiles/handlers/Thermo/LaserchronElementIIFileHandler.java
@@ -299,6 +299,10 @@ public class LaserchronElementIIFileHandler extends AbstractRawDataFileHandler {
                 System.out.println("\n**** Element II FractionID  " + fractionID + " refMat? " + isReferenceMaterial + "  livemode = " + inLiveMode + " <<<<<<<<<<<<<<<<<<\n");
 
                 myTripoliFractions.add(tripoliFraction);
+                
+                if (isReferenceMaterial){
+                    loadDataTask.firePropertyChange("refMaterialLoaded", 0, 1);
+                }
 
             } catch (PyException pyException) {
                 System.out.println("bad read of fraction " + analysisFiles[f].getName() + " message = " + pyException.getMessage());

--- a/src/main/java/org/earthtime/Tripoli/rawDataFiles/handlers/Thermo/LaserchronElementIIFileHandler.java
+++ b/src/main/java/org/earthtime/Tripoli/rawDataFiles/handlers/Thermo/LaserchronElementIIFileHandler.java
@@ -102,9 +102,10 @@ public class LaserchronElementIIFileHandler extends AbstractRawDataFileHandler {
      * @param usingFullPropagation the value of usingFullPropagation
      * @param leftShadeCount the value of leftShadeCount
      * @param ignoreFirstFractions the value of ignoreFirstFracts
+     * @param inLiveMode the value of inLiveMode
      */
     @Override
-    public void getAndLoadRawIntensityDataFile(SwingWorker loadDataTask, boolean usingFullPropagation, int leftShadeCount, int ignoreFirstFractions) {
+    public void getAndLoadRawIntensityDataFile(SwingWorker loadDataTask, boolean usingFullPropagation, int leftShadeCount, int ignoreFirstFractions, boolean inLiveMode) {
 
         if (referenceMaterialIncrementerMap == null) {
             referenceMaterialIncrementerMap = new ConcurrentHashMap<>();
@@ -152,7 +153,7 @@ public class LaserchronElementIIFileHandler extends AbstractRawDataFileHandler {
                 }
 
                 // create fractions from raw data and perform corrections and calculate ratios
-                tripoliFractions = loadRawDataFile(loadDataTask, usingFullPropagation, leftShadeCount, ignoreFirstFractions);
+                tripoliFractions = loadRawDataFile(loadDataTask, usingFullPropagation, leftShadeCount, ignoreFirstFractions, inLiveMode);
             }
         } else {
             JOptionPane.showMessageDialog(
@@ -202,11 +203,12 @@ public class LaserchronElementIIFileHandler extends AbstractRawDataFileHandler {
      * @param usingFullPropagation the value of usingFullPropagation
      * @param leftShadeCount the value of leftShadeCount
      * @param ignoreFirstFractions the value of ignoreFirstFractions
-     * @return
+     * @param inLiveMode the value of inLiveMode
+     * @return the java.util.SortedSet<org.earthtime.Tripoli.fractions.TripoliFraction>
      */
     @Override
     protected SortedSet<TripoliFraction> loadRawDataFile(//
-            SwingWorker loadDataTask, boolean usingFullPropagation, int leftShadeCount, int ignoreFirstFractions) {
+            SwingWorker loadDataTask, boolean usingFullPropagation, int leftShadeCount, int ignoreFirstFractions, boolean inLiveMode) {
 
         SortedSet myTripoliFractions = new TreeSet<>();
 
@@ -291,10 +293,10 @@ public class LaserchronElementIIFileHandler extends AbstractRawDataFileHandler {
                 massSpec.setCountOfAcquisitions(peakAcquisitions.size());
 
                 massSpec.processFractionRawRatiosII(//
-                        backgroundAcquisitions, peakAcquisitions, usingFullPropagation, tripoliFraction);
+                        backgroundAcquisitions, peakAcquisitions, usingFullPropagation, tripoliFraction, inLiveMode);
 
                 tripoliFraction.shadeDataActiveMapLeft(leftShadeCount);
-                System.out.println("\n**** Element II FractionID  " + fractionID + " refMat? " + isReferenceMaterial + " <<<<<<<<<<<<<<<<<<\n");
+                System.out.println("\n**** Element II FractionID  " + fractionID + " refMat? " + isReferenceMaterial + "  livemode = " + inLiveMode + " <<<<<<<<<<<<<<<<<<\n");
 
                 myTripoliFractions.add(tripoliFraction);
 

--- a/src/main/java/org/earthtime/Tripoli/rawDataFiles/handlers/Thermo/MemUnivNewfoundlandElementIIFileHandler.java
+++ b/src/main/java/org/earthtime/Tripoli/rawDataFiles/handlers/Thermo/MemUnivNewfoundlandElementIIFileHandler.java
@@ -86,9 +86,10 @@ public class MemUnivNewfoundlandElementIIFileHandler extends AbstractRawDataFile
      * @param usingFullPropagation the value of usingFullPropagation
      * @param leftShadeCount the value of leftShadeCount
      * @param ignoreFirstFractions the value of ignoreFirstFract
+     * @param inLiveMode the value of inLiveMode
      */
     @Override
-    public void getAndLoadRawIntensityDataFile(SwingWorker loadDataTask, boolean usingFullPropagation, int leftShadeCount, int ignoreFirstFractions) {
+    public void getAndLoadRawIntensityDataFile(SwingWorker loadDataTask, boolean usingFullPropagation, int leftShadeCount, int ignoreFirstFractions, boolean inLiveMode) {
 
         // ElementII has folder of .FIN2 files plus INF DAT and TXT files for each acquisition
         // also there is a FIN file containing naming and ordering of samples
@@ -105,7 +106,7 @@ public class MemUnivNewfoundlandElementIIFileHandler extends AbstractRawDataFile
                     && //
                     areKeyWordsPresent(onPeakFileContents)) {
                 // create fractions from raw data and perform corrections and calculate ratios
-                tripoliFractions = loadRawDataFile(loadDataTask, usingFullPropagation, leftShadeCount, 0);
+                tripoliFractions = loadRawDataFile(loadDataTask, usingFullPropagation, leftShadeCount, 0, inLiveMode);
             }
         } else {
             JOptionPane.showMessageDialog(
@@ -155,11 +156,12 @@ public class MemUnivNewfoundlandElementIIFileHandler extends AbstractRawDataFile
      * @param usingFullPropagation the value of usingFullPropagation
      * @param leftShadeCount the value of leftShadeCount
      * @param ignoreFirstFractions the value of ignoreFirstFractions
-     * @return
+     * @param inLiveMode the value of inLiveMode
+     * @return the java.util.SortedSet<org.earthtime.Tripoli.fractions.TripoliFraction>
      */
     @Override
     protected SortedSet<TripoliFraction> loadRawDataFile(//
-            SwingWorker loadDataTask, boolean usingFullPropagation, int leftShadeCount, int ignoreFirstFractions) {
+            SwingWorker loadDataTask, boolean usingFullPropagation, int leftShadeCount, int ignoreFirstFractions, boolean inLiveMode) {
 
         SortedSet myTripoliFractions = new TreeSet<>();
 

--- a/src/main/java/org/earthtime/Tripoli/rawDataFiles/handlers/Thermo/TexasAMElementIISingleCollFileHandler.java
+++ b/src/main/java/org/earthtime/Tripoli/rawDataFiles/handlers/Thermo/TexasAMElementIISingleCollFileHandler.java
@@ -87,9 +87,10 @@ public class TexasAMElementIISingleCollFileHandler extends AbstractRawDataFileHa
      * @param usingFullPropagation the value of usingFullPropagation
      * @param leftShadeCount the value of leftShadeCount
      * @param ignoreFirstFractions the value of ignoreFirstFractions
+     * @param inLiveMode the value of inLiveMode
      */
     @Override
-    public void getAndLoadRawIntensityDataFile(SwingWorker loadDataTask, boolean usingFullPropagation, int leftShadeCount, int ignoreFirstFractions) {
+    public void getAndLoadRawIntensityDataFile(SwingWorker loadDataTask, boolean usingFullPropagation, int leftShadeCount, int ignoreFirstFractions, boolean inLiveMode) {
 
         // ElementII has folder of .dat files some of which end with _b_b.dat unfortunately        
         analysisFiles = rawDataFile.listFiles((File f)
@@ -104,7 +105,7 @@ public class TexasAMElementIISingleCollFileHandler extends AbstractRawDataFileHa
                     && //
                     areKeyWordsPresent(onPeakFileContents)) {
                 // create fractions from raw data and perform corrections and calculate ratios
-                tripoliFractions = loadRawDataFile(loadDataTask, usingFullPropagation, leftShadeCount, 0);
+                tripoliFractions = loadRawDataFile(loadDataTask, usingFullPropagation, leftShadeCount, 0, inLiveMode);
             }
         } else {
             JOptionPane.showMessageDialog(
@@ -152,10 +153,11 @@ public class TexasAMElementIISingleCollFileHandler extends AbstractRawDataFileHa
      * @param usingFullPropagation the value of usingFullPropagation
      * @param leftShadeCount the value of leftShadeCount
      * @param ignoreFirstFractions the value of ignoreFirstFractions
-     * @return
+     * @param inLiveMode the value of inLiveMode
+     * @return the java.util.SortedSet<org.earthtime.Tripoli.fractions.TripoliFraction>
      */
     @Override
-    protected SortedSet<TripoliFraction> loadRawDataFile(SwingWorker loadDataTask, boolean usingFullPropagation, int leftShadeCount, int ignoreFirstFractions) {
+    protected SortedSet<TripoliFraction> loadRawDataFile(SwingWorker loadDataTask, boolean usingFullPropagation, int leftShadeCount, int ignoreFirstFractions, boolean inLiveMode) {
         tripoliFractions = new TreeSet<>();
 
         SortedSet myTripoliFractions = new TreeSet<>();

--- a/src/main/java/org/earthtime/Tripoli/rawDataFiles/handlers/Thermo/UnivKansasElementIIFileHandler.java
+++ b/src/main/java/org/earthtime/Tripoli/rawDataFiles/handlers/Thermo/UnivKansasElementIIFileHandler.java
@@ -92,9 +92,10 @@ public class UnivKansasElementIIFileHandler extends AbstractRawDataFileHandler {
      * @param usingFullPropagation the value of usingFullPropagation
      * @param leftShadeCount the value of leftShadeCount
      * @param ignoreFirstFractions the value of ignoreFirstFract
+     * @param inLiveMode the value of inLiveMode
      */
     @Override
-    public void getAndLoadRawIntensityDataFile(SwingWorker loadDataTask, boolean usingFullPropagation, int leftShadeCount, int ignoreFirstFractions) {
+    public void getAndLoadRawIntensityDataFile(SwingWorker loadDataTask, boolean usingFullPropagation, int leftShadeCount, int ignoreFirstFractions, boolean inLiveMode) {
 
         // ElementII has folder of .FIN2 files plus INF DAT and TXT files for each acquisition
         // also there is a FIN file containing naming and ordering of samples
@@ -135,7 +136,7 @@ public class UnivKansasElementIIFileHandler extends AbstractRawDataFileHandler {
                 }
 
                 // create fractions from raw data and perform corrections and calculate ratios
-                tripoliFractions = loadRawDataFile(loadDataTask, usingFullPropagation, leftShadeCount, 0);
+                tripoliFractions = loadRawDataFile(loadDataTask, usingFullPropagation, leftShadeCount, 0, inLiveMode);
             }
         } else {
             JOptionPane.showMessageDialog(
@@ -185,11 +186,12 @@ public class UnivKansasElementIIFileHandler extends AbstractRawDataFileHandler {
      * @param usingFullPropagation the value of usingFullPropagation
      * @param leftShadeCount the value of leftShadeCount
      * @param ignoreFirstFractions the value of ignoreFirstFractions
-     * @return
+     * @param inLiveMode the value of inLiveMode
+     * @return the java.util.SortedSet<org.earthtime.Tripoli.fractions.TripoliFraction>
      */
     @Override
     protected SortedSet<TripoliFraction> loadRawDataFile(//
-            SwingWorker loadDataTask, boolean usingFullPropagation, int leftShadeCount, int ignoreFirstFractions) {
+            SwingWorker loadDataTask, boolean usingFullPropagation, int leftShadeCount, int ignoreFirstFractions, boolean inLiveMode) {
 
         SortedSet myTripoliFractions = new TreeSet<>();
  

--- a/src/main/java/org/earthtime/Tripoli/rawDataFiles/handlers/Thermo/WashStateElementIISingleCollFileHandler.java
+++ b/src/main/java/org/earthtime/Tripoli/rawDataFiles/handlers/Thermo/WashStateElementIISingleCollFileHandler.java
@@ -91,9 +91,10 @@ public class WashStateElementIISingleCollFileHandler extends AbstractRawDataFile
      * @param usingFullPropagation the value of usingFullPropagation
      * @param leftShadeCount the value of leftShadeCount
      * @param ignoreFirstFractions the value of ignoreFirstFractions
+     * @param inLiveMode the value of inLiveMode
      */
     @Override
-    public void getAndLoadRawIntensityDataFile(SwingWorker loadDataTask, boolean usingFullPropagation, int leftShadeCount, int ignoreFirstFractions) {
+    public void getAndLoadRawIntensityDataFile(SwingWorker loadDataTask, boolean usingFullPropagation, int leftShadeCount, int ignoreFirstFractions, boolean inLiveMode) {
 
         // get .txt files from the folder and check the first one        
         analysisFiles = rawDataFile.listFiles((File f)
@@ -133,7 +134,7 @@ public class WashStateElementIISingleCollFileHandler extends AbstractRawDataFile
                     }
                 }
                 // create fractions from raw data and perform corrections and calculate ratios
-                loadRawDataFile(loadDataTask, usingFullPropagation, leftShadeCount, 0);
+                loadRawDataFile(loadDataTask, usingFullPropagation, leftShadeCount, 0, inLiveMode);
             }
         } else {
             JOptionPane.showMessageDialog(
@@ -181,10 +182,11 @@ public class WashStateElementIISingleCollFileHandler extends AbstractRawDataFile
      * @param usingFullPropagation the value of usingFullPropagation
      * @param leftShadeCount the value of leftShadeCount
      * @param ignoreFirstFractions the value of ignoreFirstFractions
-     * @return
+     * @param inLiveMode the value of inLiveMode
+     * @return the java.util.SortedSet<org.earthtime.Tripoli.fractions.TripoliFraction>
      */
     @Override
-    protected SortedSet<TripoliFraction> loadRawDataFile(SwingWorker loadDataTask, boolean usingFullPropagation, int leftShadeCount, int ignoreFirstFractions) {
+    protected SortedSet<TripoliFraction> loadRawDataFile(SwingWorker loadDataTask, boolean usingFullPropagation, int leftShadeCount, int ignoreFirstFractions, boolean inLiveMode) {
         tripoliFractions = new TreeSet<>();
 
         // assume we are golden        

--- a/src/main/java/org/earthtime/Tripoli/rawDataFiles/handlers/shrimp/ShrimpFileHandler.java
+++ b/src/main/java/org/earthtime/Tripoli/rawDataFiles/handlers/shrimp/ShrimpFileHandler.java
@@ -89,9 +89,10 @@ public class ShrimpFileHandler extends AbstractRawDataFileHandler {
      * @param usingFullPropagation the value of usingFullPropagation
      * @param leftShadeCount the value of leftShadeCount
      * @param ignoreFirstFractions the value of ignoreFirstFracts
+     * @param inLiveMode the value of inLiveMode
      */
     @Override
-    public void getAndLoadRawIntensityDataFile(SwingWorker loadDataTask, boolean usingFullPropagation, int leftShadeCount, int ignoreFirstFractions) {
+    public void getAndLoadRawIntensityDataFile(SwingWorker loadDataTask, boolean usingFullPropagation, int leftShadeCount, int ignoreFirstFractions, boolean inLiveMode) {
 
         // temp       
         rawDataFile = new File("/Users/sbowring/Documents/Development_XSD/100142_G6147_10111109.43 10.33.37 AM.xml");
@@ -99,7 +100,7 @@ public class ShrimpFileHandler extends AbstractRawDataFileHandler {
         if (rawDataFile != null) {
 
             // create fractions from raw data and perform corrections and calculate ratios
-            tripoliFractions = loadRawDataFile(loadDataTask, usingFullPropagation, leftShadeCount, ignoreFirstFractions);
+            tripoliFractions = loadRawDataFile(loadDataTask, usingFullPropagation, leftShadeCount, ignoreFirstFractions, inLiveMode);
         } else {
             JOptionPane.showMessageDialog(
                     null,
@@ -147,11 +148,12 @@ public class ShrimpFileHandler extends AbstractRawDataFileHandler {
      * @param usingFullPropagation the value of usingFullPropagation
      * @param leftShadeCount the value of leftShadeCount
      * @param ignoreFirstFractions the value of ignoreFirstFractions
-     * @return
+     * @param inLiveMode the value of inLiveMode
+     * @return the java.util.SortedSet<org.earthtime.Tripoli.fractions.TripoliFraction>
      */
     @Override
     protected SortedSet<TripoliFraction> loadRawDataFile(//
-            SwingWorker loadDataTask, boolean usingFullPropagation, int leftShadeCount, int ignoreFirstFractions) {
+            SwingWorker loadDataTask, boolean usingFullPropagation, int leftShadeCount, int ignoreFirstFractions, boolean inLiveMode) {
 
         SortedSet myTripoliFractions = new TreeSet<>();
         PrawnFile prawnFile;
@@ -286,7 +288,7 @@ public class ShrimpFileHandler extends AbstractRawDataFileHandler {
         ((ShrimpSetupUPb) massSpec).populateRawAndLogRatios(shrimpFraction.getIsotopicRatios());
 
         massSpec.processFractionRawRatiosII(//
-                backgroundAcquisitions, peakAcquisitions, true, tripoliFraction);
+                backgroundAcquisitions, peakAcquisitions, true, tripoliFraction, false);
 
         tripoliFraction.shadeDataActiveMapLeft(0);
         System.out.println("\n**** SHRIMP FractionID  " + fractionID + " refMat? " + tripoliFraction.isStandard() + " <<<<<<<<<<<<<<<<<<\n");

--- a/src/main/java/org/earthtime/Tripoli/sessions/TripoliSession.java
+++ b/src/main/java/org/earthtime/Tripoli/sessions/TripoliSession.java
@@ -708,13 +708,15 @@ public class TripoliSession implements
      */
     @Override
     public void interceptCalculatePbcCorrAndRhos(boolean inLiveMode) {
-        // refit any  fractions not currently fitted
-        Set<TripoliFraction> includedTripoliFractions = FractionsFilterInterface.getTripoliFractionsFiltered(tripoliFractions, FractionSelectionTypeEnum.ALL, IncludedTypeEnum.INCLUDED);
-        for (TripoliFraction tf : includedTripoliFractions) {
-            tf.reProcessToRejectNegativeRatios();
-            if (!tf.isCurrentlyFitted()) {
-                tf.updateInterceptFitFunctionsIncludingCommonLead();
-                fitFunctionsUpToDate = false;
+        if (!inLiveMode) {
+            // refit any  fractions not currently fitted
+            Set<TripoliFraction> includedTripoliFractions = FractionsFilterInterface.getTripoliFractionsFiltered(tripoliFractions, FractionSelectionTypeEnum.ALL, IncludedTypeEnum.INCLUDED);
+            for (TripoliFraction tf : includedTripoliFractions) {
+                tf.reProcessToRejectNegativeRatios();
+                if (!tf.isCurrentlyFitted()) {
+                    tf.updateInterceptFitFunctionsIncludingCommonLead();
+                    fitFunctionsUpToDate = false;
+                }
             }
         }
 

--- a/src/main/java/org/earthtime/Tripoli/sessions/TripoliSession.java
+++ b/src/main/java/org/earthtime/Tripoli/sessions/TripoliSession.java
@@ -702,8 +702,12 @@ public class TripoliSession implements
         }
     }
 
+    /**
+     *
+     * @param inLiveMode the value of inLiveMode
+     */
     @Override
-    public void interceptCalculatePbcCorrAndRhos() {
+    public void interceptCalculatePbcCorrAndRhos(boolean inLiveMode) {
         // refit any  fractions not currently fitted
         Set<TripoliFraction> includedTripoliFractions = FractionsFilterInterface.getTripoliFractionsFiltered(tripoliFractions, FractionSelectionTypeEnum.ALL, IncludedTypeEnum.INCLUDED);
         for (TripoliFraction tf : includedTripoliFractions) {
@@ -714,7 +718,7 @@ public class TripoliSession implements
             }
         }
 
-        prepareForReductionAndCommonLeadCorrection(false);
+        prepareForReductionAndCommonLeadCorrection(inLiveMode);
     }
 
     @Override

--- a/src/main/java/org/earthtime/Tripoli/sessions/TripoliSessionFractionationCalculatorInterface.java
+++ b/src/main/java/org/earthtime/Tripoli/sessions/TripoliSessionFractionationCalculatorInterface.java
@@ -32,13 +32,15 @@ public interface TripoliSessionFractionationCalculatorInterface {
     
     /**
      * 
+     * @param inLiveMode the value of inLiveMode
      */
-    public void calculateSessionFitFunctionsForPrimaryStandard ();
+    public void calculateSessionFitFunctionsForPrimaryStandard (boolean inLiveMode);
     
     /**
      * 
+     * @param inLiveMode the value of inLiveMode
      */
-    public void applyCorrections ();
+    public void applyCorrections (boolean inLiveMode);
     
     /**
      *

--- a/src/main/java/org/earthtime/Tripoli/sessions/TripoliSessionFractionationCalculatorInterface.java
+++ b/src/main/java/org/earthtime/Tripoli/sessions/TripoliSessionFractionationCalculatorInterface.java
@@ -42,6 +42,8 @@ public interface TripoliSessionFractionationCalculatorInterface {
      */
     public void applyCorrections (boolean inLiveMode);
     
+    public void resetAllUPbFractionReduction();
+    
     /**
      *
      * @return

--- a/src/main/java/org/earthtime/Tripoli/sessions/TripoliSessionInterface.java
+++ b/src/main/java/org/earthtime/Tripoli/sessions/TripoliSessionInterface.java
@@ -64,7 +64,11 @@ public interface TripoliSessionInterface extends TripoliSessionFractionationCalc
     @Override
     void applyCorrections(boolean inLiveMode);
 
-    public void interceptCalculatePbcCorrAndRhos();
+    /**
+     *
+     * @param inLiveMode the value of inLiveMode
+     */
+    public void interceptCalculatePbcCorrAndRhos(boolean inLiveMode);
 
     /**
      *

--- a/src/main/java/org/earthtime/Tripoli/sessions/TripoliSessionInterface.java
+++ b/src/main/java/org/earthtime/Tripoli/sessions/TripoliSessionInterface.java
@@ -251,9 +251,10 @@ public interface TripoliSessionInterface extends TripoliSessionFractionationCalc
 
     /**
      *
+     * @param inLiveMode
      * @param isLiveMode the value of isLiveMode
      */
-    public void prepareForReductionAndCommonLeadCorrection(boolean isLiveMode);
+    public void prepareForReductionAndCommonLeadCorrection(boolean inLiveMode);
 
     public void setLeftShadeCount(int leftShadeCount);
 

--- a/src/main/java/org/earthtime/Tripoli/sessions/TripoliSessionInterface.java
+++ b/src/main/java/org/earthtime/Tripoli/sessions/TripoliSessionInterface.java
@@ -49,54 +49,55 @@ public interface TripoliSessionInterface extends TripoliSessionFractionationCalc
      *
      * @return
      */
-    FractionationTechniquesEnum getFractionationTechnique ();
+    FractionationTechniquesEnum getFractionationTechnique();
 
     /**
      *
      * @param fractionationTechnique
      */
-    void setFractionationTechnique ( FractionationTechniquesEnum fractionationTechnique );
+    void setFractionationTechnique(FractionationTechniquesEnum fractionationTechnique);
 
     /**
      *
+     * @param inLiveMode the value of inLiveMode
      */
     @Override
-    void applyCorrections ();
-    
+    void applyCorrections(boolean inLiveMode);
+
     public void interceptCalculatePbcCorrAndRhos();
 
     /**
      *
-     * @return  
+     * @return
      */
-    public boolean prepareMatrixJfPlotting (  );
+    public boolean prepareMatrixJfPlotting();
 
     /**
      *
      * @param fractionSelectionTypeEnum the value of fractionSelectionTypeEnum
      * @return the boolean
      */
-    public boolean prepareMatrixJfMapFractionsByType (FractionSelectionTypeEnum fractionSelectionTypeEnum);
+    public boolean prepareMatrixJfMapFractionsByType(FractionSelectionTypeEnum fractionSelectionTypeEnum);
 
     /**
      *
      * @param fitFunctionType
      * @return
      */
-    public Matrix getMatrixJfPlottingActiveStandards ( FitFunctionTypeEnum fitFunctionType );
+    public Matrix getMatrixJfPlottingActiveStandards(FitFunctionTypeEnum fitFunctionType);
 
     /**
      *
      * @param estimatedPlottingPointsCount
      */
-    public void setEstimatedPlottingPointsCount ( int estimatedPlottingPointsCount );
+    public void setEstimatedPlottingPointsCount(int estimatedPlottingPointsCount);
 
     /**
      *
      * @return
      */
-    public double[] getTimesForPlotting ();
-    
+    public double[] getTimesForPlotting();
+
     /**
      *
      * @return
@@ -107,150 +108,161 @@ public interface TripoliSessionInterface extends TripoliSessionFractionationCalc
      *
      */
     @Override
-    void calculateDownholeFitSummariesForPrimaryStandard ();
+    void calculateDownholeFitSummariesForPrimaryStandard();
 
     /**
      *
      */
-    public void clearAllFractionsOfLocalYAxis ();
+    public void clearAllFractionsOfLocalYAxis();
+
     public void setAllFractionsOfLocalYAxis();
 
     /**
      * @return the getDownholeFractionationDataModels
      */
-    SortedMap<RawRatioNames, DownholeFractionationDataModel> getDownholeFractionationDataModels ();
+    SortedMap<RawRatioNames, DownholeFractionationDataModel> getDownholeFractionationDataModels();
 
     /**
      *
      * @return
      */
-    AbstractMassSpecSetup getMassSpec ();
+    AbstractMassSpecSetup getMassSpec();
 
     /**
      * @return the rawDataFileHandler
      */
-    AbstractRawDataFileHandler getRawDataFileHandler ();
+    AbstractRawDataFileHandler getRawDataFileHandler();
 
     /**
      *
      * @return
      */
-    SortedMap<RawRatioNames, AbstractSessionForStandardDataModel> getCurrentSessionForStandardsFractionation ();
+    SortedMap<RawRatioNames, AbstractSessionForStandardDataModel> getCurrentSessionForStandardsFractionation();
 
     /**
      * @return the tripoliFractions
      */
-    SortedSet<TripoliFraction> getTripoliFractions ();
-    
+    SortedSet<TripoliFraction> getTripoliFractions();
+
     public SortedSet<TripoliFraction> getTripoliFractionsFromSample(AbstractTripoliSample sample);
 
     /**
      *
      * @param fractionSelectionType
      */
-    void includeAllFractions ( FractionSelectionTypeEnum fractionSelectionType );
+    void includeAllFractions(FractionSelectionTypeEnum fractionSelectionType);
 
     /**
      *
      */
-    void includeAllAquisitions ();
+    void includeAllAquisitions();
 
     /**
      *
      * @param updateOnly the value of updateOnly
      */
-    void processRawData (boolean updateOnly);
+    void processRawData(boolean updateOnly);
+
     void postProcessDataForCommonLeadLossPreparation();
 
     /**
      * @param rawDataFileHandler the rawDataFileHandler to set
      */
-    void setRawDataFileHandler ( AbstractRawDataFileHandler rawDataFileHandler );
+    void setRawDataFileHandler(AbstractRawDataFileHandler rawDataFileHandler);
 
     /**
      * @param tripoliFractions the tripoliFractions to set
      */
-    void setTripoliFractions ( SortedSet<TripoliFraction> tripoliFractions );
+    void setTripoliFractions(SortedSet<TripoliFraction> tripoliFractions);
 
     /**
      *
      * @return
      */
-    public ArrayList<AbstractTripoliSample> getTripoliSamples ();
+    public ArrayList<AbstractTripoliSample> getTripoliSamples();
 
     /**
      *
      * @param tripoliSamples
      */
-    public void setTripoliSamples ( ArrayList<AbstractTripoliSample> tripoliSamples );
+    public void setTripoliSamples(ArrayList<AbstractTripoliSample> tripoliSamples);
 
     /**
      *
      */
-    public void updateFractionsToSampleMembership ();
+    public void updateFractionsToSampleMembership();
 
     /**
      *
      * @return
      */
-    public AbstractRatiosDataModel getPrimaryMineralStandard ();
+    public AbstractRatiosDataModel getPrimaryMineralStandard();
 
     /**
      *
      * @param primaryMineralStandard
      */
-    public void setPrimaryMineralStandard ( AbstractRatiosDataModel primaryMineralStandard );
+    public void setPrimaryMineralStandard(AbstractRatiosDataModel primaryMineralStandard);
 
     /**
      *
      */
-    public void refreshMaskingArray ();
+    public void refreshMaskingArray();
 
     /**
      *
      */
-    public void applyMaskingArray ();
+    public void applyMaskingArray();
 
     /**
      *
      */
-    public void reFitAllFractions ();
+    public void reFitAllFractions();
 
     /**
      *
      * @param setOD
      */
-    public void setODforAllFractionsAllRatios ( boolean setOD );
-    public void setDownHoleODforAllFractionsAllRatios ( boolean setOD );
-    
+    public void setODforAllFractionsAllRatios(boolean setOD);
+
+    public void setDownHoleODforAllFractionsAllRatios(boolean setOD);
+
     /**
      *
      * @return
      */
-    public SortedMap<RadRatios, SessionCorrectedUnknownsSummary> getSessionCorrectedUnknownsSummaries ();
-    
+    public SortedMap<RadRatios, SessionCorrectedUnknownsSummary> getSessionCorrectedUnknownsSummaries();
+
     /**
      *
      * @return
      */
     public MaskingSingleton getMaskingSingleton();
-    
+
     /**
      *
      * @return
      */
     public boolean isDataProcessed();
-    
-    public void prepareForReductionAndCommonLeadCorrection();
-    
+
+    /**
+     *
+     * @param isLiveMode the value of isLiveMode
+     */
+    public void prepareForReductionAndCommonLeadCorrection(boolean isLiveMode);
+
     public void setLeftShadeCount(int leftShadeCount);
-    
+
     public boolean isFitFunctionsUpToDate();
-    
+
     public void setFitFunctionsUpToDate(boolean fitFunctionsUpToDate);
-    
+
     public void refitAllFractionsForDownhole();
-    
+
     public void prepareFractionTimeStamps();
+
+    public boolean isRefMaterialSessionFittedForLiveMode();
+
+    public void setRefMaterialSessionFittedForLiveMode(boolean refMaterialSessionFittedForLiveMode);
 
 }

--- a/src/main/java/org/earthtime/UPb_Redux/aliquots/UPbReduxAliquot.java
+++ b/src/main/java/org/earthtime/UPb_Redux/aliquots/UPbReduxAliquot.java
@@ -308,8 +308,10 @@ public class UPbReduxAliquot extends Aliquot
 
     /**
      *
+     * @param inLiveMode the value of inLiveMode
      */
-    public void reduceData() {
+    @Override
+    public void reduceData(boolean inLiveMode) {
         // may 2014 modified to determine best date  
         ArrayList<Double> sorted206_238 = new ArrayList<>();
         for (ETFractionInterface f : getAliquotFractions()) {
@@ -646,16 +648,6 @@ public class UPbReduxAliquot extends Aliquot
         it = tempAlphaUModels.iterator();
         while (it.hasNext()) {
             getAlphaUModels().add((ValueModel) it.next());
-        }
-    }
-
-    /**
-     *
-     */
-    public void initializeFractionReductionHandlers() {
-        for (ETFractionInterface f : getAliquotFractions()) {
-            //((UPbFraction) f).initializeReductionHandler();
-            UPbFractionReducer.getInstance().fullFractionReduce((FractionI) f, true);
         }
     }
 

--- a/src/main/java/org/earthtime/UPb_Redux/dateInterpretation/DateProbabilityDensityPanel.java
+++ b/src/main/java/org/earthtime/UPb_Redux/dateInterpretation/DateProbabilityDensityPanel.java
@@ -706,12 +706,12 @@ public class DateProbabilityDensityPanel extends JLayeredPane
     }
 
     @Override
-    public void resetPanel(boolean doReScale) {
-        refreshPanel(doReScale);
+    public void resetPanel(boolean doReScale, boolean inLiveMode) {
+        refreshPanel(doReScale, inLiveMode);
     }
 
     @Override
-    public void refreshPanel(boolean doReScale) {
+    public void refreshPanel(boolean doReScale, boolean inLiveMode) {
         if (doReScale) {
             // nov 2011
             setMinX(DateProbabilityDensityPanel.DEFAULT_DISPLAY_MINX);
@@ -719,7 +719,7 @@ public class DateProbabilityDensityPanel extends JLayeredPane
             setDisplayOffsetX(0);
         }
 
-        preparePanel(doReScale);
+        preparePanel(doReScale, inLiveMode);
         repaint();
     }
 
@@ -727,15 +727,17 @@ public class DateProbabilityDensityPanel extends JLayeredPane
      *
      */
     public void prepareAndPaintPanel() {
-        preparePanel(true);
+        preparePanel(true, false);
         repaint();
     }
 
     /**
      *
+     * @param doReScale the value of doReScale
+     * @param inLiveMode the value of inLiveMode
      */
     @Override
-    public void preparePanel(boolean doReScale) {
+    public void preparePanel(boolean doReScale, boolean inLiveMode) {
 
         System.out.println("========Probability Prep=======");
         this.removeAll();
@@ -868,7 +870,7 @@ public class DateProbabilityDensityPanel extends JLayeredPane
      *
      */
     public void showTight() {
-        refreshPanel(true);
+        refreshPanel(true, false);
 
         for (int i = 0; i < pdfPoints.size(); i++) {
             if (stackedAliquotKernels[0][i] > 0.01) {

--- a/src/main/java/org/earthtime/UPb_Redux/dateInterpretation/SampleTreeAnalysisMode.java
+++ b/src/main/java/org/earthtime/UPb_Redux/dateInterpretation/SampleTreeAnalysisMode.java
@@ -46,7 +46,6 @@ import org.earthtime.aliquots.AliquotInterface;
 import org.earthtime.aliquots.ReduxAliquotInterface;
 import org.earthtime.dataDictionaries.SampleAnalysisTypesEnum;
 import org.earthtime.dialogs.DialogEditor;
-import org.earthtime.fractions.ETFractionInterface;
 import org.earthtime.samples.SampleInterface;
 
 /**
@@ -99,66 +98,66 @@ public class SampleTreeAnalysisMode extends JTree implements SampleTreeI {
 
         // populate tree
         // todo: just walk aliquots now that ths mapping is fixed (may 2015)
-        int saveAliquotNum = -1;
-        for (int i = 0; i < sample.getFractions().size(); i++) {
-            ETFractionInterface tempFraction = sample.getFractions().get(i);
-            AliquotInterface tempAliquot;
+//        int saveAliquotNum = -1;
+//        for (int i = 0; i < sample.getFractions().size(); i++) {
+        for (int i = 0; i < sample.getActiveAliquots().size(); i++) {
+//            ETFractionInterface tempFraction = sample.getFractions().get(i);
+            AliquotInterface tempAliquot = sample.getActiveAliquots().get(i);
 
-            if (!tempFraction.isRejected()) {
-                if (saveAliquotNum != tempFraction.getAliquotNumber()) {
-                    saveAliquotNum = tempFraction.getAliquotNumber();
+//            if (!tempFraction.isRejected()) {
+//                if (saveAliquotNum != tempFraction.getAliquotNumber()) {
+//                    saveAliquotNum = tempFraction.getAliquotNumber();
+            //tempAliquot = sample.getAliquotByNumber(saveAliquotNum);
+            aliquotNode = new DefaultMutableTreeNode(tempAliquot);
 
-                    tempAliquot = sample.getAliquotByNumber(saveAliquotNum);
-                    aliquotNode = new DefaultMutableTreeNode(tempAliquot);
+            ((DefaultMutableTreeNode) getModel().getRoot()).add(aliquotNode);
 
-                    ((DefaultMutableTreeNode) getModel().getRoot()).add(aliquotNode);
+            // get a master vector of active fraction names
+            Vector<String> activeFractionIDs
+                    = ((ReduxAliquotInterface) tempAliquot).//
+                    getAliquotFractionIDs();
 
-                    // get a master vector of active fraction names
-                    Vector<String> activeFractionIDs
-                            = ((ReduxAliquotInterface) tempAliquot).//
-                            getAliquotFractionIDs();
+            // now load the sample date interpretations
+            for (int index = 0; index < tempAliquot.getSampleDateModels().size(); index++) {
+                DefaultMutableTreeNode sampleDateModelNode
+                        = new DefaultMutableTreeNode(//
+                                tempAliquot.getSampleDateModels().get(index));
 
-                    // now load the sample date interpretations
-                    for (int index = 0; index < tempAliquot.getSampleDateModels().size(); index++) {
-                        DefaultMutableTreeNode sampleDateModelNode
-                                = new DefaultMutableTreeNode(//
-                                        tempAliquot.getSampleDateModels().get(index));
+                aliquotNode.add(sampleDateModelNode);
 
-                        aliquotNode.add(sampleDateModelNode);
-
-                        // remove from activefractionIDs any fraction with 0 date
-                        Vector<String> zeroFractionDates = new Vector<>();
-                        for (int f = 0; f < activeFractionIDs.size(); f++) {
-                            try {
-                                if (!((SampleDateModel) tempAliquot.getSampleDateModels().get(index)).//
-                                        fractionDateIsPositive(((ReduxAliquotInterface) tempAliquot).getAliquotFractionByName(activeFractionIDs.get(f)))) {
-                                    zeroFractionDates.add(activeFractionIDs.get(f));
-                                }
-                            } catch (Exception e) {
-                            }
+                // remove from activefractionIDs any fraction with 0 date
+                Vector<String> zeroFractionDates = new Vector<>();
+                for (int f = 0; f < activeFractionIDs.size(); f++) {
+                    try {
+                        if (!((SampleDateModel) tempAliquot.getSampleDateModels().get(index)).//
+                                fractionDateIsPositive(((ReduxAliquotInterface) tempAliquot).getAliquotFractionByName(activeFractionIDs.get(f)))) {
+                            zeroFractionDates.add(activeFractionIDs.get(f));
                         }
-                        for (int f = 0; f < zeroFractionDates.size(); f++) {
-                            activeFractionIDs.remove(zeroFractionDates.get(f));
-                        }
-
-                        // only show sample dates with non-zero data
-                        if (activeFractionIDs.size() > 0) {
-                            // give sample Date interpretation a value for aliquot
-                            ((SampleDateModel) tempAliquot.getSampleDateModels().get(index)).//
-                                    setAliquot(tempAliquot);
-                            // calculate sample age
-                            ((SampleDateModel) tempAliquot.getSampleDateModels().get(index)).//
-                                    CalculateDateInterpretationForAliquot();
-
-                            populateSampleDateModel(
-                                    activeFractionIDs,
-                                    tempAliquot,
-                                    tempAliquot.getSampleDateModels().get(index),
-                                    sampleDateModelNode);
-                        }
-
+                    } catch (Exception e) {
                     }
                 }
+                for (int f = 0; f < zeroFractionDates.size(); f++) {
+                    activeFractionIDs.remove(zeroFractionDates.get(f));
+                }
+
+                // only show sample dates with non-zero data
+                if (activeFractionIDs.size() > 0) {
+                    // give sample Date interpretation a value for aliquot
+                    ((SampleDateModel) tempAliquot.getSampleDateModels().get(index)).//
+                            setAliquot(tempAliquot);
+                    // calculate sample age
+                    ((SampleDateModel) tempAliquot.getSampleDateModels().get(index)).//
+                            CalculateDateInterpretationForAliquot();
+
+                    populateSampleDateModel(
+                            activeFractionIDs,
+                            tempAliquot,
+                            tempAliquot.getSampleDateModels().get(index),
+                            sampleDateModelNode);
+                }
+
+//                    }
+//                }
             }
         }
 

--- a/src/main/java/org/earthtime/UPb_Redux/dateInterpretation/WeightedMeanGraphPanel.java
+++ b/src/main/java/org/earthtime/UPb_Redux/dateInterpretation/WeightedMeanGraphPanel.java
@@ -983,17 +983,19 @@ public class WeightedMeanGraphPanel extends JPanel
     /**
      *
      * @param doReScale the value of doReScale
+     * @param inLiveMode the value of inLiveMode
      */
-    public void refreshPanel(boolean doReScale) {
-        preparePanel(doReScale);
+    public void refreshPanel(boolean doReScale, boolean inLiveMode) {
+        preparePanel(doReScale, false);
         repaint();
     }
 
     /**
      *
      * @param doReScale the value of doReScale
+     * @param inLiveMode the value of inLiveMode
      */
-    public void preparePanel(boolean doReScale) {
+    public void preparePanel(boolean doReScale, boolean inLiveMode) {
 
         zoomMaxX = 0;
         zoomMaxY = 0;
@@ -1570,7 +1572,7 @@ public class WeightedMeanGraphPanel extends JPanel
     }
 
     @Override
-    public void resetPanel(boolean doReScale) {
-        refreshPanel(doReScale);
+    public void resetPanel(boolean doReScale, boolean inLiveMode) {
+        refreshPanel(doReScale, inLiveMode);
     }
 }

--- a/src/main/java/org/earthtime/UPb_Redux/dateInterpretation/concordia/ConcordiaGraphPanel.java
+++ b/src/main/java/org/earthtime/UPb_Redux/dateInterpretation/concordia/ConcordiaGraphPanel.java
@@ -1490,9 +1490,10 @@ public class ConcordiaGraphPanel extends JLayeredPane
     /**
      *
      * @param doReScale the value of doReScale
+     * @param inLiveMode the value of inLiveMode
      */
     @Override
-    public void resetPanel(boolean doReScale) {
+    public void resetPanel(boolean doReScale, boolean inLiveMode) {
 
         if (doReScale) {
             setDisplayOffsetX(0.0);
@@ -1513,17 +1514,18 @@ public class ConcordiaGraphPanel extends JLayeredPane
             graphPanelModeChanger.switchToPanMode();
         } catch (Exception e) {
         } finally {
-            refreshPanel(doReScale);
+            refreshPanel(doReScale, inLiveMode);
         }
     }
 
     /**
      *
      * @param doReScale the value of doReScale
+     * @param inLiveMode the value of inLiveMode
      */
     @Override
-    public void refreshPanel(boolean doReScale) {
-        preparePanel(doReScale);
+    public void refreshPanel(boolean doReScale, boolean inLiveMode) {
+        preparePanel(doReScale, inLiveMode);
         repaint();
     }
 
@@ -1544,9 +1546,10 @@ public class ConcordiaGraphPanel extends JLayeredPane
     /**
      *
      * @param doReScale the value of doReScale
+     * @param inLiveMode the value of inLiveMode
      */
     @Override
-    public void preparePanel(boolean doReScale) {
+    public void preparePanel(boolean doReScale, boolean inLiveMode) {
 
         try {
             if (getConcordiaFlavor().equalsIgnoreCase("Th")) {
@@ -1844,7 +1847,10 @@ public class ConcordiaGraphPanel extends JLayeredPane
         setImageMode("PAN");
 
         // april 2016 - this causes update of weighted means when sample is changed
-        SampleInterface.updateAndSaveSampleDateModelsByAliquot(sample);
+        // June 2016 not to be called in live mode
+        if (!inLiveMode) {
+            SampleInterface.updateAndSaveSampleDateModelsByAliquot(sample);
+        }
 
     }
 
@@ -2444,11 +2450,13 @@ public class ConcordiaGraphPanel extends JLayeredPane
                 }
             }
         } else // set best age divider
-         if (changingBestDateDivider) {
+        {
+            if (changingBestDateDivider) {
                 ((AliquotForUPbInterface) curAliquot).setBestAgeDivider206_238(new BigDecimal(currentBestDate));
                 ((UPbReduxAliquot) curAliquot).updateBestAge();
-                reportUpdater.updateReportTable(false);
+                reportUpdater.updateReportTable(false, false);
             }
+        }
 
         changingBestDateDivider = false;
 

--- a/src/main/java/org/earthtime/UPb_Redux/dateInterpretation/concordia/ConcordiaGraphPanelIsoplot.java
+++ b/src/main/java/org/earthtime/UPb_Redux/dateInterpretation/concordia/ConcordiaGraphPanelIsoplot.java
@@ -136,7 +136,7 @@ public class ConcordiaGraphPanelIsoplot extends JFXPanel
     }
 
     @Override
-    public void preparePanel(boolean doReScale) {
+    public void preparePanel(boolean doReScale, boolean inLiveMode) {
 
 ////        String r206_238r_corrected = "r206_238r";
 ////        String r207_235r_corrected = "r207_235r";
@@ -173,20 +173,20 @@ public class ConcordiaGraphPanelIsoplot extends JFXPanel
     }
 
     @Override
-    public void refreshPanel(boolean doReScale) {
+    public void refreshPanel(boolean doReScale, boolean inLiveMode) {
 
         Platform.runLater(new Runnable() {
             @Override
             public void run() {
                 observableSequence.clear();//.remove(0);
-                preparePanel(doReScale);
+                preparePanel(doReScale, false);
             }
         });
 
     }
 
     @Override
-    public void resetPanel(boolean doReScale) {
+    public void resetPanel(boolean doReScale, boolean inLiveMode) {
         throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
     }
 

--- a/src/main/java/org/earthtime/UPb_Redux/dateInterpretation/concordia/PlottingDetailsDisplayInterface.java
+++ b/src/main/java/org/earthtime/UPb_Redux/dateInterpretation/concordia/PlottingDetailsDisplayInterface.java
@@ -27,19 +27,22 @@ public interface PlottingDetailsDisplayInterface {
     /**
      *
      * @param doReScale the value of doReScale
+     * @param inLiveMode the value of inLiveMode
      */
-    void preparePanel(boolean doReScale);
+    void preparePanel(boolean doReScale, boolean inLiveMode);
 
     /**
      *
      * @param doReScale the value of doReScale
+     * @param inLiveMode the value of inLiveMode
      */
-    void refreshPanel(boolean doReScale);
+    void refreshPanel(boolean doReScale, boolean inLiveMode);
 
     /**
      *
      * @param doReScale the value of doReScale
+     * @param inLiveMode the value of inLiveMode
      */
-    void resetPanel(boolean doReScale);
+    void resetPanel(boolean doReScale, boolean inLiveMode);
 
 }

--- a/src/main/java/org/earthtime/UPb_Redux/dateInterpretation/kwiki/KwikiConcordiaToolBar.java
+++ b/src/main/java/org/earthtime/UPb_Redux/dateInterpretation/kwiki/KwikiConcordiaToolBar.java
@@ -128,7 +128,7 @@ public class KwikiConcordiaToolBar extends JLayeredPane implements GraphPanelMod
         restoreZoom.setMargin(new Insets(0, 0, 0, 0));
 
         restoreZoom.addActionListener((ActionEvent arg0) -> {
-            ((PlottingDetailsDisplayInterface) concordiaGraphPanel).resetPanel(true);
+            ((PlottingDetailsDisplayInterface) concordiaGraphPanel).resetPanel(true, false);
         });
 
         add(restoreZoom, javax.swing.JLayeredPane.DEFAULT_LAYER);

--- a/src/main/java/org/earthtime/UPb_Redux/dateInterpretation/kwiki/KwikiPDFToolBar.java
+++ b/src/main/java/org/earthtime/UPb_Redux/dateInterpretation/kwiki/KwikiPDFToolBar.java
@@ -464,7 +464,7 @@ public class KwikiPDFToolBar extends JLayeredPane implements GraphPanelModeChang
         restoreZoom.setMargin(new Insets(0, 0, 0, 0));
 
         restoreZoom.addActionListener((ActionEvent arg0) -> {
-            ((PlottingDetailsDisplayInterface) probabilityPanel).refreshPanel(true);
+            ((PlottingDetailsDisplayInterface) probabilityPanel).refreshPanel(true, false);
         });
         add(restoreZoom, javax.swing.JLayeredPane.DEFAULT_LAYER);
 

--- a/src/main/java/org/earthtime/UPb_Redux/dialogs/aliquotManagers/AliquotEditorDialog.java
+++ b/src/main/java/org/earthtime/UPb_Redux/dialogs/aliquotManagers/AliquotEditorDialog.java
@@ -4658,7 +4658,7 @@ private void publishAliquot_panelMouseClicked(java.awt.event.MouseEvent evt) {//
 
                 concordiaGraphPanel.setShowTightToEdges(true);
 
-                concordiaGraphPanel.refreshPanel(true);
+                concordiaGraphPanel.refreshPanel(true, false);
 
                 concordiaGraphPanel.setShowTightToEdges(false);
 

--- a/src/main/java/org/earthtime/UPb_Redux/dialogs/fractionManagers/UPbFractionEditorDialog.java
+++ b/src/main/java/org/earthtime/UPb_Redux/dialogs/fractionManagers/UPbFractionEditorDialog.java
@@ -411,7 +411,7 @@ public class UPbFractionEditorDialog extends DialogEditor {
             reInitializeKwikiTab(fraction);
 
             // bring into view
-            ((PlottingDetailsDisplayInterface) concordiaGraphPanel).resetPanel(true);
+            ((PlottingDetailsDisplayInterface) concordiaGraphPanel).resetPanel(true, false);
         }
 
         /**
@@ -778,7 +778,7 @@ public class UPbFractionEditorDialog extends DialogEditor {
                 .setCorrectPaSelected(((ConcordiaGraphPanel) concordiaGraphPanel).isDisplay_r206_238r_Pa());
         ((KwikiDateModesSelectorPanel) kwikiDateModesSelectorPanel).CalculateDateCorrectionMode("None");
 
-        ((PlottingDetailsDisplayInterface) concordiaGraphPanel).refreshPanel(true);
+        ((PlottingDetailsDisplayInterface) concordiaGraphPanel).refreshPanel(true, false);
 
         drawSlidersByClump(fraction);
 

--- a/src/main/java/org/earthtime/UPb_Redux/dialogs/projectManagers/AbstractProjectManagerForRawData.java
+++ b/src/main/java/org/earthtime/UPb_Redux/dialogs/projectManagers/AbstractProjectManagerForRawData.java
@@ -386,7 +386,7 @@ public abstract class AbstractProjectManagerForRawData extends DialogEditor impl
         MaskingSingleton.getInstance().setLeftShadeCount(leftShadeCount);
         MaskingSingleton.getInstance().setRightShadeCount(-1);
 
-        rawDataFileHandler.getAndLoadRawIntensityDataFile(loadDataTask, usingFullPropagation, leftShadeCount, ignoreFirstFractions);
+        rawDataFileHandler.getAndLoadRawIntensityDataFile(loadDataTask, usingFullPropagation, leftShadeCount, ignoreFirstFractions, false);
     }
 
     private void loadAndShowRawDataFinishUp() {
@@ -457,7 +457,7 @@ public abstract class AbstractProjectManagerForRawData extends DialogEditor impl
             myMassSpec.reProcessFractionRawRatios(usingFullPropagation, tf.getFractionID(), tf);
         }
 
-        tripoliSession.calculateSessionFitFunctionsForPrimaryStandard();
+        tripoliSession.calculateSessionFitFunctionsForPrimaryStandard(false);
         // jan 2015 moved to calculate sessionfittripoliSession.applyCorrections();
 
         try {

--- a/src/main/java/org/earthtime/UPb_Redux/dialogs/projectManagers/AbstractProjectManagerForRawData.java
+++ b/src/main/java/org/earthtime/UPb_Redux/dialogs/projectManagers/AbstractProjectManagerForRawData.java
@@ -461,7 +461,7 @@ public abstract class AbstractProjectManagerForRawData extends DialogEditor impl
         // jan 2015 moved to calculate sessionfittripoliSession.applyCorrections();
 
         try {
-            uPbReduxFrame.updateReportTable(true);
+            uPbReduxFrame.updateReportTable(true, false);
         } catch (Exception e) {
         }
 
@@ -909,7 +909,7 @@ public abstract class AbstractProjectManagerForRawData extends DialogEditor impl
 
             project.prepareSamplesForRedux();
 
-            uPbReduxFrame.initializeProject();
+            uPbReduxFrame.initializeProject(false);
 
             initializeSessionManager(true, true, true);
 //            } catch (ETException ex) {

--- a/src/main/java/org/earthtime/UPb_Redux/dialogs/projectManagers/ProjectManagerFor_LAICPMS_FromRawData.java
+++ b/src/main/java/org/earthtime/UPb_Redux/dialogs/projectManagers/ProjectManagerFor_LAICPMS_FromRawData.java
@@ -517,7 +517,7 @@ public class ProjectManagerFor_LAICPMS_FromRawData extends DialogEditor implemen
         MaskingSingleton.getInstance().setLeftShadeCount(leftShadeCount);
         MaskingSingleton.getInstance().setRightShadeCount(-1);
 
-        rawDataFileHandler.getAndLoadRawIntensityDataFile(loadDataTask, usingFullPropagation, leftShadeCount, ignoreFirstFractions);
+        rawDataFileHandler.getAndLoadRawIntensityDataFile(loadDataTask, usingFullPropagation, leftShadeCount, ignoreFirstFractions, false);
     }
 
     private void loadAndShowRawDataFinishUp() {
@@ -595,7 +595,7 @@ public class ProjectManagerFor_LAICPMS_FromRawData extends DialogEditor implemen
             myMassSpec.reProcessFractionRawRatios(usingFullPropagation, tf.getFractionID(), tf);
         }
 
-        tripoliSession.calculateSessionFitFunctionsForPrimaryStandard();
+        tripoliSession.calculateSessionFitFunctionsForPrimaryStandard(false);
         // jan 2015 moved to calcualte sessionfittripoliSession.applyCorrections();
 
         try {

--- a/src/main/java/org/earthtime/UPb_Redux/dialogs/projectManagers/ProjectManagerFor_LAICPMS_FromRawData.java
+++ b/src/main/java/org/earthtime/UPb_Redux/dialogs/projectManagers/ProjectManagerFor_LAICPMS_FromRawData.java
@@ -623,6 +623,12 @@ public class ProjectManagerFor_LAICPMS_FromRawData extends DialogEditor implemen
                 int progress = (Integer) pce.getNewValue();
                 loadDataTaskProgressBar.setValue(progress);
                 loadDataTaskProgressBar.validate();
+            } else if ("projectName".equalsIgnoreCase(pce.getPropertyName())) {
+                project.setProjectName((String) pce.getNewValue());
+                projectName_text.setText(project.getProjectName());
+            } else if ("refMaterialLoaded".equalsIgnoreCase(pce.getPropertyName())) {
+                tripoliSession.setRefMaterialSessionFittedForLiveMode(false);
+                System.out.println("ref material loaded <<<<");
             }
         }
     }

--- a/src/main/java/org/earthtime/UPb_Redux/dialogs/projectManagers/ProjectManagerFor_LAICPMS_FromRawData.java
+++ b/src/main/java/org/earthtime/UPb_Redux/dialogs/projectManagers/ProjectManagerFor_LAICPMS_FromRawData.java
@@ -599,7 +599,7 @@ public class ProjectManagerFor_LAICPMS_FromRawData extends DialogEditor implemen
         // jan 2015 moved to calcualte sessionfittripoliSession.applyCorrections();
 
         try {
-            uPbReduxFrame.updateReportTable(true);
+            uPbReduxFrame.updateReportTable(true, false);
         } catch (Exception e) {
         }
 
@@ -627,8 +627,11 @@ public class ProjectManagerFor_LAICPMS_FromRawData extends DialogEditor implemen
                 project.setProjectName((String) pce.getNewValue());
                 projectName_text.setText(project.getProjectName());
             } else if ("refMaterialLoaded".equalsIgnoreCase(pce.getPropertyName())) {
-                tripoliSession.setRefMaterialSessionFittedForLiveMode(false);
-                System.out.println("ref material loaded <<<<");
+                try {
+                    tripoliSession.setRefMaterialSessionFittedForLiveMode(false);
+                    System.out.println("ref material loaded <<<<");
+                } catch (Exception e) {
+                }
             }
         }
     }
@@ -1049,7 +1052,7 @@ public class ProjectManagerFor_LAICPMS_FromRawData extends DialogEditor implemen
 
                 project.prepareSamplesForRedux();
 
-                uPbReduxFrame.initializeProject();
+                uPbReduxFrame.initializeProject(false);
 
                 initializeSessionManager(true, true, true);
             } catch (ETException ex) {

--- a/src/main/java/org/earthtime/UPb_Redux/dialogs/sampleManagers/sampleDateInterpretationManagers/SampleDateInterpretationsManager.java
+++ b/src/main/java/org/earthtime/UPb_Redux/dialogs/sampleManagers/sampleDateInterpretationManagers/SampleDateInterpretationsManager.java
@@ -187,15 +187,16 @@ public class SampleDateInterpretationsManager extends DialogEditor
         doLinkDiscordances = true;
 
         // fire off a refresh to get things started
-        ((PlottingDetailsDisplayInterface) concordiaGraphPanel).refreshPanel(true);
+        ((PlottingDetailsDisplayInterface) concordiaGraphPanel).refreshPanel(true, false);
 
     }
 
     /**
      *
      * @param doReScale the value of doReScale
+     * @param inLiveMode the value of inLiveMode
      */
-    public void refreshSampleDateInterpretations(boolean doReScale) {
+    public void refreshSampleDateInterpretations(boolean doReScale, boolean inLiveMode) {
 
         String expansionHistory = "";
         if (!doReScale) {
@@ -214,15 +215,15 @@ public class SampleDateInterpretationsManager extends DialogEditor
         dateTreeBySample.buildTree();
         dateTreeBySample_ScrollPane.setViewportView((Component) dateTreeBySample);
 
-        ((PlottingDetailsDisplayInterface) concordiaGraphPanel).resetPanel(doReScale);
+        ((PlottingDetailsDisplayInterface) concordiaGraphPanel).resetPanel(doReScale, inLiveMode);
 
         try {
             // June 2010 ensures backward compatibility with previous versions that used dummy aliquot in this list
             setupWeightedMeansPanelForAliquots();
         } catch (Exception e) {
         }
-        ((PlottingDetailsDisplayInterface) weightedMeanGraphPanel).resetPanel(doReScale);
-        ((PlottingDetailsDisplayInterface) probabilityPanel).resetPanel(doReScale);
+        ((PlottingDetailsDisplayInterface) weightedMeanGraphPanel).resetPanel(doReScale, inLiveMode);
+        ((PlottingDetailsDisplayInterface) probabilityPanel).resetPanel(doReScale, inLiveMode);
 
     }
 
@@ -1908,7 +1909,7 @@ public class SampleDateInterpretationsManager extends DialogEditor
 
     private void resetGraphDisplay_buttonActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_resetGraphDisplay_buttonActionPerformed
         ((ConcordiaGraphPanel) concordiaGraphPanel).setShowTightToEdges(false);
-        ((PlottingDetailsDisplayInterface) concordiaGraphPanel).resetPanel(true);
+        ((PlottingDetailsDisplayInterface) concordiaGraphPanel).resetPanel(true, false);
 }//GEN-LAST:event_resetGraphDisplay_buttonActionPerformed
     private void writeConcordiaPDF_buttonActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_writeConcordiaPDF_buttonActionPerformed
         try {
@@ -1969,7 +1970,7 @@ private void zoomBox_toggleButtonActionPerformed(java.awt.event.ActionEvent evt)
 }//GEN-LAST:event_zoomBox_toggleButtonActionPerformed
 
 private void restoreGraphDisplay_WeightedMean_buttonActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_restoreGraphDisplay_WeightedMean_buttonActionPerformed
-    ((PlottingDetailsDisplayInterface) weightedMeanGraphPanel).refreshPanel(true);
+    ((PlottingDetailsDisplayInterface) weightedMeanGraphPanel).refreshPanel(true, false);
 }//GEN-LAST:event_restoreGraphDisplay_WeightedMean_buttonActionPerformed
 
 private void fractionOrderByDate_radioButtonActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_fractionOrderByDate_radioButtonActionPerformed
@@ -2021,7 +2022,7 @@ private void graphPanelsTabbedPaneResized(java.awt.event.ComponentEvent evt) {//
     weightedMeanToolPanel.setBounds(
             1, heightCP + 16, widthCP + leftMarginCP, 35);
 
-    ((PlottingDetailsDisplayInterface) weightedMeanGraphPanel).refreshPanel(true);
+    ((PlottingDetailsDisplayInterface) weightedMeanGraphPanel).refreshPanel(true, false);
 
     // june 2010 expansion to include additional panels
     any2ToolPanel.setBounds(
@@ -2049,7 +2050,7 @@ private void concordiaFlavor_radioButtonActionPerformed(java.awt.event.ActionEve
 
     ((ConcordiaGraphPanel) concordiaGraphPanel).setConcordiaFlavor("C");
 
-    ((PlottingDetailsDisplayInterface) concordiaGraphPanel).refreshPanel(true);
+    ((PlottingDetailsDisplayInterface) concordiaGraphPanel).refreshPanel(true, false);
 }//GEN-LAST:event_concordiaFlavor_radioButtonActionPerformed
 private void terraWasserburgFlavor_radioButtonActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_terraWasserburgFlavor_radioButtonActionPerformed
     ((AliquotDetailsDisplayInterface) concordiaGraphPanel).getConcordiaOptions().//
@@ -2057,7 +2058,7 @@ private void terraWasserburgFlavor_radioButtonActionPerformed(java.awt.event.Act
 
     ((ConcordiaGraphPanel) concordiaGraphPanel).setConcordiaFlavor("T-W");
 
-    ((PlottingDetailsDisplayInterface) concordiaGraphPanel).refreshPanel(true);
+    ((PlottingDetailsDisplayInterface) concordiaGraphPanel).refreshPanel(true, false);
 
 }//GEN-LAST:event_terraWasserburgFlavor_radioButtonActionPerformed
 private void dateTrees_tabsMouseClicked(java.awt.event.MouseEvent evt) {//GEN-FIRST:event_dateTrees_tabsMouseClicked
@@ -2093,7 +2094,7 @@ private void weightedMeansChooser_menuItemActionPerformed (java.awt.event.Action
     ((WeightedMeanGraphPanel) weightedMeanGraphPanel).//
             setSelectedSampleDateModels(((WeightedMeanOptionsDialog) myWMChooser).getSelectedModels());
 
-    ((PlottingDetailsDisplayInterface) weightedMeanGraphPanel).preparePanel(true);
+    ((PlottingDetailsDisplayInterface) weightedMeanGraphPanel).preparePanel(true, false);
 }//GEN-LAST:event_weightedMeansChooser_menuItemActionPerformed
 private void zoomInAny2X2_buttonActionPerformed (java.awt.event.ActionEvent evt) {//GEN-FIRST:event_zoomInAny2X2_buttonActionPerformed
     // TODO add your handling code here:
@@ -2130,7 +2131,7 @@ private void graphViewTabChanged (java.awt.event.MouseEvent evt) {//GEN-FIRST:ev
             ((DateProbabilityDensityPanel) probabilityPanel).//
                     getDeSelectedFractions().clear();
             ((PlottingDetailsDisplayInterface) probabilityPanel).//
-                    refreshPanel(true);
+                    refreshPanel(true, false);
         } else {
             probabilityPanel.repaint();
         }
@@ -2149,7 +2150,7 @@ private void resetGraphProbability_buttonActionPerformed (java.awt.event.ActionE
     ((DateProbabilityDensityPanel) probabilityPanel).//
             setSelectedFractions(filterActiveUPbFractions(sample.getUpbFractionsUnknown()));
 
-    ((PlottingDetailsDisplayInterface) probabilityPanel).refreshPanel(true);
+    ((PlottingDetailsDisplayInterface) probabilityPanel).refreshPanel(true, false);
 }//GEN-LAST:event_resetGraphProbability_buttonActionPerformed
 
 private void thoriumCorrectionSelector_checkboxActionPerformed (java.awt.event.ActionEvent evt) {//GEN-FIRST:event_thoriumCorrectionSelector_checkboxActionPerformed
@@ -2238,7 +2239,7 @@ private void lockUnlockHistogramBinsMouseEntered (java.awt.event.MouseEvent evt)
 
     private void showTight_toggleButtonActionPerformed ( java.awt.event.ActionEvent evt ) {//GEN-FIRST:event_showTight_toggleButtonActionPerformed
         ((ConcordiaGraphPanel) concordiaGraphPanel).setShowTightToEdges(true);
-        ((PlottingDetailsDisplayInterface) concordiaGraphPanel).resetPanel(true);
+        ((PlottingDetailsDisplayInterface) concordiaGraphPanel).resetPanel(true, false);
     }//GEN-LAST:event_showTight_toggleButtonActionPerformed
 
     private void choosePDFPeaks_menuMenuSelected ( javax.swing.event.MenuEvent evt ) {//GEN-FIRST:event_choosePDFPeaks_menuMenuSelected
@@ -2285,7 +2286,7 @@ private void lockUnlockHistogramBinsMouseEntered (java.awt.event.MouseEvent evt)
 
         ((ConcordiaGraphPanel) concordiaGraphPanel).setConcordiaFlavor("Th");
 
-        ((PlottingDetailsDisplayInterface) concordiaGraphPanel).refreshPanel(true);
+        ((PlottingDetailsDisplayInterface) concordiaGraphPanel).refreshPanel(true, false);
     }//GEN-LAST:event_thoriumConcordiaFlavor_radioButtonActionPerformed
 
     private void commonLeadCorrectionSelectorPDF_checkboxActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_commonLeadCorrectionSelectorPDF_checkboxActionPerformed
@@ -2303,7 +2304,7 @@ private void lockUnlockHistogramBinsMouseEntered (java.awt.event.MouseEvent evt)
         ((ConcordiaGraphPanel) concordiaGraphPanel).toggleDisplay_PbcCorr();
         commonLeadCorrectionSelector_checkbox.setSelected(((ConcordiaGraphPanel) concordiaGraphPanel).isDisplay_PbcCorr());
 
-        ((PlottingDetailsDisplayInterface) concordiaGraphPanel).refreshPanel(true);
+        ((PlottingDetailsDisplayInterface) concordiaGraphPanel).refreshPanel(true, false);
     }//GEN-LAST:event_commonLeadCorrectionSelector_checkboxActionPerformed
 
     // Variables declaration - do not modify//GEN-BEGIN:variables
@@ -2458,7 +2459,7 @@ private void lockUnlockHistogramBinsMouseEntered (java.awt.event.MouseEvent evt)
                 ((DateProbabilityDensityPanel) probabilityPanel).//
                         setSelectedAliquot(0);
                 ((PlottingDetailsDisplayInterface) probabilityPanel).//
-                        refreshPanel(true);
+                        refreshPanel(true, false);
             }
 
         } else if (nodeInfo instanceof AliquotInterface) {
@@ -2490,7 +2491,7 @@ private void lockUnlockHistogramBinsMouseEntered (java.awt.event.MouseEvent evt)
             ((WeightedMeanGraphPanel) weightedMeanGraphPanel).setWeightedMeanOptions(weightedMeanOptions);
 
             setupWeightedMeansPanelForAliquots();
-            ((PlottingDetailsDisplayInterface) weightedMeanGraphPanel).refreshPanel(true);
+            ((PlottingDetailsDisplayInterface) weightedMeanGraphPanel).refreshPanel(true, false);
 
             // } else {
             // probability density tab ... select and paint aliquot

--- a/src/main/java/org/earthtime/UPb_Redux/dialogs/sessionManagers/SessionAnalysisWorkflowManagerLAICPMS.java
+++ b/src/main/java/org/earthtime/UPb_Redux/dialogs/sessionManagers/SessionAnalysisWorkflowManagerLAICPMS.java
@@ -289,7 +289,7 @@ public class SessionAnalysisWorkflowManagerLAICPMS extends DialogEditor //
                     }
                     pane.setForegroundAt(sel, Color.red);
 
-                    tripoliSession.applyCorrections();
+                    tripoliSession.applyCorrections(false);
 
                     // nov 2015 to update data
                     uPbReduxFrame.updateReportTable(true);
@@ -303,7 +303,7 @@ public class SessionAnalysisWorkflowManagerLAICPMS extends DialogEditor //
         tripoliSessionRawDataView.refreshPanel(true);
 
         if (doCorrections) {
-            tripoliSession.calculateSessionFitFunctionsForPrimaryStandard();
+            tripoliSession.calculateSessionFitFunctionsForPrimaryStandard(false);
         }
 
         if (tripoliSession.getFractionationTechnique().compareTo(FractionationTechniquesEnum.DOWNHOLE) == 0) {
@@ -553,7 +553,7 @@ public class SessionAnalysisWorkflowManagerLAICPMS extends DialogEditor //
 
         // do the math
         if (!tripoliSession.isFitFunctionsUpToDate()) {
-            tripoliSession.calculateSessionFitFunctionsForPrimaryStandard();
+            tripoliSession.calculateSessionFitFunctionsForPrimaryStandard(false);
         }
         try {
             uPbReduxFrame.updateReportTable(true);
@@ -1661,13 +1661,13 @@ private void removeAllIndividualYAxisPanes_buttonActionPerformed(java.awt.event.
     }//GEN-LAST:event_setAllIndividualYAxisPanes_buttonActionPerformed
 
     private void refitInterceptSessionActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_refitInterceptSessionActionPerformed
-        tripoliSession.calculateSessionFitFunctionsForPrimaryStandard();
+        tripoliSession.calculateSessionFitFunctionsForPrimaryStandard(false);
         uPbReduxFrame.updateReportTable(true);
         tripoliSessionRawDataView.refreshPanel(true);
     }//GEN-LAST:event_refitInterceptSessionActionPerformed
 
     private void refitDownholeSessionActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_refitDownholeSessionActionPerformed
-        tripoliSession.calculateSessionFitFunctionsForPrimaryStandard();
+        tripoliSession.calculateSessionFitFunctionsForPrimaryStandard(false);
         uPbReduxFrame.updateReportTable(true);
         tripoliSessionRawDataView.refreshPanel(true);
     }//GEN-LAST:event_refitDownholeSessionActionPerformed

--- a/src/main/java/org/earthtime/UPb_Redux/dialogs/sessionManagers/SessionAnalysisWorkflowManagerLAICPMS.java
+++ b/src/main/java/org/earthtime/UPb_Redux/dialogs/sessionManagers/SessionAnalysisWorkflowManagerLAICPMS.java
@@ -1629,7 +1629,7 @@ private void removeAllIndividualYAxisPanes_buttonActionPerformed(java.awt.event.
     private void interceptCalculatePbcCorrAndRhos_button1ActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_interceptCalculatePbcCorrAndRhos_button1ActionPerformed
         // refit any  fractions not currently fitted
         try {
-            tripoliSession.interceptCalculatePbcCorrAndRhos();
+            tripoliSession.interceptCalculatePbcCorrAndRhos(false);
         } catch (Exception e) {
         }
 

--- a/src/main/java/org/earthtime/UPb_Redux/dialogs/sessionManagers/SessionAnalysisWorkflowManagerLAICPMS.java
+++ b/src/main/java/org/earthtime/UPb_Redux/dialogs/sessionManagers/SessionAnalysisWorkflowManagerLAICPMS.java
@@ -204,7 +204,7 @@ public class SessionAnalysisWorkflowManagerLAICPMS extends DialogEditor //
                     }
 
                     ((TripoliSessionRawDataView) tripoliSessionRawDataView).setSelectedSample(sample);
-                    tripoliSessionRawDataView.refreshPanel(true);
+                    tripoliSessionRawDataView.refreshPanel(true, false);
                     tripoliSessionDataView_scrollPane.revalidate();
                 }
             });
@@ -260,7 +260,7 @@ public class SessionAnalysisWorkflowManagerLAICPMS extends DialogEditor //
             rawIsotopes_radioButton.setSelected(true);
             gridPlot_radioButton.setSelected(true);
 
-            tripoliSessionRawDataView.preparePanel(true);
+            tripoliSessionRawDataView.preparePanel(true, false);
 
             // now init listeners
             ((TripoliSessionRawDataView) tripoliSessionRawDataView).initializeListeners();
@@ -292,7 +292,7 @@ public class SessionAnalysisWorkflowManagerLAICPMS extends DialogEditor //
                     tripoliSession.applyCorrections(false);
 
                     // nov 2015 to update data
-                    uPbReduxFrame.updateReportTable(true);
+                    uPbReduxFrame.updateReportTable(true, false);
                 }
             } // This method is called whenever the selected tab changes
             );
@@ -300,7 +300,7 @@ public class SessionAnalysisWorkflowManagerLAICPMS extends DialogEditor //
     }
 
     public void invokeSavedFractionationTechnique(boolean doCorrections) {
-        tripoliSessionRawDataView.refreshPanel(true);
+        tripoliSessionRawDataView.refreshPanel(true, false);
 
         if (doCorrections) {
             tripoliSession.calculateSessionFitFunctionsForPrimaryStandard(false);
@@ -312,7 +312,7 @@ public class SessionAnalysisWorkflowManagerLAICPMS extends DialogEditor //
             fractionationTechniqueTabbedPane.setSelectedIndex(1);
         }
 
-        tripoliSessionRawDataView.refreshPanel(true);
+        tripoliSessionRawDataView.refreshPanel(true, false);
     }
 
     private void setDefaultZoom() {
@@ -556,7 +556,7 @@ public class SessionAnalysisWorkflowManagerLAICPMS extends DialogEditor //
             tripoliSession.calculateSessionFitFunctionsForPrimaryStandard(false);
         }
         try {
-            uPbReduxFrame.updateReportTable(true);
+            uPbReduxFrame.updateReportTable(true, false);
         } catch (Exception e) {
         }
 
@@ -592,19 +592,19 @@ public class SessionAnalysisWorkflowManagerLAICPMS extends DialogEditor //
 
     private void gridPlotFractions() {
         ((TripoliSessionRawDataView) tripoliSessionRawDataView).setFRACTION_LAYOUT_VIEW_STYLE(FractionLayoutViewStylesEnum.GRID);
-        tripoliSessionRawDataView.preparePanel(true);
+        tripoliSessionRawDataView.preparePanel(true, false);
         tripoliSessionDataView_scrollPane.revalidate();
     }
 
     private void graphPlotFractions() {
         ((TripoliSessionRawDataView) tripoliSessionRawDataView).setFRACTION_LAYOUT_VIEW_STYLE(FractionLayoutViewStylesEnum.GRAPH);
-        tripoliSessionRawDataView.preparePanel(true);
+        tripoliSessionRawDataView.preparePanel(true, false);
         tripoliSessionDataView_scrollPane.revalidate();
     }
 
     private void overlayPlotFractions() {
         ((TripoliSessionRawDataView) tripoliSessionRawDataView).setFRACTION_LAYOUT_VIEW_STYLE(FractionLayoutViewStylesEnum.OVERLAY);
-        tripoliSessionRawDataView.refreshPanel(true);
+        tripoliSessionRawDataView.refreshPanel(true, false);
     }
 
     /**
@@ -619,7 +619,7 @@ public class SessionAnalysisWorkflowManagerLAICPMS extends DialogEditor //
         // jan 2015
        // moved to button may 2016 tripoliSession.calculateSessionFitFunctionsForPrimaryStandard();
         try {
-            uPbReduxFrame.updateReportTable(true);
+            uPbReduxFrame.updateReportTable(true, false);
         } catch (Exception e) {
         }
     }
@@ -633,7 +633,7 @@ public class SessionAnalysisWorkflowManagerLAICPMS extends DialogEditor //
         // jan 2015
         // moved to button may 2016 tripoliSession.calculateSessionFitFunctionsForPrimaryStandard();
         try {
-            uPbReduxFrame.updateReportTable(true);
+            uPbReduxFrame.updateReportTable(true, false);
         } catch (Exception e) {
         }
     }
@@ -1527,13 +1527,13 @@ public class SessionAnalysisWorkflowManagerLAICPMS extends DialogEditor //
     private void showAllFractions_radioButtonActionPerformed (java.awt.event.ActionEvent evt) {//GEN-FIRST:event_showAllFractions_radioButtonActionPerformed
         ((TripoliSessionRawDataView) tripoliSessionRawDataView).setFractionIncludedType(IncludedTypeEnum.ALL);
 //        currentFractionView = IncludedTypeEnum.ALL;
-        tripoliSessionRawDataView.refreshPanel(true);
+        tripoliSessionRawDataView.refreshPanel(true, false);
     }//GEN-LAST:event_showAllFractions_radioButtonActionPerformed
 
     private void showIncludedFractions_radioButtonActionPerformed (java.awt.event.ActionEvent evt) {//GEN-FIRST:event_showIncludedFractions_radioButtonActionPerformed
         ((TripoliSessionRawDataView) tripoliSessionRawDataView).setFractionIncludedType(IncludedTypeEnum.INCLUDED);
 //        currentFractionView = IncludedTypeEnum.INCLUDED;
-        tripoliSessionRawDataView.refreshPanel(true);
+        tripoliSessionRawDataView.refreshPanel(true, false);
 
     }//GEN-LAST:event_showIncludedFractions_radioButtonActionPerformed
 
@@ -1619,7 +1619,7 @@ private void removeAllIndividualYAxisPanes_buttonActionPerformed(java.awt.event.
         // for now we have to undo internal acquisition rejecttions allowed by intercept but not by downhole
         tripoliSession.refitAllFractionsForDownhole();
 
-        uPbReduxFrame.updateReportTable(true);
+        uPbReduxFrame.updateReportTable(true, false);
     }//GEN-LAST:event_downholeCalculateRhos_buttonActionPerformed
 
     private void downholeFitEachStandard_radioButtonActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_downholeFitEachStandard_radioButtonActionPerformed
@@ -1633,27 +1633,27 @@ private void removeAllIndividualYAxisPanes_buttonActionPerformed(java.awt.event.
         } catch (Exception e) {
         }
 
-        uPbReduxFrame.updateReportTable(true);
+        uPbReduxFrame.updateReportTable(true, false);
     }//GEN-LAST:event_interceptCalculatePbcCorrAndRhos_button1ActionPerformed
 
     private void uniformYaxisActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_uniformYaxisActionPerformed
         ((TripoliSessionRawDataView) tripoliSessionRawDataView).setSAVED_YAXIS_IS_UNIFORM(true);
-        tripoliSessionRawDataView.refreshPanel(true);
+        tripoliSessionRawDataView.refreshPanel(true, false);
     }//GEN-LAST:event_uniformYaxisActionPerformed
 
     private void independentYaxisActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_independentYaxisActionPerformed
         ((TripoliSessionRawDataView) tripoliSessionRawDataView).setSAVED_YAXIS_IS_UNIFORM(false);
-        tripoliSessionRawDataView.refreshPanel(true);
+        tripoliSessionRawDataView.refreshPanel(true, false);
     }//GEN-LAST:event_independentYaxisActionPerformed
 
     private void allDataUsedForScalingActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_allDataUsedForScalingActionPerformed
         ((TripoliSessionRawDataView) tripoliSessionRawDataView).setSAVED_DATA_USED_FOR_SCALING(IncludedTypeEnum.ALL);
-        tripoliSessionRawDataView.refreshPanel(true);
+        tripoliSessionRawDataView.refreshPanel(true, false);
     }//GEN-LAST:event_allDataUsedForScalingActionPerformed
 
     private void includedDataUsedForScalingActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_includedDataUsedForScalingActionPerformed
         ((TripoliSessionRawDataView) tripoliSessionRawDataView).setSAVED_DATA_USED_FOR_SCALING(IncludedTypeEnum.INCLUDED);
-        tripoliSessionRawDataView.refreshPanel(true);
+        tripoliSessionRawDataView.refreshPanel(true, false);
     }//GEN-LAST:event_includedDataUsedForScalingActionPerformed
 
     private void setAllIndividualYAxisPanes_buttonActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_setAllIndividualYAxisPanes_buttonActionPerformed
@@ -1662,14 +1662,14 @@ private void removeAllIndividualYAxisPanes_buttonActionPerformed(java.awt.event.
 
     private void refitInterceptSessionActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_refitInterceptSessionActionPerformed
         tripoliSession.calculateSessionFitFunctionsForPrimaryStandard(false);
-        uPbReduxFrame.updateReportTable(true);
-        tripoliSessionRawDataView.refreshPanel(true);
+        uPbReduxFrame.updateReportTable(true, false);
+        tripoliSessionRawDataView.refreshPanel(true, false);
     }//GEN-LAST:event_refitInterceptSessionActionPerformed
 
     private void refitDownholeSessionActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_refitDownholeSessionActionPerformed
         tripoliSession.calculateSessionFitFunctionsForPrimaryStandard(false);
-        uPbReduxFrame.updateReportTable(true);
-        tripoliSessionRawDataView.refreshPanel(true);
+        uPbReduxFrame.updateReportTable(true, false);
+        tripoliSessionRawDataView.refreshPanel(true, false);
     }//GEN-LAST:event_refitDownholeSessionActionPerformed
 
     // Variables declaration - do not modify//GEN-BEGIN:variables

--- a/src/main/java/org/earthtime/UPb_Redux/dialogs/sessionManagers/SessionAnalysisWorkflowManagerSHRIMP.java
+++ b/src/main/java/org/earthtime/UPb_Redux/dialogs/sessionManagers/SessionAnalysisWorkflowManagerSHRIMP.java
@@ -292,7 +292,7 @@ public class SessionAnalysisWorkflowManagerSHRIMP extends DialogEditor //
                     }
                     pane.setForegroundAt(sel, Color.red);
 
-                    tripoliSession.applyCorrections();
+                    tripoliSession.applyCorrections(false);
 
                     // nov 2015 to update data
                     uPbReduxFrame.updateReportTable(true);
@@ -306,7 +306,7 @@ public class SessionAnalysisWorkflowManagerSHRIMP extends DialogEditor //
         tripoliSessionRawDataView.refreshPanel(true);
 
         if (doCorrections) {
-            tripoliSession.calculateSessionFitFunctionsForPrimaryStandard();
+            tripoliSession.calculateSessionFitFunctionsForPrimaryStandard(false);
         }
 
         if (tripoliSession.getFractionationTechnique().compareTo(FractionationTechniquesEnum.DOWNHOLE) == 0) {
@@ -556,7 +556,7 @@ public class SessionAnalysisWorkflowManagerSHRIMP extends DialogEditor //
 
         // do the math
         if (!tripoliSession.isFitFunctionsUpToDate()) {
-            tripoliSession.calculateSessionFitFunctionsForPrimaryStandard();
+            tripoliSession.calculateSessionFitFunctionsForPrimaryStandard(false);
         }
         try {
             uPbReduxFrame.updateReportTable(true);
@@ -620,7 +620,7 @@ public class SessionAnalysisWorkflowManagerSHRIMP extends DialogEditor //
         showAllFractions_radioButton.setSelected(true);
 
         // jan 2015
-        tripoliSession.calculateSessionFitFunctionsForPrimaryStandard();
+        tripoliSession.calculateSessionFitFunctionsForPrimaryStandard(false);
         try {
             uPbReduxFrame.updateReportTable(true);
         } catch (Exception e) {
@@ -634,7 +634,7 @@ public class SessionAnalysisWorkflowManagerSHRIMP extends DialogEditor //
         ((TripoliSessionRawDataView) tripoliSessionRawDataView).includeAllAquisitions();
 
         // jan 2015
-        tripoliSession.calculateSessionFitFunctionsForPrimaryStandard();
+        tripoliSession.calculateSessionFitFunctionsForPrimaryStandard(false);
         try {
             uPbReduxFrame.updateReportTable(true);
         } catch (Exception e) {

--- a/src/main/java/org/earthtime/UPb_Redux/dialogs/sessionManagers/SessionAnalysisWorkflowManagerSHRIMP.java
+++ b/src/main/java/org/earthtime/UPb_Redux/dialogs/sessionManagers/SessionAnalysisWorkflowManagerSHRIMP.java
@@ -1612,7 +1612,7 @@ private void removeAllIndividualYAxisPanes_buttonActionPerformed(java.awt.event.
     private void interceptCalculatePbcCorrAndRhos_button1ActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_interceptCalculatePbcCorrAndRhos_button1ActionPerformed
         // refit any  fractions not currently fitted
         try {
-            tripoliSession.interceptCalculatePbcCorrAndRhos();
+            tripoliSession.interceptCalculatePbcCorrAndRhos(false);
         } catch (Exception e) {
         }
 

--- a/src/main/java/org/earthtime/UPb_Redux/dialogs/sessionManagers/SessionAnalysisWorkflowManagerSHRIMP.java
+++ b/src/main/java/org/earthtime/UPb_Redux/dialogs/sessionManagers/SessionAnalysisWorkflowManagerSHRIMP.java
@@ -207,7 +207,7 @@ public class SessionAnalysisWorkflowManagerSHRIMP extends DialogEditor //
                     }
 
                     ((TripoliSessionRawDataView) tripoliSessionRawDataView).setSelectedSample(sample);
-                    tripoliSessionRawDataView.refreshPanel(true);
+                    tripoliSessionRawDataView.refreshPanel(true, false);
                     tripoliSessionDataView_scrollPane.revalidate();
                 }
             });
@@ -263,7 +263,7 @@ public class SessionAnalysisWorkflowManagerSHRIMP extends DialogEditor //
             rawIsotopes_radioButton.setSelected(true);
             gridPlot_radioButton.setSelected(true);
 
-            tripoliSessionRawDataView.preparePanel(true);
+            tripoliSessionRawDataView.preparePanel(true, false);
 
             // now init listeners
             ((TripoliSessionRawDataView) tripoliSessionRawDataView).initializeListeners();
@@ -295,7 +295,7 @@ public class SessionAnalysisWorkflowManagerSHRIMP extends DialogEditor //
                     tripoliSession.applyCorrections(false);
 
                     // nov 2015 to update data
-                    uPbReduxFrame.updateReportTable(true);
+                    uPbReduxFrame.updateReportTable(true, false);
                 }
             } // This method is called whenever the selected tab changes
             );
@@ -303,7 +303,7 @@ public class SessionAnalysisWorkflowManagerSHRIMP extends DialogEditor //
     }
 
     public void invokeSavedFractionationTechnique(boolean doCorrections) {
-        tripoliSessionRawDataView.refreshPanel(true);
+        tripoliSessionRawDataView.refreshPanel(true, false);
 
         if (doCorrections) {
             tripoliSession.calculateSessionFitFunctionsForPrimaryStandard(false);
@@ -315,7 +315,7 @@ public class SessionAnalysisWorkflowManagerSHRIMP extends DialogEditor //
             fractionationTechniqueTabbedPane.setSelectedIndex(1);
         }
 
-        tripoliSessionRawDataView.refreshPanel(true);
+        tripoliSessionRawDataView.refreshPanel(true, false);
     }
 
     private void setDefaultZoom() {
@@ -559,7 +559,7 @@ public class SessionAnalysisWorkflowManagerSHRIMP extends DialogEditor //
             tripoliSession.calculateSessionFitFunctionsForPrimaryStandard(false);
         }
         try {
-            uPbReduxFrame.updateReportTable(true);
+            uPbReduxFrame.updateReportTable(true, false);
         } catch (Exception e) {
         }
 
@@ -595,19 +595,19 @@ public class SessionAnalysisWorkflowManagerSHRIMP extends DialogEditor //
 
     private void gridPlotFractions() {
         ((TripoliSessionRawDataView) tripoliSessionRawDataView).setFRACTION_LAYOUT_VIEW_STYLE(FractionLayoutViewStylesEnum.GRID);
-        tripoliSessionRawDataView.preparePanel(true);
+        tripoliSessionRawDataView.preparePanel(true, false);
         tripoliSessionDataView_scrollPane.revalidate();
     }
 
     private void graphPlotFractions() {
         ((TripoliSessionRawDataView) tripoliSessionRawDataView).setFRACTION_LAYOUT_VIEW_STYLE(FractionLayoutViewStylesEnum.GRAPH);
-        tripoliSessionRawDataView.preparePanel(true);
+        tripoliSessionRawDataView.preparePanel(true, false);
         tripoliSessionDataView_scrollPane.revalidate();
     }
 
     private void overlayPlotFractions() {
         ((TripoliSessionRawDataView) tripoliSessionRawDataView).setFRACTION_LAYOUT_VIEW_STYLE(FractionLayoutViewStylesEnum.OVERLAY);
-        tripoliSessionRawDataView.refreshPanel(true);
+        tripoliSessionRawDataView.refreshPanel(true, false);
     }
 
     /**
@@ -622,7 +622,7 @@ public class SessionAnalysisWorkflowManagerSHRIMP extends DialogEditor //
         // jan 2015
         tripoliSession.calculateSessionFitFunctionsForPrimaryStandard(false);
         try {
-            uPbReduxFrame.updateReportTable(true);
+            uPbReduxFrame.updateReportTable(true, false);
         } catch (Exception e) {
         }
     }
@@ -636,7 +636,7 @@ public class SessionAnalysisWorkflowManagerSHRIMP extends DialogEditor //
         // jan 2015
         tripoliSession.calculateSessionFitFunctionsForPrimaryStandard(false);
         try {
-            uPbReduxFrame.updateReportTable(true);
+            uPbReduxFrame.updateReportTable(true, false);
         } catch (Exception e) {
         }
     }
@@ -1510,13 +1510,13 @@ public class SessionAnalysisWorkflowManagerSHRIMP extends DialogEditor //
     private void showAllFractions_radioButtonActionPerformed (java.awt.event.ActionEvent evt) {//GEN-FIRST:event_showAllFractions_radioButtonActionPerformed
         ((TripoliSessionRawDataView) tripoliSessionRawDataView).setFractionIncludedType(IncludedTypeEnum.ALL);
 //        currentFractionView = IncludedTypeEnum.ALL;
-        tripoliSessionRawDataView.refreshPanel(true);
+        tripoliSessionRawDataView.refreshPanel(true, false);
     }//GEN-LAST:event_showAllFractions_radioButtonActionPerformed
 
     private void showIncludedFractions_radioButtonActionPerformed (java.awt.event.ActionEvent evt) {//GEN-FIRST:event_showIncludedFractions_radioButtonActionPerformed
         ((TripoliSessionRawDataView) tripoliSessionRawDataView).setFractionIncludedType(IncludedTypeEnum.INCLUDED);
 //        currentFractionView = IncludedTypeEnum.INCLUDED;
-        tripoliSessionRawDataView.refreshPanel(true);
+        tripoliSessionRawDataView.refreshPanel(true, false);
 
     }//GEN-LAST:event_showIncludedFractions_radioButtonActionPerformed
 
@@ -1602,7 +1602,7 @@ private void removeAllIndividualYAxisPanes_buttonActionPerformed(java.awt.event.
         // for now we have to undo internal acquisition rejecttions allowed by intercept but not by downhole
         tripoliSession.refitAllFractionsForDownhole();
 
-        uPbReduxFrame.updateReportTable(true);
+        uPbReduxFrame.updateReportTable(true, false);
     }//GEN-LAST:event_downholeCalculateRhos_buttonActionPerformed
 
     private void downholeFitEachStandard_radioButtonActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_downholeFitEachStandard_radioButtonActionPerformed
@@ -1616,27 +1616,27 @@ private void removeAllIndividualYAxisPanes_buttonActionPerformed(java.awt.event.
         } catch (Exception e) {
         }
 
-        uPbReduxFrame.updateReportTable(true);
+        uPbReduxFrame.updateReportTable(true, false);
     }//GEN-LAST:event_interceptCalculatePbcCorrAndRhos_button1ActionPerformed
 
     private void uniformYaxisActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_uniformYaxisActionPerformed
         ((TripoliSessionRawDataView) tripoliSessionRawDataView).setSAVED_YAXIS_IS_UNIFORM(true);
-        tripoliSessionRawDataView.refreshPanel(true);
+        tripoliSessionRawDataView.refreshPanel(true, false);
     }//GEN-LAST:event_uniformYaxisActionPerformed
 
     private void independentYaxisActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_independentYaxisActionPerformed
         ((TripoliSessionRawDataView) tripoliSessionRawDataView).setSAVED_YAXIS_IS_UNIFORM(false);
-        tripoliSessionRawDataView.refreshPanel(true);
+        tripoliSessionRawDataView.refreshPanel(true, false);
     }//GEN-LAST:event_independentYaxisActionPerformed
 
     private void allDataUsedForScalingActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_allDataUsedForScalingActionPerformed
         ((TripoliSessionRawDataView) tripoliSessionRawDataView).setSAVED_DATA_USED_FOR_SCALING(IncludedTypeEnum.ALL);
-        tripoliSessionRawDataView.refreshPanel(true);
+        tripoliSessionRawDataView.refreshPanel(true, false);
     }//GEN-LAST:event_allDataUsedForScalingActionPerformed
 
     private void includedDataUsedForScalingActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_includedDataUsedForScalingActionPerformed
         ((TripoliSessionRawDataView) tripoliSessionRawDataView).setSAVED_DATA_USED_FOR_SCALING(IncludedTypeEnum.INCLUDED);
-        tripoliSessionRawDataView.refreshPanel(true);
+        tripoliSessionRawDataView.refreshPanel(true, false);
     }//GEN-LAST:event_includedDataUsedForScalingActionPerformed
 
     private void setAllIndividualYAxisPanes_buttonActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_setAllIndividualYAxisPanes_buttonActionPerformed

--- a/src/main/java/org/earthtime/UPb_Redux/fractions/AnalysisFraction.java
+++ b/src/main/java/org/earthtime/UPb_Redux/fractions/AnalysisFraction.java
@@ -263,7 +263,7 @@ public class AnalysisFraction extends Fraction implements
         FractionI analysisFraction = new UPbFraction( "NONE" );
         // new AnalysisFraction("Test Sample");
 
-        UPbFractionReducer.getInstance().fullFractionReduce( (UPbFraction) analysisFraction, true );
+        UPbFractionReducer.getInstance().fullFractionReduce((UPbFraction) analysisFraction, true);
 
         FractionI myAnalysisFraction = new AnalysisFraction( analysisFraction, false );
 

--- a/src/main/java/org/earthtime/UPb_Redux/fractions/UPbReduxFractions/UPbFractionTableModel.java
+++ b/src/main/java/org/earthtime/UPb_Redux/fractions/UPbReduxFractions/UPbFractionTableModel.java
@@ -288,7 +288,7 @@ public class UPbFractionTableModel extends AbstractTableModel {
             if ((e != null)) {
                 // here we edit the fraction and refresh the table
                 parentFrame.editFraction(fraction, 8);// kwikitab
-                parentFrame.updateReportTable(false);
+                parentFrame.updateReportTable(false, false);
             }
         }
     }
@@ -332,7 +332,7 @@ public class UPbFractionTableModel extends AbstractTableModel {
                 // here we edit the aliquot and refresh the table
                 parentFrame.editAliquotByNumber(getAliquotNum());
             }
-            parentFrame.rebuildFractionDisplays(true);//changed to true may 2012false);
+            parentFrame.rebuildFractionDisplays(true, false);//changed to true may 2012false);
         }
 
         public int getMyRow() {
@@ -387,7 +387,7 @@ public class UPbFractionTableModel extends AbstractTableModel {
                 getSample().getFractions().get(myRow).//
                         setRejected(!this.isSelected());
                 
-                getParentFrame().updateReportTable( false);//.rebuildFractionDisplays(false);
+                getParentFrame().updateReportTable(false, false);//.rebuildFractionDisplays(false);
             }
 //            getParentFrame().updateReportTable( false);//.rebuildFractionDisplays(false);
 

--- a/src/main/java/org/earthtime/UPb_Redux/fractions/UPbReduxFractions/UPbLAICPMSFraction.java
+++ b/src/main/java/org/earthtime/UPb_Redux/fractions/UPbReduxFractions/UPbLAICPMSFraction.java
@@ -1365,10 +1365,11 @@ public class UPbLAICPMSFraction extends Fraction implements
     public void initializeUpperPhiMap() {
         if (upperPhiMap == null) {
             upperPhiMap = new TreeMap<>();
+
+            upperPhiMap.put("upperPhi_r206_204", 0.0);
+            upperPhiMap.put("upperPhi_r207_204", 0.0);
+            upperPhiMap.put("upperPhi_r208_204", 0.0);
         }
-        upperPhiMap.put("upperPhi_r206_204", 0.0);
-        upperPhiMap.put("upperPhi_r207_204", 0.0);
-        upperPhiMap.put("upperPhi_r208_204", 0.0);
     }
 
     /**

--- a/src/main/java/org/earthtime/UPb_Redux/reports/ReportSettings.java
+++ b/src/main/java/org/earthtime/UPb_Redux/reports/ReportSettings.java
@@ -29,7 +29,6 @@ import java.io.PrintWriter;
 import java.util.ArrayList;
 import javax.swing.JOptionPane;
 import org.earthtime.UPb_Redux.ReduxConstants;
-import org.earthtime.UPb_Redux.exceptions.BadLabDataException;
 import org.earthtime.UPb_Redux.user.UPbReduxConfigurator;
 import org.earthtime.XMLExceptions.BadOrMissingXMLSchemaException;
 import org.earthtime.dataDictionaries.ReportSpecifications;
@@ -198,10 +197,7 @@ public class ReportSettings implements
         ReportSettingsInterface reportSettingsModel = myReportSettingsModel;
 
         if (myReportSettingsModel == null) {
-            try {
-                reportSettingsModel = ReduxLabData.getInstance().getDefaultReportSettingsModelByIsotopeStyle(myReportSettingsModel.getIsotopeStyle());
-            } catch (BadLabDataException badLabDataException) {
-            }
+            reportSettingsModel = ReduxLabData.getInstance().getDefaultReportSettingsModelByIsotopeStyle(myReportSettingsModel.getIsotopeStyle());
         } else // new approach oct 2014
         {   // this provides for seamless updates to reportsettings implementation
             String myReportSettingsName = myReportSettingsModel.getName();

--- a/src/main/java/org/earthtime/UPb_Redux/samples/Sample.java
+++ b/src/main/java/org/earthtime/UPb_Redux/samples/Sample.java
@@ -217,8 +217,7 @@ public class Sample implements
      * BadLabDataException
      */
     public Sample(
-            String sampleName, String sampleType, String sampleAnalysisType, ANALYSIS_PURPOSE defaultAnalysisPurpose, String isotopeStyle)
-            throws BadLabDataException {
+            String sampleName, String sampleType, String sampleAnalysisType, ANALYSIS_PURPOSE defaultAnalysisPurpose, String isotopeStyle) {
         this.sampleName = sampleName;
         this.sampleType = sampleType;
         this.sampleAnalysisType = sampleAnalysisType;
@@ -307,10 +306,8 @@ public class Sample implements
 
         if (!isSampleTypeLegacy()) {
             SampleInterface.registerSampleWithLabData(this);
-        } else {
-
-            // dec 2012
-            if (getFractions().size() > 0) {
+        } else // dec 2012
+         if (getFractions().size() > 0) {
                 // June 2010 fix for old legacy fractions
                 Vector<ETFractionInterface> convertedF = new Vector<>();
                 for (ETFractionInterface f : getFractions()) {
@@ -352,19 +349,16 @@ public class Sample implements
                 // modified logic oct 2010 ... sample manager allows reset
                 // additional test for missing T-W rho calculation
                 // use first fraction to test for rho < -1 or 0  (both used as default for non-existent rho)
-                double twRho = //
-                        getFractions().get(0).//
+                double twRho
+                        = getFractions().get(0).//
                         getRadiogenicIsotopeRatioByName("rhoR207_206r__r238_206r").getValue().doubleValue();
-                if ( /*
-                         * (twRho == 0) ||
-                         */(twRho < -1.0)) {
+                if ((twRho < -1.0)) {
                     for (ETFractionInterface f : getFractions()) {
                         f.getRadiogenicIsotopeRatioByName("rhoR207_206r__r238_206r")//
                                 .setValue(BigDecimal.ZERO);
                     }
                 }
             }
-        }
 
         // June 2010 be sure lab name is updated to labdata labname when used in reduction
         if (isSampleTypeAnalysis() || isSampleTypeLiveWorkflow() || isSampleTypeLegacy()) {
@@ -382,7 +376,7 @@ public class Sample implements
     public void addDefaultUPbFractionToAliquot(int aliquotNumber)
             throws BadLabDataException {
         FractionI defFraction = new UPbFraction("NONE");
-        ((ETFractionInterface) defFraction).setAliquotNumber(aliquotNumber);
+        defFraction.setAliquotNumber(aliquotNumber);
 
         initializeDefaultUPbFraction(defFraction);
 
@@ -509,7 +503,7 @@ public class Sample implements
                 }
                 addFraction(fractionFromFile);
             } else {
-                System.out.println("Existing Fraction = " + existingFraction.getFractionID() + " updating type = " + ((UPbFraction) fractionFromFile).getRatioType());
+                System.out.println("Existing Fraction = " + existingFraction.getFractionID() + " updating type = " + fractionFromFile.getRatioType());
                 boolean didUpdate
                         = ((UPbFraction) existingFraction).updateUPbFraction(fractionFromFile, isFractionDataOverriddenOnImport());
 
@@ -591,14 +585,9 @@ public class Sample implements
 
         File sampleFolder = new File(sample.getReduxSampleFilePath()).getParentFile();
 
-        File[] aliquotFolders = sampleFolder.listFiles(new java.io.FileFilter() {
-            @Override
-            public boolean accept(File pathname) {
-                return (pathname.isDirectory()
-                        && !pathname.isHidden()//
-                        && !pathname.getName().equalsIgnoreCase(ReduxConstants.NAME_OF_SAMPLEMETADATA_FOLDER));
-            }
-        });
+        File[] aliquotFolders = sampleFolder.listFiles((File pathname) -> (pathname.isDirectory()
+                && !pathname.isHidden()//
+                && !pathname.getName().equalsIgnoreCase(ReduxConstants.NAME_OF_SAMPLEMETADATA_FOLDER)));
 
         if (aliquotFolders.length == 0) {
             throw new ETException(null,
@@ -611,21 +600,18 @@ public class Sample implements
             for (final File aliquotFolder : aliquotFolders) {
 
                 // take the first prisoner
-                aliquotFractionFiles = aliquotFolder.listFiles(new java.io.FileFilter() {
-                    // 20 second cushion
-                    @Override
-                    public boolean accept(File file) {
-                        // want .xml files and only freshones in live-update, but all of them in auto-update
-                        boolean isXML = file.getName().toLowerCase().endsWith(".xml");
-
-                        if (getSampleType().equalsIgnoreCase(SampleTypesEnum.LIVEWORKFLOW.getName())) {
-                            return ((file.lastModified() >= (aliquotFolder.lastModified() - 20000l))
-                                    && isXML);
-                        } else {
-                            return isXML;
-                        }
+                aliquotFractionFiles = aliquotFolder.listFiles((File file) -> {
+                    // want .xml files and only freshones in live-update, but all of them in auto-update
+                    boolean isXML = file.getName().toLowerCase().endsWith(".xml");
+                    
+                    if (getSampleType().equalsIgnoreCase(SampleTypesEnum.LIVEWORKFLOW.getName())) {
+                        return ((file.lastModified() >= (aliquotFolder.lastModified() - 20000l))
+                                && isXML);
+                    } else {
+                        return isXML;
                     }
-                });
+                } // 20 second cushion
+                );
 
                 // assume xml files are in good shape with doValidate = false
                 updateSampleAliquot(aliquotFolder, aliquotFractionFiles, false, myFractionEditor);
@@ -671,7 +657,7 @@ public class Sample implements
                             setAutomaticDataUpdateMode(true);
 
                     ((ReduxAliquotInterface) getAliquotByNumber(aliquotNumber)).//
-                            reduceData();
+                            reduceData(false);
 
                     if (myFractionEditor != null) {
                         if (doRestoreAutoUranium) {
@@ -680,7 +666,7 @@ public class Sample implements
                         ((UPbFractionEditorDialog) myFractionEditor).InitializeFractionData(savedCurrentFraction);
 
                         // intentional static call for now
-                        UPbFractionReducer.getInstance().fullFractionReduce((FractionI)savedCurrentFraction, true);
+                        UPbFractionReducer.getInstance().fullFractionReduce((FractionI) savedCurrentFraction, true);
 
                         ((UPbFractionEditorDialog) myFractionEditor).reInitializeKwikiTab(savedCurrentFraction);
                     }
@@ -737,7 +723,7 @@ public class Sample implements
                 importAliquotFolder(fractions, aliquotNumber, false); // jan 2016true);
 
                 ((ReduxAliquotInterface) getAliquotByNumber(aliquotNumber)).//
-                        reduceData();
+                        reduceData(false);
             }
 
         }
@@ -760,7 +746,7 @@ public class Sample implements
      */
     @Override
     public String getSampleName() {
-        if (sampleName == null){
+        if (sampleName == null) {
             sampleName = "NONE";
         }
         return sampleName;
@@ -1585,10 +1571,7 @@ public class Sample implements
      */
     @Override
     public void restoreDefaultReportSettingsModel() {
-        try {
-            setReportSettingsModel(ReduxLabData.getInstance().getDefaultReportSettingsModelByIsotopeStyle((getIsotopeStyle() == null) ? "UPb" : getIsotopeStyle()));
-        } catch (BadLabDataException badLabDataException) {
-        }
+        setReportSettingsModel(ReduxLabData.getInstance().getDefaultReportSettingsModelByIsotopeStyle((getIsotopeStyle() == null) ? "UPb" : getIsotopeStyle()));
     }
 
     // used for deserialization to enforce backwards compatibility

--- a/src/main/java/org/earthtime/UTh_Redux/aliquots/UThReduxAliquot.java
+++ b/src/main/java/org/earthtime/UTh_Redux/aliquots/UThReduxAliquot.java
@@ -341,9 +341,10 @@ public class UThReduxAliquot implements //
 
     /**
      *
+     * @param inLiveMode the value of inLiveMode
      */
     @Override
-    public void reduceData() {
+    public void reduceData(boolean inLiveMode) {
         //TODO: Reduce Useries
     }
 }

--- a/src/main/java/org/earthtime/UTh_Redux/samples/SampleUTh.java
+++ b/src/main/java/org/earthtime/UTh_Redux/samples/SampleUTh.java
@@ -570,10 +570,7 @@ public class SampleUTh extends ETSample implements
      */
     @Override
     public void restoreDefaultReportSettingsModel() {
-        try {
-            setReportSettingsModel(ReduxLabData.getInstance().getDefaultReportSettingsModelByIsotopeStyle(getIsotopeStyle()));
-        } catch (BadLabDataException badLabDataException) {
-        }
+        setReportSettingsModel(ReduxLabData.getInstance().getDefaultReportSettingsModelByIsotopeStyle(getIsotopeStyle()));
     }
 
     /**
@@ -586,6 +583,5 @@ public class SampleUTh extends ETSample implements
         }
         return isotopeStyle;
     }
-
 
 }

--- a/src/main/java/org/earthtime/aliquots/ReduxAliquotInterface.java
+++ b/src/main/java/org/earthtime/aliquots/ReduxAliquotInterface.java
@@ -126,5 +126,9 @@ public interface ReduxAliquotInterface {
         return retVal;
     }
 
-    public void reduceData();
+    /**
+     *
+     * @param inLiveMode the value of inLiveMode
+     */
+    public void reduceData(boolean inLiveMode);
 }

--- a/src/main/java/org/earthtime/archivingTools/GeochronAliquotManager.java
+++ b/src/main/java/org/earthtime/archivingTools/GeochronAliquotManager.java
@@ -593,7 +593,7 @@ public class GeochronAliquotManager extends JPanel {
 
         concordiaGraphPanel.setShowTightToEdges(true);
 
-        concordiaGraphPanel.refreshPanel(true);
+        concordiaGraphPanel.refreshPanel(true, false);
 
         concordiaGraphPanel.setShowTightToEdges(false);
 

--- a/src/main/java/org/earthtime/projects/Project.java
+++ b/src/main/java/org/earthtime/projects/Project.java
@@ -3,7 +3,7 @@
  *
  *
  *
- * Copyright 2006-2015 James F. Bowring and www.Earth-Time.org
+ * Copyright 2006-2016 James F. Bowring and www.Earth-Time.org
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.

--- a/src/main/java/org/earthtime/projects/Project.java
+++ b/src/main/java/org/earthtime/projects/Project.java
@@ -37,7 +37,6 @@ import org.earthtime.Tripoli.samples.AbstractTripoliSample;
 import org.earthtime.Tripoli.sessions.TripoliSessionInterface;
 import org.earthtime.UPb_Redux.ReduxConstants;
 import org.earthtime.UPb_Redux.aliquots.UPbReduxAliquot;
-import org.earthtime.UPb_Redux.exceptions.BadLabDataException;
 import org.earthtime.UPb_Redux.filters.ReduxFileFilter;
 import org.earthtime.UPb_Redux.fractions.FractionI;
 import org.earthtime.UPb_Redux.fractions.UPbReduxFractions.UPbFractionI;
@@ -195,26 +194,33 @@ public class Project implements
         // walk the tripolisamples and convert to samples
         // Redux will end up with a set of aliquots (aka compiled sample) each named for the sample (1-to-1)
         // and a set of fractions each associated with an aliquot
-        projectSamples = new ArrayList<>();
 
         // make a super-sample or projectsample to leverage existing Redux
-        try {
-            compiledSuperSample = new Sample( //
-                    projectName, //
-                    SampleTypesEnum.PROJECT.getName(), //
-                    SampleAnalysisTypesEnum.TRIPOLIZED.getName(), //
-                    ReduxConstants.ANALYSIS_PURPOSE.DetritalSpectrum, "UPb");
-        } catch (BadLabDataException badLabDataException) {
+        if (compiledSuperSample == null) {
+                compiledSuperSample = new Sample( //
+                        projectName, //
+                        SampleTypesEnum.PROJECT.getName(), //
+                        SampleAnalysisTypesEnum.TRIPOLIZED.getName(), //
+                        ReduxConstants.ANALYSIS_PURPOSE.DetritalSpectrum, "UPb");
         }
 
-        
         ArrayList<AbstractTripoliSample> tripoliSamples = tripoliSession.getTripoliSamples();
         for (AbstractTripoliSample tripoliSample : tripoliSamples) {
             // check for primary standard and leave it out
             if (true) {//oct 2014 want to include standards now (!tripoliSample.isPrimaryStandard()) {
-//            if (!tripoliSample.isPrimaryStandard()) {
-                SampleInterface sample;
-                try {
+
+                // june 2016
+                // determine if sample already processed
+                SampleInterface sample = null;
+                AliquotInterface aliquot = null;
+                for (int i = 0; i < projectSamples.size(); i++) {
+                    if (projectSamples.get(i).getSampleName().equalsIgnoreCase(tripoliSample.getSampleName())) {
+                        sample = projectSamples.get(i);
+                        aliquot = sample.getAliquots().get(0);
+                        break;
+                    }
+                }
+                if (sample == null) {
                     sample = new Sample( //
                             tripoliSample.getSampleName(), //
                             SampleTypesEnum.ANALYSIS.getName(), //
@@ -223,22 +229,33 @@ public class Project implements
 
                     projectSamples.add(sample);
 
-                    AliquotInterface aliquot = sample.addNewAliquot(tripoliSample.getSampleName());
-                    System.out.println("New Aliquot is # " + ((UPbReduxAliquot) aliquot).getAliquotNumber() + " = " + aliquot.getAliquotName());
+                    try {
+                        aliquot = sample.addNewAliquot(tripoliSample.getSampleName());
+                        aliquot.setAnalysisPurpose(analysisPurpose);
+                        // TODO: Enum of inst methods
+                        aliquot.setAliquotInstrumentalMethod(DataDictionary.AliquotInstrumentalMethod[5]);
+                    } catch (ETException eTException) {
+                    }
 
-                    SortedSet<TripoliFraction> tripoliSampleFractions = tripoliSample.getSampleFractions();
-                    for (Iterator<TripoliFraction> it = tripoliSampleFractions.iterator(); it.hasNext();) {
-                        TripoliFraction tf = it.next();
-//                        System.out.println("Processing tripoli fraction " + tf.getFractionID());
+                    System.out.println("New Aliquot is # " + ((UPbReduxAliquot) aliquot).getAliquotNumber() + " = " + aliquot.getAliquotName());
+                }
+
+                SortedSet<TripoliFraction> tripoliSampleFractions = tripoliSample.getSampleFractions();
+                for (Iterator<TripoliFraction> it = tripoliSampleFractions.iterator(); it.hasNext();) {
+                    TripoliFraction tf = it.next();
+
+                    // june 2016
+                    // determine if fraction already exists
+                    if (!sample.containsFractionByName(tf.getFractionID())) {
 
                         // feb 2016
                         FractionI reduxVersionTripolizedFraction = null;
-                        if (sampleAnalysisType.compareTo(SampleAnalysisTypesEnum.LAICPMS) ==0 ) {
+                        if (sampleAnalysisType.compareTo(SampleAnalysisTypesEnum.LAICPMS) == 0) {
                             reduxVersionTripolizedFraction = new UPbLAICPMSFraction(tf.getFractionID());
-                        }else if (sampleAnalysisType.compareTo(SampleAnalysisTypesEnum.SHRIMP) ==0 ) {
+                        } else if (sampleAnalysisType.compareTo(SampleAnalysisTypesEnum.SHRIMP) == 0) {
                             reduxVersionTripolizedFraction = new UPbSHRIMPFraction(tf.getFractionID());
                         }
-                        
+
                         reduxVersionTripolizedFraction.setSampleName(tripoliSample.getSampleName());
                         // add to tripoli fraction so its UPbFraction can be contiunously updated
                         tf.setuPbFraction(reduxVersionTripolizedFraction);
@@ -251,19 +268,12 @@ public class Project implements
                         // feb 2015 in prep for export
                         ((ReduxAliquotInterface) aliquot).getAliquotFractions().add(reduxVersionTripolizedFraction);
                     }
-
-                    // this forces aliquot fraction population
-                    SampleInterface.copyAliquotIntoSample(compiledSuperSample, sample.getAliquotByName(aliquot.getAliquotName()), new UPbReduxAliquot());
-
-                    aliquot.setAnalysisPurpose(analysisPurpose);
-                    // TODO: Enum of inst methods
-                    aliquot.setAliquotInstrumentalMethod(DataDictionary.AliquotInstrumentalMethod[5]);
-
-                } catch (BadLabDataException badLabDataException) {
-                } catch (ETException eTException) {
-                    System.out.println("Project.java line 254 " + eTException.getMessage());
                 }
-            }
+
+                // this forces aliquot fraction population
+                SampleInterface.copyAliquotIntoSample(compiledSuperSample, sample.getAliquotByName(aliquot.getAliquotName()), new UPbReduxAliquot());
+
+            }// if true
         }
 
         // first pass without any user interaction

--- a/src/main/java/org/earthtime/projects/ProjectSample.java
+++ b/src/main/java/org/earthtime/projects/ProjectSample.java
@@ -457,10 +457,7 @@ public class ProjectSample implements//
      */
     @Override
     public void restoreDefaultReportSettingsModel() {
-        try {
-            setReportSettingsModel(ReduxLabData.getInstance().getDefaultReportSettingsModelByIsotopeStyle(getIsotopeStyle()));
-        } catch (BadLabDataException badLabDataException) {
-        }
+        setReportSettingsModel(ReduxLabData.getInstance().getDefaultReportSettingsModelByIsotopeStyle(getIsotopeStyle()));
     }
 
     /**

--- a/src/main/java/org/earthtime/reduxLabData/ReduxLabData.java
+++ b/src/main/java/org/earthtime/reduxLabData/ReduxLabData.java
@@ -1467,7 +1467,7 @@ public final class ReduxLabData implements Serializable {
      * @throws org.earthtime.UPb_Redux.exceptions.BadLabDataException
      */
     public ReportSettingsInterface getDefaultReportSettingsModelByIsotopeStyle(String isotopeStyle)
-            throws BadLabDataException {
+             {
         if (defaultReportSettingsModel == null) {
             defaultReportSettingsModel = ReportSettings.EARTHTIMEReportSettingsUPb();
             addReportSettingsModel(defaultReportSettingsModel);

--- a/src/main/java/org/earthtime/reportViews/ReportAliquotFractionsView.java
+++ b/src/main/java/org/earthtime/reportViews/ReportAliquotFractionsView.java
@@ -2,7 +2,7 @@
  * ReportAliquotFractionsView.java
  *
  *
- * Copyright 2006-2015 James F. Bowring and www.Earth-Time.org
+ * Copyright 2006-2016 James F. Bowring and www.Earth-Time.org
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -179,10 +179,11 @@ public class ReportAliquotFractionsView extends JLayeredPane implements ReportUp
     /**
      *
      * @param performReduction
+     * @param inLiveMode the value of inLiveMode
      */
     @Override
-    public void updateReportTable(boolean performReduction) {
-        parentFrame.updateReportTable(performReduction);
+    public void updateReportTable(boolean performReduction, boolean inLiveMode) {
+        parentFrame.updateReportTable(performReduction, inLiveMode);
         prepareReportFractionsArrayForDisplay();
         reSizeSortButtons();
         repaint();
@@ -1082,7 +1083,7 @@ public class ReportAliquotFractionsView extends JLayeredPane implements ReportUp
                                 notesDialog.setVisible(true);
                             } else {
                                 parentFrame.editFraction(((ETFractionInterface) verticalPixelFractionMap.get(row).rowObject), 8);// kwikitab
-                                updateReportTable(false);
+                                updateReportTable(false, false);
                             }
                         } else {
                             boolean isRejected = !((ETFractionInterface) verticalPixelFractionMap.get(row).rowObject).isRejected();
@@ -1092,7 +1093,7 @@ public class ReportAliquotFractionsView extends JLayeredPane implements ReportUp
                                 ((UPbFractionI) verticalPixelFractionMap.get(row).rowObject).getTripoliFraction().setIncluded(!isRejected);
                             } catch (Exception noTF) {
                             }
-                            parent.updateReportTable(false);
+                            parent.updateReportTable(false, false);
                         }
                     }
 
@@ -1102,7 +1103,7 @@ public class ReportAliquotFractionsView extends JLayeredPane implements ReportUp
                             parentFrame.editAliquotByProjectType(((AliquotInterface) verticalPixelFractionMap.get(row).rowObject));
                         } else {
                             AliquotInterface.toggleAliquotFractionsRejectedStatus(((ReduxAliquotInterface) verticalPixelFractionMap.get(row).rowObject));
-                            parent.updateReportTable(false);
+                            parent.updateReportTable(false, false);
                         }
 
                     }

--- a/src/main/java/org/earthtime/reportViews/ReportPainterI.java
+++ b/src/main/java/org/earthtime/reportViews/ReportPainterI.java
@@ -2,7 +2,7 @@
  * ReportPainterI.java
  *
  *
- * Copyright 2006-2015 James F. Bowring and www.Earth-Time.org
+ * Copyright 2006-2016 James F. Bowring and www.Earth-Time.org
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -30,13 +30,14 @@ public interface ReportPainterI {
     /**
      * 
      */
-    public void loadAndShowReportTableData ();// String[][] reportFractions );
+    public void loadAndShowReportTableData ();
     
     /**
      * 
      * @param performReduction
+     * @param inLiveMode the value of inLiveMode
      */
-    public void rebuildFractionDisplays ( boolean performReduction );
+    public void rebuildFractionDisplays ( boolean performReduction, boolean inLiveMode);
     
     /**
      *

--- a/src/main/java/org/earthtime/reportViews/ReportUpdaterInterface.java
+++ b/src/main/java/org/earthtime/reportViews/ReportUpdaterInterface.java
@@ -2,7 +2,7 @@
  * ReportUpdaterInterface.java
  *
  *
- * Copyright 2006-2015 James F. Bowring and www.Earth-Time.org
+ * Copyright 2006-2016 James F. Bowring and www.Earth-Time.org
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -27,6 +27,7 @@ public interface ReportUpdaterInterface {
     /**
      *
      * @param performReduction
+     * @param inLiveMode the value of inLiveMode
      */
-    public void updateReportTable( boolean performReduction);
+    public void updateReportTable( boolean performReduction, boolean inLiveMode);
 }

--- a/src/main/java/org/earthtime/reports/ReportColumnInterface.java
+++ b/src/main/java/org/earthtime/reports/ReportColumnInterface.java
@@ -411,7 +411,7 @@ public interface ReportColumnInterface extends Comparable<ReportColumnInterface>
                                 // may 2013 for tiny numbers due to below detection
                                 retVal[0] = " bd "; // below detection
 
-                            } else if (vm.hasZeroValue()) {//oct 2014
+                            } else if (vm.hasZeroValue()  && !getRetrieveVariableName().startsWith("rhoR")) {//oct 2014 // added rho June 2016
                                 retVal[0] = " - ";
 
                             } else if (isNumeric) {

--- a/src/test/java/org/earthtime/UPb_Redux/fractions/AnalysisFractionTest.java
+++ b/src/test/java/org/earthtime/UPb_Redux/fractions/AnalysisFractionTest.java
@@ -40,7 +40,7 @@ public class AnalysisFractionTest {
         FractionI analysisFraction = new UPbFraction( "NONE" );
         // new AnalysisFraction("Test Sample");
 
-        UPbFractionReducer.getInstance().fullFractionReduce( (UPbFraction) analysisFraction, true );
+        UPbFractionReducer.getInstance().fullFractionReduce((UPbFraction) analysisFraction, true);
 
         FractionI myAnalysisFraction = new AnalysisFraction( analysisFraction, false );
 


### PR DESCRIPTION
This pull request fixes #84 and fixes #86 and likely obviates the need for addressing issue #85.  Extensive tuning of the live data mode for LAICPMS provides a dramatic speedup of live data acquisitions for the ElementII at LaserChron.  These features will be extended to other live workflows as they are requested.  A consequence of the speedup is that session-wide fitting of unknowns is suspended until the user presses the "Update Sessions" button.  It is anticipated that feedback from users at LaserChron will suggest additional refinements.