### PR TITLE
Improvements for LAICPMS and Legacy UPb

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
     <groupId>org.cirdles</groupId>
     <artifactId>ET_Redux</artifactId>
     <name>ET_Redux</name>
-    <version>3.6.6</version>
+    <version>3.6.7</version>
     <description>Successor to U-Pb_Redux</description>
     <url>https://cirdles.org</url>
     <inceptionYear>2006</inceptionYear>

--- a/src/main/java/org/earthtime/ETReduxFrame.form
+++ b/src/main/java/org/earthtime/ETReduxFrame.form
@@ -398,7 +398,6 @@
         <Menu class="javax.swing.JMenu" name="aliquotsMenu">
           <Properties>
             <Property name="text" type="java.lang.String" value="Aliquots"/>
-            <Property name="enabled" type="boolean" value="false"/>
           </Properties>
         </Menu>
         <Menu class="javax.swing.JMenu" name="fractionsMenu">
@@ -409,7 +408,6 @@
             <MenuItem class="javax.swing.JMenuItem" name="selectAllFractions_menuItem">
               <Properties>
                 <Property name="text" type="java.lang.String" value="Select All Fractions"/>
-                <Property name="enabled" type="boolean" value="false"/>
               </Properties>
               <Events>
                 <EventHandler event="actionPerformed" listener="java.awt.event.ActionListener" parameters="java.awt.event.ActionEvent" handler="selectAllFractions_menuItemActionPerformed"/>
@@ -418,7 +416,6 @@
             <MenuItem class="javax.swing.JMenuItem" name="deSelectAllFractions_menuItem">
               <Properties>
                 <Property name="text" type="java.lang.String" value="De-select All Fractions"/>
-                <Property name="enabled" type="boolean" value="false"/>
               </Properties>
               <Events>
                 <EventHandler event="actionPerformed" listener="java.awt.event.ActionListener" parameters="java.awt.event.ActionEvent" handler="deSelectAllFractions_menuItemActionPerformed"/>
@@ -840,6 +837,9 @@
       <Color blue="fa" green="f2" red="ed" type="rgb"/>
     </Property>
     <Property name="locationByPlatform" type="boolean" value="true"/>
+    <Property name="preferredSize" type="java.awt.Dimension" editor="org.netbeans.beaninfo.editors.DimensionEditor">
+      <Dimension value="[1160, 750]"/>
+    </Property>
   </Properties>
   <SyntheticProperties>
     <SyntheticProperty name="menuBar" type="java.lang.String" value="mainMenuBar"/>

--- a/src/main/java/org/earthtime/ETReduxFrame.java
+++ b/src/main/java/org/earthtime/ETReduxFrame.java
@@ -1012,8 +1012,7 @@ public class ETReduxFrame extends javax.swing.JFrame implements ReportPainterI, 
 
             // set up a new empty sample based on sampleType
             theSample
-                    = //
-                    new Sample("NONE", sampleType, sampleAnalysisType, myState.getReduxPreferences().getDefaultSampleAnalysisPurpose(), isotopeStyle);
+                    = new Sample("NONE", sampleType, sampleAnalysisType, myState.getReduxPreferences().getDefaultSampleAnalysisPurpose(), isotopeStyle);
             SampleInterface.specializeNewSample(theSample);
 
             // manageTheSample sets up the correct form and returns whether it was successful
@@ -1482,7 +1481,6 @@ public class ETReduxFrame extends javax.swing.JFrame implements ReportPainterI, 
             ((SampleDateInterpretationsManager) sampleDateInterpDialog).setSample(theSample);
         }
 
-//      updated with rescaling april 2016
         try {
             ((SampleDateInterpretationsManager) sampleDateInterpDialog).refreshSampleDateInterpretations(false, inLiveMode);
         } catch (Exception e) {

--- a/src/main/java/org/earthtime/ETReduxFrame.java
+++ b/src/main/java/org/earthtime/ETReduxFrame.java
@@ -1398,33 +1398,22 @@ public class ETReduxFrame extends javax.swing.JFrame implements ReportPainterI, 
 
     private void buildAliquotsMenu() {
         // aug 2010 provide aliquot management menu
+        boolean doActivate = (theSample.getActiveAliquots().size() > 0);
         aliquotsMenu.removeAll();
-        aliquotsMenu.setEnabled(false);
-        fractionsMenu.setEnabled(false);
-        selectAllFractions_menuItem.setEnabled(false);
-        deSelectAllFractions_menuItem.setEnabled(false);
+        aliquotsMenu.setEnabled(doActivate);
+        fractionsMenu.setEnabled(doActivate);
+        selectAllFractions_menuItem.setEnabled(doActivate);
+        deSelectAllFractions_menuItem.setEnabled(doActivate);
 
-        theSample.getActiveAliquots().stream().map((a) -> {
+        theSample.getActiveAliquots().stream().forEach((a) -> {
             JMenuItem menuItem = aliquotsMenu.add(new JMenuItem(a.getAliquotName()));
-            menuItem.addActionListener(new java.awt.event.ActionListener() {
-                @Override
-                public void actionPerformed(java.awt.event.ActionEvent evt) {
-                    editAliquotByNumber(((ReduxAliquotInterface) a).getAliquotNumber());
-                }
+            menuItem.addActionListener((java.awt.event.ActionEvent evt) -> {
+                editAliquotByNumber(((ReduxAliquotInterface) a).getAliquotNumber());
             });
-            return a;
-        }).map((_item) -> {
-            aliquotsMenu.setEnabled(true);
-            return _item;
-        }).map((_item) -> {
-            fractionsMenu.setEnabled(true);
-            return _item;
-        }).map((_item) -> {
-            selectAllFractions_menuItem.setEnabled(true);
-            return _item;
-        }).forEach((_item) -> {
-            deSelectAllFractions_menuItem.setEnabled(true);
         });
+
+        //forces menu update
+        pack();
     }
 
     private void customizeReduxSkin() {
@@ -2023,6 +2012,7 @@ public class ETReduxFrame extends javax.swing.JFrame implements ReportPainterI, 
         setTitle("EARTHTIME Redux");
         setBackground(new java.awt.Color(237, 242, 250));
         setLocationByPlatform(true);
+        setPreferredSize(new java.awt.Dimension(1160, 750));
         addComponentListener(new java.awt.event.ComponentAdapter() {
             public void componentResized(java.awt.event.ComponentEvent evt) {
                 formComponentResized(evt);
@@ -2589,13 +2579,11 @@ public class ETReduxFrame extends javax.swing.JFrame implements ReportPainterI, 
         mainMenuBar.add(sampleFileMenu);
 
         aliquotsMenu.setText("Aliquots");
-        aliquotsMenu.setEnabled(false);
         mainMenuBar.add(aliquotsMenu);
 
         fractionsMenu.setText("Fractions");
 
         selectAllFractions_menuItem.setText("Select All Fractions");
-        selectAllFractions_menuItem.setEnabled(false);
         selectAllFractions_menuItem.addActionListener(new java.awt.event.ActionListener() {
             public void actionPerformed(java.awt.event.ActionEvent evt) {
                 selectAllFractions_menuItemActionPerformed(evt);
@@ -2604,7 +2592,6 @@ public class ETReduxFrame extends javax.swing.JFrame implements ReportPainterI, 
         fractionsMenu.add(selectAllFractions_menuItem);
 
         deSelectAllFractions_menuItem.setText("De-select All Fractions");
-        deSelectAllFractions_menuItem.setEnabled(false);
         deSelectAllFractions_menuItem.addActionListener(new java.awt.event.ActionListener() {
             public void actionPerformed(java.awt.event.ActionEvent evt) {
                 deSelectAllFractions_menuItemActionPerformed(evt);
@@ -3823,7 +3810,8 @@ private void startStopLiveUpdate_buttonActionPerformed(java.awt.event.ActionEven
      * @param aliquot
      */
     public void editAliquotByProjectType(AliquotInterface aliquot) {
-        if (theSample.isSampleTypeProject() && !theSample.getSampleAnalysisType().equalsIgnoreCase("TRIPOLIZED")) {
+        if (theSample.isSampleTypeProject() //
+                && !theSample.getSampleAnalysisType().equalsIgnoreCase("TRIPOLIZED")) {
             // Project has a compiledSuperSample made up of actual projectSamples
             // we need the actual sample associated with this aliquot
             // this aliquot is a copy for compiled super sample and we need

--- a/src/main/java/org/earthtime/Tripoli/dataModels/RawRatioDataModel.java
+++ b/src/main/java/org/earthtime/Tripoli/dataModels/RawRatioDataModel.java
@@ -1151,6 +1151,7 @@ public class RawRatioDataModel //
     /**
      * @return the dataActiveMap
      */
+    @Override
     public boolean[] getDataActiveMap() {
         return dataActiveMap;
     }

--- a/src/main/java/org/earthtime/Tripoli/dataViews/simpleViews/usedByReflection/RawRatioDataView.java
+++ b/src/main/java/org/earthtime/Tripoli/dataViews/simpleViews/usedByReflection/RawRatioDataView.java
@@ -133,7 +133,8 @@ public class RawRatioDataView extends AbstractRawDataView {
                 boolean showAll = showIncludedDataPoints.equals(IncludedTypeEnum.ALL);
                 // rework logic April 2016 
                 for (int i = 0; i < myOnPeakData.length; i++) {
-                    if ((Double.isFinite(myOnPeakData[i])) && (showAll || myDataActiveMap[i])) {
+                    if ((Double.isFinite(myOnPeakData[i])) //
+                            && (showAll || myDataActiveMap[i])) {
                         minY = Math.min(minY, myOnPeakData[i]);
                         maxY = Math.max(maxY, myOnPeakData[i]);
                     }

--- a/src/main/java/org/earthtime/UPb_Redux/dateInterpretation/DateProbabilityDensityPanel.java
+++ b/src/main/java/org/earthtime/UPb_Redux/dateInterpretation/DateProbabilityDensityPanel.java
@@ -500,7 +500,7 @@ public class DateProbabilityDensityPanel extends JLayeredPane
         double dataRange = 0;
         try {
             dataRange = ((visibleSample.get(visibleSample.size() - 1)) - visibleSample.get(0));
-            dataRange *= 1.05;
+            dataRange +=100; // oct 2016 changed due to bug found by Matt Rioux *= 1.05;
         } catch (Exception e) {
         }
 

--- a/src/main/java/org/earthtime/UPb_Redux/dateInterpretation/SampleTreeAnalysisMode.java
+++ b/src/main/java/org/earthtime/UPb_Redux/dateInterpretation/SampleTreeAnalysisMode.java
@@ -58,7 +58,7 @@ public class SampleTreeAnalysisMode extends JTree implements SampleTreeI {
     private SampleInterface sample;
     private SampleTreeChangeI sampleTreeChange;
     private Object lastNodeSelected;
-    private static transient boolean suppressSelectionEvent = false;
+    private static boolean sortByDateAsc = false;
 
     /**
      * Creates a new instance of SampleTreeAnalysisMode
@@ -113,9 +113,16 @@ public class SampleTreeAnalysisMode extends JTree implements SampleTreeI {
             ((DefaultMutableTreeNode) getModel().getRoot()).add(aliquotNode);
 
             // get a master vector of active fraction names
-            Vector<String> activeFractionIDs
-                    = ((ReduxAliquotInterface) tempAliquot).//
-                    getAliquotFractionIDs();
+            Vector<String> activeFractionIDs = new Vector<>();
+            if (sortByDateAsc) {
+                activeFractionIDs
+                        = ((ReduxAliquotInterface) tempAliquot).//
+                        getAliquotFractionIDsSortedByDateAsc();
+            } else {
+                activeFractionIDs
+                        = ((ReduxAliquotInterface) tempAliquot).//
+                        getAliquotFractionIDs();
+            }
 
             // now load the sample date interpretations
             for (int index = 0; index < tempAliquot.getSampleDateModels().size(); index++) {
@@ -415,8 +422,16 @@ public class SampleTreeAnalysisMode extends JTree implements SampleTreeI {
                     myEditor.setVisible(true);
 
                     // get a master vector of active fraction names
-                    Vector<String> activeFractionIDs = ((ReduxAliquotInterface) nodeInfo).//
-                            getAliquotFractionIDs();
+                    Vector<String> activeFractionIDs = new Vector<>();
+                    if (sortByDateAsc) {
+                        activeFractionIDs
+                                = ((ReduxAliquotInterface) nodeInfo).//
+                                getAliquotFractionIDsSortedByDateAsc();
+                    } else {
+                        activeFractionIDs
+                                = ((ReduxAliquotInterface) nodeInfo).//
+                                getAliquotFractionIDs();
+                    }
 
                     if (((SampleDateInterpretationChooserDialog) myEditor).getSelectedModels().size() > 0) {
                         DefaultMutableTreeNode sampleDateModelNode = null;
@@ -431,9 +446,10 @@ public class SampleTreeAnalysisMode extends JTree implements SampleTreeI {
                                     zeroFractionDates.add(activeFractionID);
                                 }
                             }
-                            zeroFractionDates.stream().forEach((zeroFractionDate) -> {
-                                activeFractionIDs.remove(zeroFractionDate);
-                            });
+
+                            for (int i = 0; i < zeroFractionDates.size(); i++) {
+                                activeFractionIDs.remove(zeroFractionDates.get(i));
+                            }
 
                             // use next two lines to pre-select all fractions
                             ((SampleDateModel) selectedSAM).setIncludedFractionIDsVector(activeFractionIDs);
@@ -618,10 +634,10 @@ public class SampleTreeAnalysisMode extends JTree implements SampleTreeI {
                             @Override
                             public void actionPerformed(ActionEvent arg0) {
                                 DefaultMutableTreeNode sampleDateNode
-                                        = (DefaultMutableTreeNode) ((DefaultMutableTreeNode) node).getParent();
+                                        = (DefaultMutableTreeNode) node.getParent();
                                 Object SampleDateNodeInfo = sampleDateNode.getUserObject();
                                 ((SampleDateModel) SampleDateNodeInfo).//
-                                        setIncludedFractionIDsVector(new Vector<String>());
+                                        setIncludedFractionIDsVector(new Vector<>());
 
                                 SampleInterface.updateAndSaveSampleDateModelsByAliquot(sample);
 
@@ -648,18 +664,22 @@ public class SampleTreeAnalysisMode extends JTree implements SampleTreeI {
                             @Override
                             public void actionPerformed(ActionEvent arg0) {
                                 DefaultMutableTreeNode sampleDateNode
-                                        = //
-                                        (DefaultMutableTreeNode) node.getParent();
+                                        = (DefaultMutableTreeNode) node.getParent();
                                 DefaultMutableTreeNode aliquotNode
-                                        = //
-                                        (DefaultMutableTreeNode) sampleDateNode.getParent();
+                                        = (DefaultMutableTreeNode) sampleDateNode.getParent();
 
                                 Object SampleDateNodeInfo = sampleDateNode.getUserObject();
                                 Object AliquotNodeInfo = aliquotNode.getUserObject();
 
-                                ((SampleDateModel) SampleDateNodeInfo).//
-                                        setIncludedFractionIDsVector(//
-                                                ((ReduxAliquotInterface) AliquotNodeInfo).getAliquotFractionIDs());
+                                if (sortByDateAsc) {
+                                    ((SampleDateModel) SampleDateNodeInfo).//
+                                            setIncludedFractionIDsVector(//
+                                                    ((ReduxAliquotInterface) AliquotNodeInfo).getAliquotFractionIDsSortedByDateAsc());
+                                } else {
+                                    ((SampleDateModel) SampleDateNodeInfo).//
+                                            setIncludedFractionIDsVector(//
+                                                    ((ReduxAliquotInterface) AliquotNodeInfo).getAliquotFractionIDs());
+                                }
 
                                 SampleInterface.updateAndSaveSampleDateModelsByAliquot(sample);
 
@@ -777,5 +797,12 @@ public class SampleTreeAnalysisMode extends JTree implements SampleTreeI {
      */
     public void setLastNodeSelected(Object lastNodeSelected) {
         this.lastNodeSelected = lastNodeSelected;
+    }
+
+    /**
+     * @param sortByDateAsc the sortByDateAsc to set
+     */
+    public void toggleSortByDateAsc() {
+        this.sortByDateAsc = !this.sortByDateAsc;
     }
 }

--- a/src/main/java/org/earthtime/UPb_Redux/dateInterpretation/SampleTreeAnalysisMode.java
+++ b/src/main/java/org/earthtime/UPb_Redux/dateInterpretation/SampleTreeAnalysisMode.java
@@ -59,6 +59,9 @@ public class SampleTreeAnalysisMode extends JTree implements SampleTreeI {
     private SampleTreeChangeI sampleTreeChange;
     private Object lastNodeSelected;
     private static boolean sortByDateAsc = false;
+    private int selRow;
+    private int selRowX;
+    private int selRowY;
 
     /**
      * Creates a new instance of SampleTreeAnalysisMode
@@ -97,17 +100,8 @@ public class SampleTreeAnalysisMode extends JTree implements SampleTreeI {
         this.removeAll();
 
         // populate tree
-        // todo: just walk aliquots now that ths mapping is fixed (may 2015)
-//        int saveAliquotNum = -1;
-//        for (int i = 0; i < sample.getFractions().size(); i++) {
         for (int i = 0; i < sample.getActiveAliquots().size(); i++) {
-//            ETFractionInterface tempFraction = sample.getFractions().get(i);
             AliquotInterface tempAliquot = sample.getActiveAliquots().get(i);
-
-//            if (!tempFraction.isRejected()) {
-//                if (saveAliquotNum != tempFraction.getAliquotNumber()) {
-//                    saveAliquotNum = tempFraction.getAliquotNumber();
-            //tempAliquot = sample.getAliquotByNumber(saveAliquotNum);
             aliquotNode = new DefaultMutableTreeNode(tempAliquot);
 
             ((DefaultMutableTreeNode) getModel().getRoot()).add(aliquotNode);
@@ -162,9 +156,6 @@ public class SampleTreeAnalysisMode extends JTree implements SampleTreeI {
                             tempAliquot.getSampleDateModels().get(index),
                             sampleDateModelNode);
                 }
-
-//                    }
-//                }
             }
         }
 
@@ -272,10 +263,8 @@ public class SampleTreeAnalysisMode extends JTree implements SampleTreeI {
     public void valueChanged(TreeSelectionEvent e) {
         //Returns the last path element of the selection.
         //This method is useful only when the selection model allows a single selection.
-//        if (!suppressSelectionEvent) {
         DefaultMutableTreeNode node = (DefaultMutableTreeNode) getLastSelectedPathComponent();
-        // april 2016
-        TreePath lastSelected = getSelectionPath();//e.getOldLeadSelectionPath();//   
+        // april 2016 
 
         if (node == null) //Nothing is selected.
         {
@@ -284,10 +273,7 @@ public class SampleTreeAnalysisMode extends JTree implements SampleTreeI {
 
         setLastNodeSelected(node);
 
-        //System.out.println(e.getSource());
         Object nodeInfo = node.getUserObject();
-        //sampleTreeChange.sampleTreeChangeAnalysisMode(node);
-        //  see below setSelectionRow(-1);
 
         if (nodeInfo instanceof SampleInterface) {
             // System.out.println(((SampleInterface) nodeInfo).getSampleName());
@@ -305,12 +291,6 @@ public class SampleTreeAnalysisMode extends JTree implements SampleTreeI {
         }
 
         getSampleTreeChange().sampleTreeChangeAnalysisMode(node);
-
-//            // april 2016
-//            suppressSelectionEvent = true;
-//            setSelectionPath((nodeInfo instanceof CheckBoxNode) ? lastSelected.getParentPath() : e.getNewLeadSelectionPath());
-//            suppressSelectionEvent = false;
-//        }
     }
 
     /**
@@ -399,13 +379,16 @@ public class SampleTreeAnalysisMode extends JTree implements SampleTreeI {
      */
     @Override
     public void mousePressed(MouseEvent e) {
-        int selRow = getRowForLocation(e.getX(), e.getY());
+        selRowX = e.getX();
+        selRowY = e.getY();
+        selRow = getRowForLocation(e.getX(), e.getY());
         TreePath selPath = getPathForLocation(e.getX(), e.getY());
 
         if (selRow != -1) {
             final DefaultMutableTreeNode node = (DefaultMutableTreeNode) selPath.getLastPathComponent();
             final Object nodeInfo = node.getUserObject();
             if (!e.isPopupTrigger() && (e.getButton() == MouseEvent.BUTTON1)) {
+                
             } else if ((e.isPopupTrigger()) || (e.getButton() == MouseEvent.BUTTON3)) {
                 setSelectionPath(selPath);
                 if (nodeInfo instanceof AliquotInterface) {
@@ -804,5 +787,47 @@ public class SampleTreeAnalysisMode extends JTree implements SampleTreeI {
      */
     public void toggleSortByDateAsc() {
         this.sortByDateAsc = !this.sortByDateAsc;
+    }
+
+    /**
+     * @return the selRow
+     */
+    public int getSelRow() {
+        return selRow;
+    }
+
+    /**
+     * @param selRow the selRow to set
+     */
+    public void setSelRow(int selRow) {
+        this.selRow = selRow;
+    }
+
+    /**
+     * @return the selRowX
+     */
+    public int getSelRowX() {
+        return selRowX;
+    }
+
+    /**
+     * @param selRowX the selRowX to set
+     */
+    public void setSelRowX(int selRowX) {
+        this.selRowX = selRowX;
+    }
+
+    /**
+     * @return the selRowY
+     */
+    public int getSelRowY() {
+        return selRowY;
+    }
+
+    /**
+     * @param selRowY the selRowY to set
+     */
+    public void setSelRowY(int selRowY) {
+        this.selRowY = selRowY;
     }
 }

--- a/src/main/java/org/earthtime/UPb_Redux/dateInterpretation/SampleTreeCompilationMode.java
+++ b/src/main/java/org/earthtime/UPb_Redux/dateInterpretation/SampleTreeCompilationMode.java
@@ -58,6 +58,9 @@ public class SampleTreeCompilationMode extends JTree implements SampleTreeI {
     private SampleTreeChangeI sampleTreeChange;
     private Object lastNodeSelected;
     private static boolean sortByDateAsc = false;
+    private int selRow;
+    private int selRowX;
+    private int selRowY;
 
     /**
      * Creates a new instance of SampleTreeCompilationMode
@@ -343,7 +346,9 @@ public class SampleTreeCompilationMode extends JTree implements SampleTreeI {
      */
     @Override
     public void mousePressed(MouseEvent e) {
-        int selRow = getRowForLocation(e.getX(), e.getY());
+        selRowX = e.getX();
+        selRowY = e.getY();
+        selRow = getRowForLocation(e.getX(), e.getY());
         TreePath selPath = getPathForLocation(e.getX(), e.getY());
 
         if (selRow != -1) {
@@ -722,5 +727,39 @@ public class SampleTreeCompilationMode extends JTree implements SampleTreeI {
     @Override
     public void toggleSortByDateAsc() {
         this.sortByDateAsc = !this.sortByDateAsc;
+    }
+
+    /**
+     * @return the selRow
+     */
+    public int getSelRow() {
+        return selRow;
+    }
+
+    /**
+     * @param selRow the selRow to set
+     */
+    public void setSelRow(int selRow) {
+        this.selRow = selRow;
+    }
+
+    @Override
+    public int getSelRowX() {
+        throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+    }
+
+    @Override
+    public void setSelRowX(int selRowX) {
+        throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+    }
+
+    @Override
+    public int getSelRowY() {
+        throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+    }
+
+    @Override
+    public void setSelRowY(int selRowY) {
+        throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
     }
 }

--- a/src/main/java/org/earthtime/UPb_Redux/dateInterpretation/SampleTreeCompilationMode.java
+++ b/src/main/java/org/earthtime/UPb_Redux/dateInterpretation/SampleTreeCompilationMode.java
@@ -57,6 +57,7 @@ public class SampleTreeCompilationMode extends JTree implements SampleTreeI {
     private SampleInterface sample;
     private SampleTreeChangeI sampleTreeChange;
     private Object lastNodeSelected;
+    private static boolean sortByDateAsc = false;
 
     /**
      * Creates a new instance of SampleTreeCompilationMode
@@ -716,5 +717,10 @@ public class SampleTreeCompilationMode extends JTree implements SampleTreeI {
     @Override
     public void performLastUserSelectionOfSampleDate() {
         throw new UnsupportedOperationException("Not supported yet.");
+    }
+
+    @Override
+    public void toggleSortByDateAsc() {
+        this.sortByDateAsc = !this.sortByDateAsc;
     }
 }

--- a/src/main/java/org/earthtime/UPb_Redux/dateInterpretation/SampleTreeI.java
+++ b/src/main/java/org/earthtime/UPb_Redux/dateInterpretation/SampleTreeI.java
@@ -117,4 +117,6 @@ public interface SampleTreeI extends MouseListener, TreeSelectionListener {
     public void expandToHistory(String expansionHistory);
     
     public void expandAllNodes();
+    
+    public void toggleSortByDateAsc();
 }

--- a/src/main/java/org/earthtime/UPb_Redux/dateInterpretation/SampleTreeI.java
+++ b/src/main/java/org/earthtime/UPb_Redux/dateInterpretation/SampleTreeI.java
@@ -115,8 +115,40 @@ public interface SampleTreeI extends MouseListener, TreeSelectionListener {
     public String collectExpansionHistory();
 
     public void expandToHistory(String expansionHistory);
-    
+
     public void expandAllNodes();
-    
+
     public void toggleSortByDateAsc();
+
+    /**
+     * @return the selRow
+     */
+    public int getSelRow();
+
+    /**
+     * @param selRow the selRow to set
+     */
+    public void setSelRow(int selRow);
+
+    /**
+     * @return the selRowX
+     */
+    public int getSelRowX();
+
+    /**
+     * @param selRowX the selRowX to set
+     */
+    public void setSelRowX(int selRowX);
+    
+    /**
+     * @return the selRowY
+     */
+    public int getSelRowY();
+
+    /**
+     * @param selRowY the selRowY to set
+     */
+    public void setSelRowY(int selRowY);
+    
+    
 }

--- a/src/main/java/org/earthtime/UPb_Redux/dialogs/aliquotManagers/AliquotEditorDialog.java
+++ b/src/main/java/org/earthtime/UPb_Redux/dialogs/aliquotManagers/AliquotEditorDialog.java
@@ -101,7 +101,6 @@ import org.earthtime.dataDictionaries.DataDictionary;
 import org.earthtime.dataDictionaries.GeochronValidationResults;
 import org.earthtime.dataDictionaries.MineralTypes;
 import org.earthtime.dataDictionaries.RadDates;
-import org.earthtime.dataDictionaries.SampleRegistries;
 import org.earthtime.dataDictionaries.SampleTypesEnum;
 import org.earthtime.dialogs.DialogEditor;
 import org.earthtime.exceptions.ETException;
@@ -120,9 +119,6 @@ import org.earthtime.utilities.FileHelper;
 import org.earthtime.xmlUtilities.SimpleTransform;
 import org.jdesktop.layout.GroupLayout.ParallelGroup;
 import org.jdesktop.layout.GroupLayout.SequentialGroup;
-import org.w3c.dom.DOMException;
-import org.w3c.dom.Node;
-import org.w3c.dom.NodeList;
 
 /**
  *
@@ -2092,7 +2088,7 @@ private void publishAliquot_panelMouseClicked(java.awt.event.MouseEvent evt) {//
         addedFractions = new Vector<>();
 
         // in compilation, leave everything blank
-        if (((UPbReduxAliquot) myAliquot).isCompiled()) {
+        if (((ReduxAliquotInterface) myAliquot).isCompiled()) {
             return;
         }
 
@@ -2381,8 +2377,8 @@ private void publishAliquot_panelMouseClicked(java.awt.event.MouseEvent evt) {//
             public void actionPerformed(ActionEvent e) {
                 for (int f = 0; f
                         < getMyAliquot().getAliquotFractions().size(); f++) {
-                    if (((JTextField) fractionTracerMassText.get(f)).isEnabled()) {
-                        ((JTextField) fractionTracerMassText.get(f)).setText(masterTracerMass.getText());
+                    if (fractionTracerMassText.get(f).isEnabled()) {
+                        ((JTextComponent) fractionTracerMassText.get(f)).setText(masterTracerMass.getText());
                     }
                 }
 
@@ -2404,8 +2400,8 @@ private void publishAliquot_panelMouseClicked(java.awt.event.MouseEvent evt) {//
             public void actionPerformed(ActionEvent e) {
                 for (int f = 0; f
                         < getMyAliquot().getAliquotFractions().size(); f++) {
-                    if (((JTextField) fractionMassText.get(f)).isEnabled()) {
-                        ((JTextField) fractionMassText.get(f)).setText(masterFractionMass.getText());
+                    if (fractionMassText.get(f).isEnabled()) {
+                        ((JTextComponent) fractionMassText.get(f)).setText(masterFractionMass.getText());
                     }
                 }
 
@@ -3771,6 +3767,50 @@ private void publishAliquot_panelMouseClicked(java.awt.event.MouseEvent evt) {//
     protected void showSavedDataI() {
         // general info
 
+        validateIGSNs();
+
+        aliquotName_text.setText(getMyAliquot().getAliquotName());
+        analystName_text.setText(getMyAliquot().getAnalystName());
+
+        instrumentalMethod_jcombo.removeAllItems();
+        for (int i = 0; i
+                < DataDictionary.AliquotInstrumentalMethod.length; i++) {
+            instrumentalMethod_jcombo.addItem(DataDictionary.AliquotInstrumentalMethod[i]);
+        }
+
+        instrumentalMethod_jcombo.setSelectedItem(getMyAliquot().
+                getAliquotInstrumentalMethod().toString());
+
+        instMethodRef_text.setText(getMyAliquot().getAliquotInstrumentalMethodReference());
+
+        reference_text.setText(getMyAliquot().getAliquotReference());
+
+        comment_textArea.setText(getMyAliquot().getAliquotComment());
+
+        calibrationUnct206_238_text.setText(//
+                getMyAliquot().getCalibrationUnct206_238()//
+                .setScale(ReduxConstants.DEFAULT_PARAMETERS_SCALE, RoundingMode.HALF_UP).toPlainString());
+
+        calibrationUnct208_232_text.setText(getMyAliquot().getCalibrationUnct208_232()//
+                .setScale(ReduxConstants.DEFAULT_PARAMETERS_SCALE, RoundingMode.HALF_UP).toPlainString());
+
+        calibrationUnct207_206_text.setText(getMyAliquot().getCalibrationUnct207_206()//
+                .setScale(ReduxConstants.DEFAULT_PARAMETERS_SCALE, RoundingMode.HALF_UP).toPlainString());
+
+        keyWordsCSV_text.setText( //
+                getMyAliquot().getKeyWordsCSV());
+
+        for (JComponent cb : mineralStandardsCheckBoxes) {
+            if (getMyAliquot().getAMineralStandardModelByName(((AbstractButton) cb).getText()) != null) {
+                ((AbstractButton) cb).setSelected(true);
+            } else {
+                ((AbstractButton) cb).setSelected(false);
+            }
+        }
+
+    }
+
+    protected void validateIGSNs() {
         // April 2011 now using xxx.sampleID for sampleIGSN and need to split off
         aliquotIGSN_text.setText(getMyAliquot().getAlliquotIGSNnoRegistry());
 
@@ -3815,46 +3855,6 @@ private void publishAliquot_panelMouseClicked(java.awt.event.MouseEvent evt) {//
                     "Aliquot IGSN " + getMyAliquot().getAliquotIGSN() + " is NOT REGISTERED as child of Sample IGSN " + sample.getSampleIGSNnoRegistry());
             geochronArchivePanel_panel.setVisible(false);
         }
-
-        aliquotName_text.setText(getMyAliquot().getAliquotName());
-        analystName_text.setText(getMyAliquot().getAnalystName());
-
-        instrumentalMethod_jcombo.removeAllItems();
-        for (int i = 0; i
-                < DataDictionary.AliquotInstrumentalMethod.length; i++) {
-            instrumentalMethod_jcombo.addItem(DataDictionary.AliquotInstrumentalMethod[i]);
-        }
-
-        instrumentalMethod_jcombo.setSelectedItem(getMyAliquot().
-                getAliquotInstrumentalMethod().toString());
-
-        instMethodRef_text.setText(getMyAliquot().getAliquotInstrumentalMethodReference());
-
-        reference_text.setText(getMyAliquot().getAliquotReference());
-
-        comment_textArea.setText(getMyAliquot().getAliquotComment());
-
-        calibrationUnct206_238_text.setText(//
-                getMyAliquot().getCalibrationUnct206_238()//
-                .setScale(ReduxConstants.DEFAULT_PARAMETERS_SCALE, RoundingMode.HALF_UP).toPlainString());
-
-        calibrationUnct208_232_text.setText(getMyAliquot().getCalibrationUnct208_232()//
-                .setScale(ReduxConstants.DEFAULT_PARAMETERS_SCALE, RoundingMode.HALF_UP).toPlainString());
-
-        calibrationUnct207_206_text.setText(getMyAliquot().getCalibrationUnct207_206()//
-                .setScale(ReduxConstants.DEFAULT_PARAMETERS_SCALE, RoundingMode.HALF_UP).toPlainString());
-
-        keyWordsCSV_text.setText( //
-                getMyAliquot().getKeyWordsCSV());
-
-        for (JComponent cb : mineralStandardsCheckBoxes) {
-            if (getMyAliquot().getAMineralStandardModelByName(((AbstractButton) cb).getText()) != null) {
-                ((AbstractButton) cb).setSelected(true);
-            } else {
-                ((AbstractButton) cb).setSelected(false);
-            }
-        }
-
     }
 
     /**
@@ -4275,7 +4275,7 @@ private void publishAliquot_panelMouseClicked(java.awt.event.MouseEvent evt) {//
         }
 
         // general info
-        getMyAliquot().setAliquotName(aliquotName_text.getText());
+        myAliquot.setAliquotName(aliquotName_text.getText().trim());
         this.setTitle("Aliquot # " + getMyAliquot().getAliquotNumber() + " <> " + getMyAliquot().getAliquotName());
 
         getMyAliquot().setAnalystName(analystName_text.getText());
@@ -4381,8 +4381,10 @@ private void publishAliquot_panelMouseClicked(java.awt.event.MouseEvent evt) {//
         myAliquot.setLaboratoryName(ReduxLabData.getInstance().getLabName());
 
         // sept 2016
-        myAliquot.setAliquotIGSN(aliquotIGSN_text.getText());
-
+        myAliquot.setAliquotIGSN(aliquotIGSN_text.getText().trim());
+               
+        validateIGSNs();
+        
         SampleInterface.saveSampleAsSerializedReduxFile(sample);
 
         System.out.println("**************** PRE-PUBLISH CHECKLIST FOR ALIQUOT");
@@ -4964,126 +4966,125 @@ private void publishAliquot_panelMouseClicked(java.awt.event.MouseEvent evt) {//
         }
     }
 
-    private ValidationFromRegistry queryRegistryWithSampleID(String SampleID) {
-        // april 2011 simple validation: is sampleID an ID in the specified registry
-        // reg.SampleID
-        return new ValidationFromRegistry( //
-                SampleID, //
-                SampleRegistries.isSampleIdentifierValidAtRegistry(SampleID));
-    }
-
-    private ValidationFromRegistry querySESAR(String SampleID) {
-        String connectionStringSESAR = "http://www.geosamples.org/display.php?igsn=";
-        org.w3c.dom.Document doc = URIHelper.RetrieveXMLfromServerAsDOMdocument(connectionStringSESAR + SampleID.trim());
-
-        ValidationFromRegistry retVal = new ValidationFromRegistry(SampleID, false);
-        String selectedSampleIGSN;
-
-        if (doc != null) {
-            if (doc.hasChildNodes()) {
-                Node SESARsample = doc.getFirstChild();
-
-                ArrayList<String> messageTop = new ArrayList<String>();
-                if (SESARsample.getNodeName().equalsIgnoreCase("sample")) {
-                    NodeList sampleDetails = SESARsample.getChildNodes();
-                    for (int i = 0; i < sampleDetails.getLength(); i++) {
-                        System.out.println(sampleDetails.item(i).getNodeName());
-                    }
-
-                    // check for child or parent type SampleID
-                    NodeList temp = doc.getElementsByTagName("ParentIGSN");
-                    if (temp.getLength() > 0) {
-                        doc = URIHelper.RetrieveXMLfromServerAsDOMdocument(connectionStringSESAR//
-                                + temp.item(0).getTextContent());
-
-                        selectedSampleIGSN = temp.item(0).getTextContent();
-
-                        messageTop.add(
-                                "SESAR reports that IGSN " + SampleID + " is a child of a sample.\n\n");
-                        messageTop.add(
-                                "You must choose a Sample IGSN, and SESAR reports that for this child, \n");
-                        messageTop.add(
-                                "the parent Sample has IGSN " //
-                                + selectedSampleIGSN //
-                                + ", identified as:\n\n");
-                    } else {
-                        // we have a sample SampleID
-                        selectedSampleIGSN = SampleID;
-                        messageTop.add(
-                                "SESAR reports that IGSN " + selectedSampleIGSN + " is a Sample identified as:\n\n");
-                    }
-
-                    // present the user with the sample SampleID and data and a confirm
-                    try {
-                        messageTop.add("IGSN = " + doc.getElementsByTagName("IGSN").item(0).getTextContent() + "\n");
-                    } catch (NullPointerException dOMException) {
-                    }
-                    try {
-                        messageTop.add("SampleID = " + doc.getElementsByTagName("SampleID").item(0).getTextContent() + "\n");
-                    } catch (NullPointerException dOMException) {
-                    }
-                    try {
-                        messageTop.add("SampleComment = " + doc.getElementsByTagName("SampleComment").item(0).getTextContent() + "\n");
-                    } catch (NullPointerException dOMException) {
-                    }
-                    try {
-                        messageTop.add("GeoObjectType = " + doc.getElementsByTagName("GeoObjectType").item(0).getTextContent() + "\n");
-                    } catch (NullPointerException dOMException) {
-                    }
-                    try {
-                        messageTop.add("Material = " + doc.getElementsByTagName("Material").item(0).getTextContent() + "\n");
-                    } catch (NullPointerException dOMException) {
-                    }
+//    private ValidationFromRegistry queryRegistryWithSampleID(String SampleID) {
+//        // april 2011 simple validation: is sampleID an ID in the specified registry
+//        // reg.SampleID
+//        return new ValidationFromRegistry( //
+//                SampleID, //
+//                SampleRegistries.isSampleIdentifierValidAtRegistry(SampleID));
+//    }
+//
+//    private ValidationFromRegistry querySESAR(String SampleID) {
+//        String connectionStringSESAR = "http://www.geosamples.org/display.php?igsn=";
+//        org.w3c.dom.Document doc = URIHelper.RetrieveXMLfromServerAsDOMdocument(connectionStringSESAR + SampleID.trim());
+//
+//        ValidationFromRegistry retVal = new ValidationFromRegistry(SampleID, false);
+//        String selectedSampleIGSN;
+//
+//        if (doc != null) {
+//            if (doc.hasChildNodes()) {
+//                Node SESARsample = doc.getFirstChild();
+//
+//                ArrayList<String> messageTop = new ArrayList<String>();
+//                if (SESARsample.getNodeName().equalsIgnoreCase("sample")) {
+//                    NodeList sampleDetails = SESARsample.getChildNodes();
+//                    for (int i = 0; i < sampleDetails.getLength(); i++) {
+//                        System.out.println(sampleDetails.item(i).getNodeName());
+//                    }
+//
+//                    // check for child or parent type SampleID
+//                    NodeList temp = doc.getElementsByTagName("ParentIGSN");
+//                    if (temp.getLength() > 0) {
+//                        doc = URIHelper.RetrieveXMLfromServerAsDOMdocument(connectionStringSESAR//
+//                                + temp.item(0).getTextContent());
+//
+//                        selectedSampleIGSN = temp.item(0).getTextContent();
+//
+//                        messageTop.add(
+//                                "SESAR reports that IGSN " + SampleID + " is a child of a sample.\n\n");
+//                        messageTop.add(
+//                                "You must choose a Sample IGSN, and SESAR reports that for this child, \n");
+//                        messageTop.add(
+//                                "the parent Sample has IGSN " //
+//                                + selectedSampleIGSN //
+//                                + ", identified as:\n\n");
+//                    } else {
+//                        // we have a sample SampleID
+//                        selectedSampleIGSN = SampleID;
+//                        messageTop.add(
+//                                "SESAR reports that IGSN " + selectedSampleIGSN + " is a Sample identified as:\n\n");
+//                    }
+//
+//                    // present the user with the sample SampleID and data and a confirm
 //                    try {
-//                        messageTop.add("PrimaryLocationName = " + doc.getElementsByTagName("PrimaryLocationName").item(0).getTextContent() + "\n");
+//                        messageTop.add("IGSN = " + doc.getElementsByTagName("IGSN").item(0).getTextContent() + "\n");
 //                    } catch (NullPointerException dOMException) {
 //                    }
 //                    try {
-//                        messageTop.add("MostRecentArchivalInstitution = " + doc.getElementsByTagName("MostRecentArchivalInstitution").item(0).getTextContent() + "\n");
+//                        messageTop.add("SampleID = " + doc.getElementsByTagName("SampleID").item(0).getTextContent() + "\n");
 //                    } catch (NullPointerException dOMException) {
 //                    }
-                    messageTop.add("\n     Do you accept this Sample as the parent of this Aliquot?");
-
-                    String[] message = new String[messageTop.size()];
-                    message = messageTop.toArray(message);
-
-                    int response = JOptionPane.showConfirmDialog(this,
-                            message,
-                            "U-Pb Redux Information",
-                            JOptionPane.YES_NO_OPTION,
-                            JOptionPane.INFORMATION_MESSAGE);
-                    if (response == JOptionPane.NO_OPTION) {
-                        retVal.selectedSampleID = SampleID;
-                        retVal.valid = false;
-                    } else {
-                        retVal.selectedSampleID = selectedSampleIGSN;
-                        retVal.valid = true;
-                    }
-
-                } else {
-                    // assume error received
-
-                    String SESAR_message = "SESAR failed to process this request - please contact SESAR.";
-
-                    try {
-                        SESAR_message = doc.getElementsByTagName("Error").item(0).getTextContent();
-                    } catch (DOMException dOMException) {
-                    }
-
-                    JOptionPane.showMessageDialog(this,
-                            new String[]{"SESAR responded: " + SESAR_message});
-
-                    retVal.selectedSampleID = SampleID;
-                    retVal.valid = false;
-
-                }
-
-            }
-        }
-
-        return retVal;
-    }
-
+//                    try {
+//                        messageTop.add("SampleComment = " + doc.getElementsByTagName("SampleComment").item(0).getTextContent() + "\n");
+//                    } catch (NullPointerException dOMException) {
+//                    }
+//                    try {
+//                        messageTop.add("GeoObjectType = " + doc.getElementsByTagName("GeoObjectType").item(0).getTextContent() + "\n");
+//                    } catch (NullPointerException dOMException) {
+//                    }
+//                    try {
+//                        messageTop.add("Material = " + doc.getElementsByTagName("Material").item(0).getTextContent() + "\n");
+//                    } catch (NullPointerException dOMException) {
+//                    }
+////                    try {
+////                        messageTop.add("PrimaryLocationName = " + doc.getElementsByTagName("PrimaryLocationName").item(0).getTextContent() + "\n");
+////                    } catch (NullPointerException dOMException) {
+////                    }
+////                    try {
+////                        messageTop.add("MostRecentArchivalInstitution = " + doc.getElementsByTagName("MostRecentArchivalInstitution").item(0).getTextContent() + "\n");
+////                    } catch (NullPointerException dOMException) {
+////                    }
+//                    messageTop.add("\n     Do you accept this Sample as the parent of this Aliquot?");
+//
+//                    String[] message = new String[messageTop.size()];
+//                    message = messageTop.toArray(message);
+//
+//                    int response = JOptionPane.showConfirmDialog(this,
+//                            message,
+//                            "U-Pb Redux Information",
+//                            JOptionPane.YES_NO_OPTION,
+//                            JOptionPane.INFORMATION_MESSAGE);
+//                    if (response == JOptionPane.NO_OPTION) {
+//                        retVal.selectedSampleID = SampleID;
+//                        retVal.valid = false;
+//                    } else {
+//                        retVal.selectedSampleID = selectedSampleIGSN;
+//                        retVal.valid = true;
+//                    }
+//
+//                } else {
+//                    // assume error received
+//
+//                    String SESAR_message = "SESAR failed to process this request - please contact SESAR.";
+//
+//                    try {
+//                        SESAR_message = doc.getElementsByTagName("Error").item(0).getTextContent();
+//                    } catch (DOMException dOMException) {
+//                    }
+//
+//                    JOptionPane.showMessageDialog(this,
+//                            new String[]{"SESAR responded: " + SESAR_message});
+//
+//                    retVal.selectedSampleID = SampleID;
+//                    retVal.valid = false;
+//
+//                }
+//
+//            }
+//        }
+//
+//        return retVal;
+//    }
     // refactor this stuff to reduce coupling
     private GeochronValidationResults confirmAliquotArchivedInGeochron(AliquotInterface aliquot) {
 
@@ -5091,8 +5092,7 @@ private void publishAliquot_panelMouseClicked(java.awt.event.MouseEvent evt) {//
         String password = ((ETReduxFrame) parent).getMyState().getReduxPreferences().getGeochronPassWord();
 
         String connectionString
-                = //
-                "http://www.geochron.org/getxml.php?sampleigsn="//
+                = "http://www.geochron.org/getxml.php?sampleigsn="//
                 + aliquot.getSampleIGSN() //
                 + "&aliquotname=" //
                 + aliquot.getAliquotName()//

--- a/src/main/java/org/earthtime/UPb_Redux/dialogs/aliquotManagers/AliquotEditorForLAICPMS.java
+++ b/src/main/java/org/earthtime/UPb_Redux/dialogs/aliquotManagers/AliquotEditorForLAICPMS.java
@@ -40,7 +40,6 @@ import org.earthtime.UPb_Redux.ReduxConstants;
 import org.earthtime.UPb_Redux.aliquots.UPbReduxAliquot;
 import org.earthtime.UPb_Redux.exceptions.BadLabDataException;
 import org.earthtime.UPb_Redux.fractions.UPbReduxFractions.UPbFraction;
-import org.earthtime.reduxLabData.ReduxLabData;
 import org.earthtime.UPb_Redux.renderers.EditFractionButton;
 import org.earthtime.UPb_Redux.valueModels.ValueModel;
 import org.earthtime.aliquots.AliquotInterface;
@@ -49,6 +48,7 @@ import org.earthtime.dataDictionaries.RadDates;
 import org.earthtime.exceptions.ETException;
 import org.earthtime.exceptions.ETWarningDialog;
 import org.earthtime.fractions.ETFractionInterface;
+import org.earthtime.reduxLabData.ReduxLabData;
 import org.earthtime.samples.SampleInterface;
 import org.earthtime.xmlUtilities.XMLSerializationI;
 import org.jdesktop.layout.GroupLayout.ParallelGroup;
@@ -662,7 +662,7 @@ public class AliquotEditorForLAICPMS extends AliquotEditorDialog {
         // Composition
         ((JTextComponent) fractionConcU_Text.get(row)).setText(tempFrac.getCompositionalMeasureByName("concU").getValue().
                 movePointRight(6).setScale(ReduxConstants.DEFAULT_CONSTANTS_SCALE,
-                        RoundingMode.HALF_UP).toPlainString());
+                RoundingMode.HALF_UP).toPlainString());
         ((JTextComponent) fractionConcU_Text.get(row)).setCaretPosition(0);
 
         ((JTextComponent) fractionRTh_Usample_Text.get(row)).setText(tempFrac.getCompositionalMeasureByName("rTh_Usample").getValue().
@@ -715,32 +715,32 @@ public class AliquotEditorForLAICPMS extends AliquotEditorDialog {
         // Isotopic Dates
         ((JTextComponent) fractionDate206_238r_Text.get(row)).setText(tempFrac.getRadiogenicIsotopeDateByName(RadDates.age206_238r).getValue().
                 movePointLeft(6).setScale(ReduxConstants.DEFAULT_CONSTANTS_SCALE,
-                        RoundingMode.HALF_UP).toPlainString());
+                RoundingMode.HALF_UP).toPlainString());
         ((JTextComponent) fractionDate206_238r_Text.get(row)).setCaretPosition(0);
 
         ((JTextComponent) fractionDate206_238r2SigmaAbs_Text.get(row)).setText(tempFrac.getRadiogenicIsotopeDateByName(RadDates.age206_238r).getOneSigmaAbs().
                 movePointLeft(6).setScale(ReduxConstants.DEFAULT_CONSTANTS_SCALE,
-                        RoundingMode.HALF_UP).toPlainString());
+                RoundingMode.HALF_UP).toPlainString());
         ((JTextComponent) fractionDate206_238r2SigmaAbs_Text.get(row)).setCaretPosition(0);
 
         ((JTextComponent) fractionDate207_235r_Text.get(row)).setText(tempFrac.getRadiogenicIsotopeDateByName(RadDates.age207_235r).getValue().
                 movePointLeft(6).setScale(ReduxConstants.DEFAULT_CONSTANTS_SCALE,
-                        RoundingMode.HALF_UP).toPlainString());
+                RoundingMode.HALF_UP).toPlainString());
         ((JTextComponent) fractionDate207_235r_Text.get(row)).setCaretPosition(0);
 
         ((JTextComponent) fractionDate207_235r2SigmaAbs_Text.get(row)).setText(tempFrac.getRadiogenicIsotopeDateByName(RadDates.age207_235r).getOneSigmaAbs().
                 movePointLeft(6).setScale(ReduxConstants.DEFAULT_CONSTANTS_SCALE,
-                        RoundingMode.HALF_UP).toPlainString());
+                RoundingMode.HALF_UP).toPlainString());
         ((JTextComponent) fractionDate207_235r2SigmaAbs_Text.get(row)).setCaretPosition(0);
 
         ((JTextComponent) fractionDate207_206r_Text.get(row)).setText(tempFrac.getRadiogenicIsotopeDateByName(RadDates.age207_206r).getValue().
                 movePointLeft(6).setScale(ReduxConstants.DEFAULT_CONSTANTS_SCALE,
-                        RoundingMode.HALF_UP).toPlainString());
+                RoundingMode.HALF_UP).toPlainString());
         ((JTextComponent) fractionDate207_206r_Text.get(row)).setCaretPosition(0);
 
         ((JTextComponent) fractionDate207_206r2SigmaAbs_Text.get(row)).setText(tempFrac.getRadiogenicIsotopeDateByName(RadDates.age207_206r).getOneSigmaAbs().
                 movePointLeft(6).setScale(ReduxConstants.DEFAULT_CONSTANTS_SCALE,
-                        RoundingMode.HALF_UP).toPlainString());
+                RoundingMode.HALF_UP).toPlainString());
         ((JTextComponent) fractionDate207_206r2SigmaAbs_Text.get(row)).setCaretPosition(0);
 
     }
@@ -890,7 +890,7 @@ public class AliquotEditorForLAICPMS extends AliquotEditorDialog {
     private void saveAliquot() {
 
         // general info
-        getMyAliquot().setAliquotName(aliquotName_text.getText());
+        myAliquot.setAliquotName(aliquotName_text.getText().trim());
         this.setTitle("Aliquot # " + getMyAliquot().getAliquotNumber() + " <> " + getMyAliquot().getAliquotName());
 
         getMyAliquot().setAnalystName(analystName_text.getText());
@@ -943,6 +943,12 @@ public class AliquotEditorForLAICPMS extends AliquotEditorDialog {
         // removed april 2011 as part of registry upgrade
 //        getMyAliquot().setSampleIGSN( aliquotIGSN_text.getText().trim() );
 //        sample.setSampleIGSN( aliquotIGSN_text.getText().trim() );
+
+       // sept 2016
+        myAliquot.setAliquotIGSN(aliquotIGSN_text.getText().trim());
+                      
+        validateIGSNs();
+
         SampleInterface.saveSampleAsSerializedReduxFile(sample);
 
         System.out.println("**************** PRE-PUBLISH CHECKLIST FOR ALIQUOT");

--- a/src/main/java/org/earthtime/UPb_Redux/dialogs/aliquotManagers/AliquotLegacyEditorForIDTIMS.java
+++ b/src/main/java/org/earthtime/UPb_Redux/dialogs/aliquotManagers/AliquotLegacyEditorForIDTIMS.java
@@ -37,7 +37,6 @@ import org.earthtime.ETReduxFrame;
 import org.earthtime.UPb_Redux.ReduxConstants;
 import org.earthtime.UPb_Redux.exceptions.BadLabDataException;
 import org.earthtime.UPb_Redux.fractions.UPbReduxFractions.UPbFraction;
-import org.earthtime.reduxLabData.ReduxLabData;
 import org.earthtime.UPb_Redux.renderers.EditFractionButton;
 import org.earthtime.UPb_Redux.valueModels.ValueModel;
 import org.earthtime.aliquots.AliquotInterface;
@@ -46,6 +45,7 @@ import org.earthtime.dataDictionaries.RadDates;
 import org.earthtime.exceptions.ETException;
 import org.earthtime.exceptions.ETWarningDialog;
 import org.earthtime.fractions.ETFractionInterface;
+import org.earthtime.reduxLabData.ReduxLabData;
 import org.earthtime.samples.SampleInterface;
 import org.jdesktop.layout.GroupLayout.ParallelGroup;
 import org.jdesktop.layout.GroupLayout.SequentialGroup;
@@ -841,12 +841,12 @@ public class AliquotLegacyEditorForIDTIMS extends AliquotEditorDialog {
         ((JTextComponent) fractionConcU_Text.get(row)).setText(
                 tempFrac.getCompositionalMeasureByName("concU").getValue().
                 movePointRight(6).setScale(1,
-                        RoundingMode.HALF_UP).toPlainString());
+                RoundingMode.HALF_UP).toPlainString());
 
         ((JTextComponent) fractionConcPb_ib_Text.get(row)).setText(
                 tempFrac.getCompositionalMeasureByName("concPb_ib").getValue().
                 movePointRight(6).setScale(3,
-                        RoundingMode.HALF_UP).toPlainString());
+                RoundingMode.HALF_UP).toPlainString());
 
         ((JTextComponent) fractionRTh_Usample_Text.get(row)).setText(tempFrac.getCompositionalMeasureByName("rTh_Usample").getValue().
                 setScale(ReduxConstants.DEFAULT_DEFAULTS_SCALE,
@@ -859,59 +859,59 @@ public class AliquotLegacyEditorForIDTIMS extends AliquotEditorDialog {
         // Isotopic Dates
         ((JTextComponent) fractionDate206_238r_Text.get(row)).setText(tempFrac.getRadiogenicIsotopeDateByName(RadDates.age206_238r).getValue().
                 movePointLeft(6).setScale(ReduxConstants.DEFAULT_DEFAULTS_SCALE,
-                        RoundingMode.HALF_UP).toPlainString());
+                RoundingMode.HALF_UP).toPlainString());
 
         ((JTextComponent) fractionDate206_238r2SigmaAbs_Text.get(row)).setText(tempFrac.getRadiogenicIsotopeDateByName(RadDates.age206_238r).getTwoSigmaAbs().
                 movePointLeft(6).setScale(ReduxConstants.DEFAULT_PARAMETERS_SCALE,
-                        RoundingMode.HALF_UP).toPlainString());
+                RoundingMode.HALF_UP).toPlainString());
 
         ((JTextComponent) fractionDate207_235r_Text.get(row)).setText(tempFrac.getRadiogenicIsotopeDateByName(RadDates.age207_235r).getValue().
                 movePointLeft(6).setScale(ReduxConstants.DEFAULT_DEFAULTS_SCALE,
-                        RoundingMode.HALF_UP).toPlainString());
+                RoundingMode.HALF_UP).toPlainString());
 
         ((JTextComponent) fractionDate207_235r2SigmaAbs_Text.get(row)).setText(tempFrac.getRadiogenicIsotopeDateByName(RadDates.age207_235r).getTwoSigmaAbs().
                 movePointLeft(6).setScale(ReduxConstants.DEFAULT_PARAMETERS_SCALE,
-                        RoundingMode.HALF_UP).toPlainString());
+                RoundingMode.HALF_UP).toPlainString());
 
         ((JTextComponent) fractionDate207_206r_Text.get(row)).setText(tempFrac.getRadiogenicIsotopeDateByName(RadDates.age207_206r).getValue().
                 movePointLeft(6).setScale(ReduxConstants.DEFAULT_DEFAULTS_SCALE,
-                        RoundingMode.HALF_UP).toPlainString());
+                RoundingMode.HALF_UP).toPlainString());
 
         ((JTextComponent) fractionDate207_206r2SigmaAbs_Text.get(row)).setText(tempFrac.getRadiogenicIsotopeDateByName(RadDates.age207_206r).getTwoSigmaAbs().
                 movePointLeft(6).setScale(ReduxConstants.DEFAULT_PARAMETERS_SCALE,
-                        RoundingMode.HALF_UP).toPlainString());
+                RoundingMode.HALF_UP).toPlainString());
 
         ((JTextComponent) fractionDate206_238r_Th_Text.get(row)).setText(tempFrac.getRadiogenicIsotopeDateByName(RadDates.age206_238r_Th).getValue().
                 movePointLeft(6).setScale(ReduxConstants.DEFAULT_DEFAULTS_SCALE,
-                        RoundingMode.HALF_UP).toPlainString());
+                RoundingMode.HALF_UP).toPlainString());
 
         ((JTextComponent) fractionDate206_238r_Th2SigmaAbs_Text.get(row)).setText(tempFrac.getRadiogenicIsotopeDateByName(RadDates.age206_238r_Th).getTwoSigmaAbs().
                 movePointLeft(6).setScale(ReduxConstants.DEFAULT_PARAMETERS_SCALE,
-                        RoundingMode.HALF_UP).toPlainString());
+                RoundingMode.HALF_UP).toPlainString());
 
         ((JTextComponent) fractionDate207_235r_Pa_Text.get(row)).setText(tempFrac.getRadiogenicIsotopeDateByName(RadDates.age207_235r_Pa).getValue().
                 movePointLeft(6).setScale(ReduxConstants.DEFAULT_DEFAULTS_SCALE,
-                        RoundingMode.HALF_UP).toPlainString());
+                RoundingMode.HALF_UP).toPlainString());
 
         ((JTextComponent) fractionDate207_235r_Pa2SigmaAbs_Text.get(row)).setText(tempFrac.getRadiogenicIsotopeDateByName(RadDates.age207_235r_Pa).getTwoSigmaAbs().
                 movePointLeft(6).setScale(ReduxConstants.DEFAULT_PARAMETERS_SCALE,
-                        RoundingMode.HALF_UP).toPlainString());
+                RoundingMode.HALF_UP).toPlainString());
 
         ((JTextComponent) fractionDate207_206r_Th_Text.get(row)).setText(tempFrac.getRadiogenicIsotopeDateByName(RadDates.age207_206r_Th).getValue().
                 movePointLeft(6).setScale(ReduxConstants.DEFAULT_DEFAULTS_SCALE,
-                        RoundingMode.HALF_UP).toPlainString());
+                RoundingMode.HALF_UP).toPlainString());
 
         ((JTextComponent) fractionDate207_206r_Th2SigmaAbs_Text.get(row)).setText(tempFrac.getRadiogenicIsotopeDateByName(RadDates.age207_206r_Th).getTwoSigmaAbs().
                 movePointLeft(6).setScale(ReduxConstants.DEFAULT_PARAMETERS_SCALE,
-                        RoundingMode.HALF_UP).toPlainString());
+                RoundingMode.HALF_UP).toPlainString());
 
         ((JTextComponent) fractionDate207_206r_Pa_Text.get(row)).setText(tempFrac.getRadiogenicIsotopeDateByName(RadDates.age207_206r_Pa.getName()).getValue().
                 movePointLeft(6).setScale(ReduxConstants.DEFAULT_DEFAULTS_SCALE,
-                        RoundingMode.HALF_UP).toPlainString());
+                RoundingMode.HALF_UP).toPlainString());
 
         ((JTextComponent) fractionDate207_206r_Pa2SigmaAbs_Text.get(row)).setText(tempFrac.getRadiogenicIsotopeDateByName(RadDates.age207_206r_Pa.getName()).getTwoSigmaAbs().
                 movePointLeft(6).setScale(ReduxConstants.DEFAULT_PARAMETERS_SCALE,
-                        RoundingMode.HALF_UP).toPlainString());
+                RoundingMode.HALF_UP).toPlainString());
 
     }
 
@@ -1089,7 +1089,7 @@ public class AliquotLegacyEditorForIDTIMS extends AliquotEditorDialog {
     private void saveAliquot() {
 
         // general info
-        getMyAliquot().setAliquotName(aliquotName_text.getText());
+        myAliquot.setAliquotName(aliquotName_text.getText().trim());
         this.setTitle("Aliquot # " + getMyAliquot().getAliquotNumber() + " <> " + getMyAliquot().getAliquotName());
 
         getMyAliquot().setAnalystName(analystName_text.getText());
@@ -1130,6 +1130,11 @@ public class AliquotLegacyEditorForIDTIMS extends AliquotEditorDialog {
         for (ETFractionInterface f : getMyAliquot().getAliquotFractions()) {
             saveAliquotFraction(f);
         }
+
+        // sept 2016
+        myAliquot.setAliquotIGSN(aliquotIGSN_text.getText().trim());
+        
+        validateIGSNs();
 
         // save the sample
         SampleInterface.saveSampleAsSerializedReduxFile(sample);

--- a/src/main/java/org/earthtime/UPb_Redux/dialogs/aliquotManagers/AliquotLegacyEditorForLAICPMS.java
+++ b/src/main/java/org/earthtime/UPb_Redux/dialogs/aliquotManagers/AliquotLegacyEditorForLAICPMS.java
@@ -36,10 +36,8 @@ import javax.swing.JOptionPane;
 import javax.swing.text.JTextComponent;
 import org.earthtime.ETReduxFrame;
 import org.earthtime.UPb_Redux.ReduxConstants;
-import org.earthtime.UPb_Redux.aliquots.UPbReduxAliquot;
 import org.earthtime.UPb_Redux.exceptions.BadLabDataException;
 import org.earthtime.UPb_Redux.fractions.UPbReduxFractions.UPbFraction;
-import org.earthtime.reduxLabData.ReduxLabData;
 import org.earthtime.UPb_Redux.renderers.EditFractionButton;
 import org.earthtime.UPb_Redux.valueModels.ValueModel;
 import org.earthtime.aliquots.AliquotInterface;
@@ -48,6 +46,7 @@ import org.earthtime.dataDictionaries.RadDates;
 import org.earthtime.exceptions.ETException;
 import org.earthtime.exceptions.ETWarningDialog;
 import org.earthtime.fractions.ETFractionInterface;
+import org.earthtime.reduxLabData.ReduxLabData;
 import org.earthtime.samples.SampleInterface;
 import org.earthtime.xmlUtilities.XMLSerializationI;
 import org.jdesktop.layout.GroupLayout.ParallelGroup;
@@ -894,7 +893,7 @@ public class AliquotLegacyEditorForLAICPMS extends AliquotEditorDialog {
         this.setTitle("Aliquot # " + getMyAliquot().getAliquotNumber() + " <> " + getMyAliquot().getAliquotName());
 
         getMyAliquot().setAnalystName(analystName_text.getText());
-        ((UPbReduxAliquot) getMyAliquot()).getMyReduxLabData().setAnalystName(analystName_text.getText());
+        getMyAliquot().getMyReduxLabData().setAnalystName(analystName_text.getText());
         getMyAliquot().setAliquotInstrumentalMethod(
                 instrumentalMethod_jcombo.getSelectedItem().toString());
         getMyAliquot().setAliquotInstrumentalMethodReference(instMethodRef_text.getText());
@@ -943,6 +942,12 @@ public class AliquotLegacyEditorForLAICPMS extends AliquotEditorDialog {
         // removed april 2011 as part of registry upgrade
 //        getMyAliquot().setSampleIGSN( aliquotIGSN_text.getText().trim() );
 //        sample.setSampleIGSN( aliquotIGSN_text.getText().trim() );
+
+       // sept 2016
+        myAliquot.setAliquotIGSN(aliquotIGSN_text.getText().trim());
+        
+        validateIGSNs();
+
         SampleInterface.saveSampleAsSerializedReduxFile(sample);
 
         System.out.println("**************** PRE-PUBLISH CHECKLIST FOR ALIQUOT");

--- a/src/main/java/org/earthtime/UPb_Redux/dialogs/graphManagers/WeightedMeanOptionsDialog.form
+++ b/src/main/java/org/earthtime/UPb_Redux/dialogs/graphManagers/WeightedMeanOptionsDialog.form
@@ -35,7 +35,7 @@
     <DimensionLayout dim="1">
       <Group type="103" groupAlignment="0" attributes="0">
           <Group type="102" alignment="1" attributes="0">
-              <EmptySpace pref="363" max="32767" attributes="0"/>
+              <EmptySpace pref="366" max="32767" attributes="0"/>
               <Component id="buttonsPanel" min="-2" max="-2" attributes="0"/>
           </Group>
           <Group type="103" rootIndex="1" groupAlignment="0" attributes="0">
@@ -74,8 +74,8 @@
         <DimensionLayout dim="1">
           <Group type="103" groupAlignment="0" attributes="0">
               <Group type="103" alignment="0" groupAlignment="3" attributes="0">
-                  <Component id="save_button" alignment="3" min="-2" pref="28" max="-2" attributes="0"/>
-                  <Component id="close_button" alignment="3" min="-2" pref="28" max="-2" attributes="0"/>
+                  <Component id="save_button" alignment="3" min="-2" pref="25" max="-2" attributes="0"/>
+                  <Component id="close_button" alignment="3" min="-2" pref="25" max="-2" attributes="0"/>
               </Group>
           </Group>
         </DimensionLayout>
@@ -97,6 +97,9 @@
           <Events>
             <EventHandler event="actionPerformed" listener="java.awt.event.ActionListener" parameters="java.awt.event.ActionEvent" handler="save_buttonActionPerformed"/>
           </Events>
+          <AuxValues>
+            <AuxValue name="JavaCodeGenerator_CreateCodeCustom" type="java.lang.String" value="new ET_JButton();"/>
+          </AuxValues>
         </Component>
         <Component class="javax.swing.JButton" name="close_button">
           <Properties>
@@ -114,6 +117,9 @@
           <Events>
             <EventHandler event="actionPerformed" listener="java.awt.event.ActionListener" parameters="java.awt.event.ActionEvent" handler="close_buttonActionPerformed"/>
           </Events>
+          <AuxValues>
+            <AuxValue name="JavaCodeGenerator_CreateCodeCustom" type="java.lang.String" value="new ET_JButton();"/>
+          </AuxValues>
         </Component>
       </SubComponents>
     </Container>

--- a/src/main/java/org/earthtime/UPb_Redux/dialogs/graphManagers/WeightedMeanOptionsDialog.java
+++ b/src/main/java/org/earthtime/UPb_Redux/dialogs/graphManagers/WeightedMeanOptionsDialog.java
@@ -26,6 +26,7 @@ import javax.swing.JCheckBox;
 import javax.swing.JLabel;
 import org.earthtime.UPb_Redux.valueModels.SampleDateModel;
 import org.earthtime.aliquots.AliquotInterface;
+import org.earthtime.beans.ET_JButton;
 import org.earthtime.dialogs.DialogEditor;
 import org.earthtime.samples.SampleInterface;
 import org.jdesktop.layout.GroupLayout.ParallelGroup;
@@ -454,8 +455,8 @@ public class WeightedMeanOptionsDialog extends DialogEditor {
     private void initComponents() {
 
         buttonsPanel = new javax.swing.JPanel();
-        save_button = new javax.swing.JButton();
-        close_button = new javax.swing.JButton();
+        save_button = new ET_JButton();
+        close_button = new ET_JButton();
         jScrollPane1 = new javax.swing.JScrollPane();
         wmAliquotArray_panel = new javax.swing.JPanel();
         jLabel8 = new javax.swing.JLabel();
@@ -503,13 +504,13 @@ public class WeightedMeanOptionsDialog extends DialogEditor {
         buttonsPanelLayout.setVerticalGroup(
             buttonsPanelLayout.createParallelGroup(org.jdesktop.layout.GroupLayout.LEADING)
             .add(buttonsPanelLayout.createParallelGroup(org.jdesktop.layout.GroupLayout.BASELINE)
-                .add(save_button, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE, 28, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE)
-                .add(close_button, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE, 28, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE))
+                .add(save_button, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE, 25, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE)
+                .add(close_button, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE, 25, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE))
         );
 
         wmAliquotArray_panel.setBackground(new java.awt.Color(244, 255, 244));
 
-        jLabel8.setFont(new java.awt.Font("SansSerif", 1, 18));
+        jLabel8.setFont(new java.awt.Font("Lucida Grande", 1, 18)); // NOI18N
         jLabel8.setHorizontalAlignment(javax.swing.SwingConstants.CENTER);
         jLabel8.setText("Weighted Mean Sample Date Interpretation");
 
@@ -543,7 +544,7 @@ public class WeightedMeanOptionsDialog extends DialogEditor {
         layout.setVerticalGroup(
             layout.createParallelGroup(org.jdesktop.layout.GroupLayout.LEADING)
             .add(org.jdesktop.layout.GroupLayout.TRAILING, layout.createSequentialGroup()
-                .addContainerGap(363, Short.MAX_VALUE)
+                .addContainerGap(366, Short.MAX_VALUE)
                 .add(buttonsPanel, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE, org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE))
             .add(layout.createParallelGroup(org.jdesktop.layout.GroupLayout.LEADING)
                 .add(org.jdesktop.layout.GroupLayout.TRAILING, layout.createSequentialGroup()

--- a/src/main/java/org/earthtime/UPb_Redux/dialogs/parameterManagers/AbstractProjectParametersManager.java
+++ b/src/main/java/org/earthtime/UPb_Redux/dialogs/parameterManagers/AbstractProjectParametersManager.java
@@ -204,7 +204,7 @@ public abstract class AbstractProjectParametersManager extends JLayeredPane {
     protected JRadioButton fullPropagationRB;
 
     protected ET_JButton monitorButton;
-    
+
     protected ET_JButton repropagateButton;
 
     /**
@@ -603,12 +603,17 @@ public abstract class AbstractProjectParametersManager extends JLayeredPane {
         propagationSpeedGroup.add(fastPropagationRB);
         fastPropagationRB.setBounds(leftMargin, 450, 300, 25);
         fastPropagationRB.setSelected(!rawDataFileHandler.getAcquisitionModel().isUsingFullPropagation());
+        fastPropagationRB.setOpaque(true);
+        fastPropagationRB.setBackground(this.getBackground());
         this.add(fastPropagationRB);
 
         fullPropagationRB = new JRadioButton("Full uncertainty propagation");
         propagationSpeedGroup.add(fullPropagationRB);
         fullPropagationRB.setBounds(leftMargin, 475, 300, 25);
         fullPropagationRB.setSelected(rawDataFileHandler.getAcquisitionModel().isUsingFullPropagation());
+        fullPropagationRB.setOpaque(true);
+        fullPropagationRB.setBackground(this.getBackground());
+
         this.add(fullPropagationRB);
 
         initReferenceMaterialChooser();
@@ -643,11 +648,9 @@ public abstract class AbstractProjectParametersManager extends JLayeredPane {
         JButton viewStandardModelButton = new ET_JButton("View");
         viewStandardModelButton.addActionListener((ActionEvent e) -> {
             AbstractRatiosDataModel selectedModel
-                    = 
-                    ((AbstractRatiosDataModel) mineralStandardsComboBox.getSelectedItem());
+                    = ((AbstractRatiosDataModel) mineralStandardsComboBox.getSelectedItem());
             AbstractRatiosDataView modelView
-                    = 
-                    new ReferenceMaterialUPbRatiosDataViewNotEditable(selectedModel, null, false);
+                    = new ReferenceMaterialUPbRatiosDataViewNotEditable(selectedModel, null, false);
             modelView.displayModelInFrame();
         });
         viewStandardModelButton.setFont(ReduxConstants.sansSerif_10_Bold);

--- a/src/main/java/org/earthtime/UPb_Redux/dialogs/parameterManagers/LAICPMSProjectParametersManager.java
+++ b/src/main/java/org/earthtime/UPb_Redux/dialogs/parameterManagers/LAICPMSProjectParametersManager.java
@@ -211,6 +211,8 @@ public class LAICPMSProjectParametersManager extends JLayeredPane {
 
     protected JTextField peakEndIndexTextBox;
 
+    protected AcquisitionTypesEnum acquisitionType;
+
     /**
      *
      * @param project
@@ -280,7 +282,7 @@ public class LAICPMSProjectParametersManager extends JLayeredPane {
         massSpecTypeLabel.setBounds(leftMargin, 45, parentDimension.width - 50, 25);
         this.add(massSpecTypeLabel);
 
-        AcquisitionTypesEnum acquisitionType = rawDataFileHandler.getAcquisitionType();
+        acquisitionType = rawDataFileHandler.getAcquisitionType();
 
         JLabel acquistionTypeLabel = new JLabel("Acquisition Type:   " + acquisitionType.getName());
         acquistionTypeLabel.setHorizontalAlignment(SwingConstants.LEFT);
@@ -924,19 +926,20 @@ public class LAICPMSProjectParametersManager extends JLayeredPane {
         }
 
         acquisitionModel.updateMassSpec(massSpecSetup);
+        // Aug 2016
+        if (acquisitionType.equals(AcquisitionTypesEnum.SINGLE_COLLECTOR)) {
+            acquisitionModel.setBaselineStartIndex(Integer.parseInt(baselineStartIndexTextBox.getText()));
+            rawDataFileHandler.setBaselineStartIndex(Integer.parseInt(baselineStartIndexTextBox.getText()));
 
-        acquisitionModel.setBaselineStartIndex(Integer.parseInt(baselineStartIndexTextBox.getText()));
-        rawDataFileHandler.setBaselineStartIndex(Integer.parseInt(baselineStartIndexTextBox.getText()));
+            acquisitionModel.setBaselineEndIndex(Integer.parseInt(baselineEndIndexTextBox.getText()));
+            rawDataFileHandler.setBaselineEndIndex(Integer.parseInt(baselineEndIndexTextBox.getText()));
 
-        acquisitionModel.setBaselineEndIndex(Integer.parseInt(baselineEndIndexTextBox.getText()));
-        rawDataFileHandler.setBaselineEndIndex(Integer.parseInt(baselineEndIndexTextBox.getText()));
+            acquisitionModel.setPeakStartIndex(Integer.parseInt(peakStartIndexTextBox.getText()));
+            rawDataFileHandler.setPeakStartIndex(Integer.parseInt(peakStartIndexTextBox.getText()));
 
-        acquisitionModel.setPeakStartIndex(Integer.parseInt(peakStartIndexTextBox.getText()));
-        rawDataFileHandler.setPeakStartIndex(Integer.parseInt(peakStartIndexTextBox.getText()));
-
-        acquisitionModel.setPeakEndIndex(Integer.parseInt(peakEndIndexTextBox.getText()));
-        rawDataFileHandler.setPeakEndIndex(Integer.parseInt(peakEndIndexTextBox.getText()));
-
+            acquisitionModel.setPeakEndIndex(Integer.parseInt(peakEndIndexTextBox.getText()));
+            rawDataFileHandler.setPeakEndIndex(Integer.parseInt(peakEndIndexTextBox.getText()));
+        }
         readyToProcessData = loadData;
     }
 

--- a/src/main/java/org/earthtime/UPb_Redux/dialogs/parameterManagers/LAICPMSProjectParametersManager.java
+++ b/src/main/java/org/earthtime/UPb_Redux/dialogs/parameterManagers/LAICPMSProjectParametersManager.java
@@ -675,12 +675,16 @@ public class LAICPMSProjectParametersManager extends JLayeredPane {
         propagationSpeedGroup.add(fastPropagationRB);
         fastPropagationRB.setBounds(leftMargin, 450, 300, 25);
         fastPropagationRB.setSelected(!rawDataFileHandler.getAcquisitionModel().isUsingFullPropagation());
+        fastPropagationRB.setOpaque(true);
+        fastPropagationRB.setBackground(this.getBackground());
         this.add(fastPropagationRB);
 
         final JRadioButton fullPropagationRB = new JRadioButton("Full uncertainty propagation");
         propagationSpeedGroup.add(fullPropagationRB);
         fullPropagationRB.setBounds(leftMargin, 475, 300, 25);
         fullPropagationRB.setSelected(rawDataFileHandler.getAcquisitionModel().isUsingFullPropagation());
+        fullPropagationRB.setOpaque(true);
+        fullPropagationRB.setBackground(this.getBackground());
         this.add(fullPropagationRB);
 
         // primary reference material chooser

--- a/src/main/java/org/earthtime/UPb_Redux/dialogs/sampleManagers/analysisManagers/SampleAnalysisWorkflowManagerIDTIMS.form
+++ b/src/main/java/org/earthtime/UPb_Redux/dialogs/sampleManagers/analysisManagers/SampleAnalysisWorkflowManagerIDTIMS.form
@@ -46,7 +46,7 @@
           <Group type="102" alignment="0" attributes="0">
               <Component id="sampleType_panel" min="-2" pref="20" max="-2" attributes="0"/>
               <EmptySpace max="-2" attributes="0"/>
-              <Component id="jLayeredPane1" pref="674" max="32767" attributes="0"/>
+              <Component id="jLayeredPane1" pref="679" max="32767" attributes="0"/>
               <EmptySpace max="-2" attributes="0"/>
               <Component id="jPanel2" min="-2" max="-2" attributes="0"/>
           </Group>
@@ -133,9 +133,12 @@
             <EventHandler event="mouseEntered" listener="java.awt.event.MouseListener" parameters="java.awt.event.MouseEvent" handler="sampleToolBox_buttonMouseEntered"/>
             <EventHandler event="actionPerformed" listener="java.awt.event.ActionListener" parameters="java.awt.event.ActionEvent" handler="saveSampleWithDataStructure_buttonActionPerformed"/>
           </Events>
+          <AuxValues>
+            <AuxValue name="JavaCodeGenerator_CreateCodeCustom" type="java.lang.String" value="new ET_JButton()"/>
+          </AuxValues>
           <Constraints>
             <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.DesignAbsoluteLayout" value="org.netbeans.modules.form.compat2.layouts.DesignAbsoluteLayout$AbsoluteConstraintsDescription">
-              <AbsoluteConstraints x="260" y="2" width="207" height="30"/>
+              <AbsoluteConstraints x="260" y="2" width="207" height="25"/>
             </Constraint>
           </Constraints>
         </Component>
@@ -168,9 +171,12 @@
             <EventHandler event="mouseEntered" listener="java.awt.event.MouseListener" parameters="java.awt.event.MouseEvent" handler="sampleToolBox_buttonMouseEntered"/>
             <EventHandler event="actionPerformed" listener="java.awt.event.ActionListener" parameters="java.awt.event.ActionEvent" handler="setSampleMetaDataFolder_buttonActionPerformed"/>
           </Events>
+          <AuxValues>
+            <AuxValue name="JavaCodeGenerator_CreateCodeCustom" type="java.lang.String" value="new ET_JButton()"/>
+          </AuxValues>
           <Constraints>
             <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.DesignAbsoluteLayout" value="org.netbeans.modules.form.compat2.layouts.DesignAbsoluteLayout$AbsoluteConstraintsDescription">
-              <AbsoluteConstraints x="823" y="2" width="205" height="30"/>
+              <AbsoluteConstraints x="823" y="2" width="205" height="25"/>
             </Constraint>
           </Constraints>
         </Component>
@@ -203,9 +209,12 @@
             <EventHandler event="mouseEntered" listener="java.awt.event.MouseListener" parameters="java.awt.event.MouseEvent" handler="sampleToolBox_buttonMouseEntered"/>
             <EventHandler event="actionPerformed" listener="java.awt.event.ActionListener" parameters="java.awt.event.ActionEvent" handler="saveAsSampleWithDataStructure_buttonActionPerformed"/>
           </Events>
+          <AuxValues>
+            <AuxValue name="JavaCodeGenerator_CreateCodeCustom" type="java.lang.String" value="new ET_JButton()"/>
+          </AuxValues>
           <Constraints>
             <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.DesignAbsoluteLayout" value="org.netbeans.modules.form.compat2.layouts.DesignAbsoluteLayout$AbsoluteConstraintsDescription">
-              <AbsoluteConstraints x="577" y="2" width="246" height="30"/>
+              <AbsoluteConstraints x="577" y="2" width="246" height="25"/>
             </Constraint>
           </Constraints>
         </Component>
@@ -238,9 +247,12 @@
             <EventHandler event="mouseEntered" listener="java.awt.event.MouseListener" parameters="java.awt.event.MouseEvent" handler="sampleToolBox_buttonMouseEntered"/>
             <EventHandler event="actionPerformed" listener="java.awt.event.ActionListener" parameters="java.awt.event.ActionEvent" handler="saveAsSample_buttonActionPerformed"/>
           </Events>
+          <AuxValues>
+            <AuxValue name="JavaCodeGenerator_CreateCodeCustom" type="java.lang.String" value="new ET_JButton()"/>
+          </AuxValues>
           <Constraints>
             <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.DesignAbsoluteLayout" value="org.netbeans.modules.form.compat2.layouts.DesignAbsoluteLayout$AbsoluteConstraintsDescription">
-              <AbsoluteConstraints x="467" y="2" width="-1" height="30"/>
+              <AbsoluteConstraints x="467" y="2" width="-1" height="25"/>
             </Constraint>
           </Constraints>
         </Component>
@@ -273,9 +285,12 @@
             <EventHandler event="mouseEntered" listener="java.awt.event.MouseListener" parameters="java.awt.event.MouseEvent" handler="sampleToolBox_buttonMouseEntered"/>
             <EventHandler event="actionPerformed" listener="java.awt.event.ActionListener" parameters="java.awt.event.ActionEvent" handler="revertToSaved_buttonActionPerformed"/>
           </Events>
+          <AuxValues>
+            <AuxValue name="JavaCodeGenerator_CreateCodeCustom" type="java.lang.String" value="new ET_JButton()"/>
+          </AuxValues>
           <Constraints>
             <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.DesignAbsoluteLayout" value="org.netbeans.modules.form.compat2.layouts.DesignAbsoluteLayout$AbsoluteConstraintsDescription">
-              <AbsoluteConstraints x="150" y="2" width="-1" height="30"/>
+              <AbsoluteConstraints x="150" y="2" width="-1" height="25"/>
             </Constraint>
           </Constraints>
         </Component>
@@ -308,9 +323,12 @@
             <EventHandler event="mouseEntered" listener="java.awt.event.MouseListener" parameters="java.awt.event.MouseEvent" handler="sampleToolBox_buttonMouseEntered"/>
             <EventHandler event="actionPerformed" listener="java.awt.event.ActionListener" parameters="java.awt.event.ActionEvent" handler="closeAndSave_buttonActionPerformed"/>
           </Events>
+          <AuxValues>
+            <AuxValue name="JavaCodeGenerator_CreateCodeCustom" type="java.lang.String" value="new ET_JButton()"/>
+          </AuxValues>
           <Constraints>
             <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.DesignAbsoluteLayout" value="org.netbeans.modules.form.compat2.layouts.DesignAbsoluteLayout$AbsoluteConstraintsDescription">
-              <AbsoluteConstraints x="0" y="2" width="150" height="30"/>
+              <AbsoluteConstraints x="0" y="2" width="150" height="25"/>
             </Constraint>
           </Constraints>
         </Component>
@@ -475,9 +493,12 @@
           <Events>
             <EventHandler event="actionPerformed" listener="java.awt.event.ActionListener" parameters="java.awt.event.ActionEvent" handler="insertFraction_buttonActionPerformed"/>
           </Events>
+          <AuxValues>
+            <AuxValue name="JavaCodeGenerator_CreateCodeCustom" type="java.lang.String" value="new ET_JButton()"/>
+          </AuxValues>
           <Constraints>
             <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.DesignAbsoluteLayout" value="org.netbeans.modules.form.compat2.layouts.DesignAbsoluteLayout$AbsoluteConstraintsDescription">
-              <AbsoluteConstraints x="330" y="160" width="130" height="-1"/>
+              <AbsoluteConstraints x="330" y="160" width="130" height="25"/>
             </Constraint>
           </Constraints>
         </Component>
@@ -488,9 +509,12 @@
           <Events>
             <EventHandler event="actionPerformed" listener="java.awt.event.ActionListener" parameters="java.awt.event.ActionEvent" handler="removeAliquot_buttonActionPerformed"/>
           </Events>
+          <AuxValues>
+            <AuxValue name="JavaCodeGenerator_CreateCodeCustom" type="java.lang.String" value="new ET_JButton()"/>
+          </AuxValues>
           <Constraints>
             <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.DesignAbsoluteLayout" value="org.netbeans.modules.form.compat2.layouts.DesignAbsoluteLayout$AbsoluteConstraintsDescription">
-              <AbsoluteConstraints x="300" y="220" width="220" height="-1"/>
+              <AbsoluteConstraints x="300" y="220" width="220" height="25"/>
             </Constraint>
           </Constraints>
         </Component>
@@ -669,9 +693,12 @@
           <Events>
             <EventHandler event="actionPerformed" listener="java.awt.event.ActionListener" parameters="java.awt.event.ActionEvent" handler="addAliquot_buttonActionPerformed"/>
           </Events>
+          <AuxValues>
+            <AuxValue name="JavaCodeGenerator_CreateCodeCustom" type="java.lang.String" value="new ET_JButton()"/>
+          </AuxValues>
           <Constraints>
             <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.DesignAbsoluteLayout" value="org.netbeans.modules.form.compat2.layouts.DesignAbsoluteLayout$AbsoluteConstraintsDescription">
-              <AbsoluteConstraints x="300" y="130" width="100" height="-1"/>
+              <AbsoluteConstraints x="300" y="130" width="100" height="25"/>
             </Constraint>
           </Constraints>
         </Component>
@@ -685,9 +712,12 @@
           <Events>
             <EventHandler event="actionPerformed" listener="java.awt.event.ActionListener" parameters="java.awt.event.ActionEvent" handler="importFractionFiles_buttonActionPerformed"/>
           </Events>
+          <AuxValues>
+            <AuxValue name="JavaCodeGenerator_CreateCodeCustom" type="java.lang.String" value="new ET_JButton()"/>
+          </AuxValues>
           <Constraints>
             <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.DesignAbsoluteLayout" value="org.netbeans.modules.form.compat2.layouts.DesignAbsoluteLayout$AbsoluteConstraintsDescription">
-              <AbsoluteConstraints x="330" y="190" width="190" height="-1"/>
+              <AbsoluteConstraints x="330" y="190" width="190" height="25"/>
             </Constraint>
           </Constraints>
         </Component>
@@ -944,9 +974,12 @@
           <Events>
             <EventHandler event="actionPerformed" listener="java.awt.event.ActionListener" parameters="java.awt.event.ActionEvent" handler="editAliquot_buttonActionPerformed"/>
           </Events>
+          <AuxValues>
+            <AuxValue name="JavaCodeGenerator_CreateCodeCustom" type="java.lang.String" value="new ET_JButton()"/>
+          </AuxValues>
           <Constraints>
             <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.DesignAbsoluteLayout" value="org.netbeans.modules.form.compat2.layouts.DesignAbsoluteLayout$AbsoluteConstraintsDescription">
-              <AbsoluteConstraints x="400" y="130" width="120" height="-1"/>
+              <AbsoluteConstraints x="400" y="130" width="120" height="25"/>
             </Constraint>
           </Constraints>
         </Component>
@@ -1082,6 +1115,9 @@
           <Events>
             <EventHandler event="actionPerformed" listener="java.awt.event.ActionListener" parameters="java.awt.event.ActionEvent" handler="validateSampleID_buttonActionPerformed"/>
           </Events>
+          <AuxValues>
+            <AuxValue name="JavaCodeGenerator_CreateCodeCustom" type="java.lang.String" value="new ET_JButton()"/>
+          </AuxValues>
           <Constraints>
             <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.DesignAbsoluteLayout" value="org.netbeans.modules.form.compat2.layouts.DesignAbsoluteLayout$AbsoluteConstraintsDescription">
               <AbsoluteConstraints x="370" y="33" width="20" height="20"/>

--- a/src/main/java/org/earthtime/UPb_Redux/dialogs/sampleManagers/analysisManagers/SampleAnalysisWorkflowManagerIDTIMS.java
+++ b/src/main/java/org/earthtime/UPb_Redux/dialogs/sampleManagers/analysisManagers/SampleAnalysisWorkflowManagerIDTIMS.java
@@ -79,6 +79,7 @@ import org.earthtime.UPb_Redux.utilities.comparators.IntuitiveStringComparator;
 import org.earthtime.UPb_Redux.valueModels.ValueModel;
 import org.earthtime.aliquots.AliquotInterface;
 import org.earthtime.aliquots.ReduxAliquotInterface;
+import org.earthtime.beans.ET_JButton;
 import org.earthtime.dataDictionaries.AnalysisMeasures;
 import org.earthtime.dataDictionaries.SampleRegistries;
 import org.earthtime.dialogs.DialogEditor;
@@ -1605,7 +1606,6 @@ public class SampleAnalysisWorkflowManagerIDTIMS extends DialogEditor implements
     }
 
     private void validateSampleID(String sampleID) {
-//        if (  ! mySample.isArchivedInRegistry() ) {
         boolean valid = SampleRegistries.isSampleIdentifierValidAtRegistry(//
                 sampleID);
         validSampleID_label.setText((String) (valid ? "Sample ID is Valid at registry." : "Sample ID is NOT valid at registry."));
@@ -2466,12 +2466,12 @@ public class SampleAnalysisWorkflowManagerIDTIMS extends DialogEditor implements
         sampleType_panel = new javax.swing.JPanel();
         sampleType_label = new javax.swing.JLabel();
         jPanel2 = new javax.swing.JPanel();
-        saveSampleWithDataStructure_button = new javax.swing.JButton();
-        setSampleMetaDataFolder_button = new javax.swing.JButton();
-        saveAsSampleWithDataStructure_button = new javax.swing.JButton();
-        saveAsSample_button = new javax.swing.JButton();
-        revertToSaved_button = new javax.swing.JButton();
-        closeAndSave_button = new javax.swing.JButton();
+        saveSampleWithDataStructure_button = new ET_JButton();
+        setSampleMetaDataFolder_button = new ET_JButton();
+        saveAsSampleWithDataStructure_button = new ET_JButton();
+        saveAsSample_button = new ET_JButton();
+        revertToSaved_button = new ET_JButton();
+        closeAndSave_button = new ET_JButton();
         jLayeredPane1 = new javax.swing.JLayeredPane();
         sampleIGSN_text = new javax.swing.JTextField();
         sampleID_label = new javax.swing.JLabel();
@@ -2480,11 +2480,11 @@ public class SampleAnalysisWorkflowManagerIDTIMS extends DialogEditor implements
         physicalConstantsModel_label = new javax.swing.JLabel();
         aliquotName_text = new javax.swing.JTextField();
         jScrollPane2 = new javax.swing.JScrollPane();
-        aliquotsList_jList = new javax.swing.JList<String>();
+        aliquotsList_jList = new javax.swing.JList<>();
         aliquotName_label = new javax.swing.JLabel();
         insertFractionCount_spinner = new javax.swing.JSpinner();
-        insertFraction_button = new javax.swing.JButton();
-        removeAliquot_button = new javax.swing.JButton();
+        insertFraction_button = new ET_JButton();
+        removeAliquot_button = new ET_JButton();
         aliquotFractionsArea_label = new javax.swing.JLabel();
         fastEdits_scrollPane = new javax.swing.JScrollPane();
         fastEdits_panel = new javax.swing.JPanel();
@@ -2496,8 +2496,8 @@ public class SampleAnalysisWorkflowManagerIDTIMS extends DialogEditor implements
         sampleMetaData_label = new javax.swing.JLabel();
         sampleMetaDataFolder_label = new javax.swing.JLabel();
         aliquotsArea_label = new javax.swing.JLabel();
-        addAliquot_button = new javax.swing.JButton();
-        importFractionFiles_button = new javax.swing.JButton();
+        addAliquot_button = new ET_JButton();
+        importFractionFiles_button = new ET_JButton();
         jTabbedPane1 = new javax.swing.JTabbedPane();
         jScrollPane1 = new javax.swing.JScrollPane();
         welcomeStatement_jTextArea = new javax.swing.JTextArea();
@@ -2513,16 +2513,16 @@ public class SampleAnalysisWorkflowManagerIDTIMS extends DialogEditor implements
         jTextArea3 = new javax.swing.JTextArea();
         moveAliquotDown_button = new javax.swing.JButton();
         moveAliquotUp_button = new javax.swing.JButton();
-        editAliquot_button = new javax.swing.JButton();
+        editAliquot_button = new ET_JButton();
         fractionTableHeader = new javax.swing.JLabel();
         chooseAnalysisPurpose_label = new javax.swing.JLabel();
-        analysisPurposeChooser = new javax.swing.JComboBox<String>();
-        physicalConstantsModelChooser = new javax.swing.JComboBox<String>();
+        analysisPurposeChooser = new javax.swing.JComboBox<>();
+        physicalConstantsModelChooser = new javax.swing.JComboBox<>();
         sampleRegistry_label = new javax.swing.JLabel();
-        sampleRegistryChooser = new javax.swing.JComboBox<SampleRegistries>();
+        sampleRegistryChooser = new javax.swing.JComboBox<>();
         validSampleID_label = new javax.swing.JLabel();
         allowTracerChange_checkbox = new javax.swing.JCheckBox();
-        validateSampleID_button = new javax.swing.JButton();
+        validateSampleID_button = new ET_JButton();
 
         setDefaultCloseOperation(javax.swing.WindowConstants.DISPOSE_ON_CLOSE);
         setResizable(false);
@@ -2577,7 +2577,7 @@ public class SampleAnalysisWorkflowManagerIDTIMS extends DialogEditor implements
                 saveSampleWithDataStructure_buttonActionPerformed(evt);
             }
         });
-        jPanel2.add(saveSampleWithDataStructure_button, new org.netbeans.lib.awtextra.AbsoluteConstraints(260, 2, 207, 30));
+        jPanel2.add(saveSampleWithDataStructure_button, new org.netbeans.lib.awtextra.AbsoluteConstraints(260, 2, 207, 25));
 
         setSampleMetaDataFolder_button.setBackground(new java.awt.Color(255, 255, 255));
         setSampleMetaDataFolder_button.setForeground(new java.awt.Color(255, 51, 0));
@@ -2601,7 +2601,7 @@ public class SampleAnalysisWorkflowManagerIDTIMS extends DialogEditor implements
                 setSampleMetaDataFolder_buttonActionPerformed(evt);
             }
         });
-        jPanel2.add(setSampleMetaDataFolder_button, new org.netbeans.lib.awtextra.AbsoluteConstraints(823, 2, 205, 30));
+        jPanel2.add(setSampleMetaDataFolder_button, new org.netbeans.lib.awtextra.AbsoluteConstraints(823, 2, 205, 25));
 
         saveAsSampleWithDataStructure_button.setBackground(new java.awt.Color(255, 255, 255));
         saveAsSampleWithDataStructure_button.setForeground(new java.awt.Color(255, 51, 0));
@@ -2625,7 +2625,7 @@ public class SampleAnalysisWorkflowManagerIDTIMS extends DialogEditor implements
                 saveAsSampleWithDataStructure_buttonActionPerformed(evt);
             }
         });
-        jPanel2.add(saveAsSampleWithDataStructure_button, new org.netbeans.lib.awtextra.AbsoluteConstraints(577, 2, 246, 30));
+        jPanel2.add(saveAsSampleWithDataStructure_button, new org.netbeans.lib.awtextra.AbsoluteConstraints(577, 2, 246, 25));
 
         saveAsSample_button.setBackground(new java.awt.Color(255, 255, 255));
         saveAsSample_button.setForeground(new java.awt.Color(255, 51, 0));
@@ -2649,7 +2649,7 @@ public class SampleAnalysisWorkflowManagerIDTIMS extends DialogEditor implements
                 saveAsSample_buttonActionPerformed(evt);
             }
         });
-        jPanel2.add(saveAsSample_button, new org.netbeans.lib.awtextra.AbsoluteConstraints(467, 2, -1, 30));
+        jPanel2.add(saveAsSample_button, new org.netbeans.lib.awtextra.AbsoluteConstraints(467, 2, -1, 25));
 
         revertToSaved_button.setBackground(new java.awt.Color(255, 255, 255));
         revertToSaved_button.setForeground(new java.awt.Color(255, 51, 0));
@@ -2673,7 +2673,7 @@ public class SampleAnalysisWorkflowManagerIDTIMS extends DialogEditor implements
                 revertToSaved_buttonActionPerformed(evt);
             }
         });
-        jPanel2.add(revertToSaved_button, new org.netbeans.lib.awtextra.AbsoluteConstraints(150, 2, -1, 30));
+        jPanel2.add(revertToSaved_button, new org.netbeans.lib.awtextra.AbsoluteConstraints(150, 2, -1, 25));
 
         closeAndSave_button.setBackground(new java.awt.Color(255, 255, 255));
         closeAndSave_button.setForeground(new java.awt.Color(255, 51, 0));
@@ -2697,7 +2697,7 @@ public class SampleAnalysisWorkflowManagerIDTIMS extends DialogEditor implements
                 closeAndSave_buttonActionPerformed(evt);
             }
         });
-        jPanel2.add(closeAndSave_button, new org.netbeans.lib.awtextra.AbsoluteConstraints(0, 2, 150, 30));
+        jPanel2.add(closeAndSave_button, new org.netbeans.lib.awtextra.AbsoluteConstraints(0, 2, 150, 25));
 
         jLayeredPane1.setBackground(new java.awt.Color(245, 236, 206));
         jLayeredPane1.setOpaque(true);
@@ -2712,7 +2712,7 @@ public class SampleAnalysisWorkflowManagerIDTIMS extends DialogEditor implements
             }
         });
         jLayeredPane1.add(sampleIGSN_text);
-        sampleIGSN_text.setBounds(270, 30, 100, 27);
+        sampleIGSN_text.setBounds(270, 30, 100, 25);
 
         sampleID_label.setFont(new java.awt.Font("Arial", 1, 12)); // NOI18N
         sampleID_label.setHorizontalAlignment(javax.swing.SwingConstants.RIGHT);
@@ -2724,7 +2724,7 @@ public class SampleAnalysisWorkflowManagerIDTIMS extends DialogEditor implements
         sampleName_text.setHorizontalAlignment(javax.swing.JTextField.CENTER);
         sampleName_text.setText("Sample Name");
         jLayeredPane1.add(sampleName_text);
-        sampleName_text.setBounds(130, 0, 190, 27);
+        sampleName_text.setBounds(130, 0, 190, 25);
 
         sampleName_label.setFont(new java.awt.Font("Arial", 1, 12)); // NOI18N
         sampleName_label.setHorizontalAlignment(javax.swing.SwingConstants.TRAILING);
@@ -2742,7 +2742,7 @@ public class SampleAnalysisWorkflowManagerIDTIMS extends DialogEditor implements
         aliquotName_text.setHorizontalAlignment(javax.swing.JTextField.CENTER);
         aliquotName_text.setText("Aliquot Name");
         jLayeredPane1.add(aliquotName_text);
-        aliquotName_text.setBounds(300, 100, 220, 27);
+        aliquotName_text.setBounds(300, 100, 220, 25);
 
         aliquotsList_jList.setSelectionMode(javax.swing.ListSelectionModel.SINGLE_SELECTION);
         jScrollPane2.setViewportView(aliquotsList_jList);
@@ -2757,7 +2757,7 @@ public class SampleAnalysisWorkflowManagerIDTIMS extends DialogEditor implements
 
         insertFractionCount_spinner.setFont(new java.awt.Font("Arial", 1, 12)); // NOI18N
         jLayeredPane1.add(insertFractionCount_spinner);
-        insertFractionCount_spinner.setBounds(460, 160, 52, 26);
+        insertFractionCount_spinner.setBounds(460, 160, 52, 24);
 
         insertFraction_button.setForeground(new java.awt.Color(255, 51, 0));
         insertFraction_button.setText("Insert Fractions:");
@@ -2767,7 +2767,7 @@ public class SampleAnalysisWorkflowManagerIDTIMS extends DialogEditor implements
             }
         });
         jLayeredPane1.add(insertFraction_button);
-        insertFraction_button.setBounds(330, 160, 130, 29);
+        insertFraction_button.setBounds(330, 160, 130, 25);
 
         removeAliquot_button.setText("Remove Selected Aliquot");
         removeAliquot_button.addActionListener(new java.awt.event.ActionListener() {
@@ -2776,7 +2776,7 @@ public class SampleAnalysisWorkflowManagerIDTIMS extends DialogEditor implements
             }
         });
         jLayeredPane1.add(removeAliquot_button);
-        removeAliquot_button.setBounds(300, 220, 220, 29);
+        removeAliquot_button.setBounds(300, 220, 220, 25);
 
         aliquotFractionsArea_label.setFont(new java.awt.Font("Arial", 1, 12)); // NOI18N
         aliquotFractionsArea_label.setHorizontalAlignment(javax.swing.SwingConstants.LEFT);
@@ -2858,7 +2858,7 @@ public class SampleAnalysisWorkflowManagerIDTIMS extends DialogEditor implements
             }
         });
         jLayeredPane1.add(addAliquot_button);
-        addAliquot_button.setBounds(300, 130, 100, 29);
+        addAliquot_button.setBounds(300, 130, 100, 25);
 
         importFractionFiles_button.setForeground(new java.awt.Color(255, 51, 0));
         importFractionFiles_button.setText("Import Fraction Files");
@@ -2868,7 +2868,7 @@ public class SampleAnalysisWorkflowManagerIDTIMS extends DialogEditor implements
             }
         });
         jLayeredPane1.add(importFractionFiles_button);
-        importFractionFiles_button.setBounds(330, 190, 190, 29);
+        importFractionFiles_button.setBounds(330, 190, 190, 25);
 
         welcomeStatement_jTextArea.setBackground(new java.awt.Color(238, 255, 255));
         welcomeStatement_jTextArea.setColumns(20);
@@ -2976,7 +2976,7 @@ public class SampleAnalysisWorkflowManagerIDTIMS extends DialogEditor implements
             }
         });
         jLayeredPane1.add(editAliquot_button);
-        editAliquot_button.setBounds(400, 130, 120, 29);
+        editAliquot_button.setBounds(400, 130, 120, 25);
 
         fractionTableHeader.setBackground(new java.awt.Color(238, 255, 255));
         fractionTableHeader.setFont(new java.awt.Font("Arial", 1, 12)); // NOI18N
@@ -3049,7 +3049,7 @@ public class SampleAnalysisWorkflowManagerIDTIMS extends DialogEditor implements
             .add(layout.createSequentialGroup()
                 .add(sampleType_panel, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE, 20, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE)
                 .addPreferredGap(org.jdesktop.layout.LayoutStyle.RELATED)
-                .add(jLayeredPane1, org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, 674, Short.MAX_VALUE)
+                .add(jLayeredPane1, org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, 679, Short.MAX_VALUE)
                 .addPreferredGap(org.jdesktop.layout.LayoutStyle.RELATED)
                 .add(jPanel2, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE, org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE))
         );

--- a/src/main/java/org/earthtime/UPb_Redux/dialogs/sampleManagers/heatMapManagers/HeatMapManager.form
+++ b/src/main/java/org/earthtime/UPb_Redux/dialogs/sampleManagers/heatMapManagers/HeatMapManager.form
@@ -95,6 +95,9 @@
           <Layout class="org.netbeans.modules.form.compat2.layouts.support.JTabbedPaneSupportLayout"/>
           <SubComponents>
             <Container class="javax.swing.JLayeredPane" name="compositionPanel">
+              <Properties>
+                <Property name="opaque" type="boolean" value="true"/>
+              </Properties>
               <Constraints>
                 <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.support.JTabbedPaneSupportLayout" value="org.netbeans.modules.form.compat2.layouts.support.JTabbedPaneSupportLayout$JTabbedPaneConstraintsDescription">
                   <JTabbedPaneConstraints tabName="Compostion">
@@ -117,6 +120,9 @@
               </Layout>
             </Container>
             <Container class="javax.swing.JLayeredPane" name="ratiosPanel">
+              <Properties>
+                <Property name="opaque" type="boolean" value="true"/>
+              </Properties>
               <Constraints>
                 <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.support.JTabbedPaneSupportLayout" value="org.netbeans.modules.form.compat2.layouts.support.JTabbedPaneSupportLayout$JTabbedPaneConstraintsDescription">
                   <JTabbedPaneConstraints tabName="Ratios">
@@ -139,6 +145,9 @@
               </Layout>
             </Container>
             <Container class="javax.swing.JLayeredPane" name="rhosPanel">
+              <Properties>
+                <Property name="opaque" type="boolean" value="true"/>
+              </Properties>
               <Constraints>
                 <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.support.JTabbedPaneSupportLayout" value="org.netbeans.modules.form.compat2.layouts.support.JTabbedPaneSupportLayout$JTabbedPaneConstraintsDescription">
                   <JTabbedPaneConstraints tabName="rhos">
@@ -161,6 +170,9 @@
               </Layout>
             </Container>
             <Container class="javax.swing.JLayeredPane" name="ratiosPbcCorrPanel">
+              <Properties>
+                <Property name="opaque" type="boolean" value="true"/>
+              </Properties>
               <Constraints>
                 <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.support.JTabbedPaneSupportLayout" value="org.netbeans.modules.form.compat2.layouts.support.JTabbedPaneSupportLayout$JTabbedPaneConstraintsDescription">
                   <JTabbedPaneConstraints tabName="Ratios PbcCorr">
@@ -183,6 +195,9 @@
               </Layout>
             </Container>
             <Container class="javax.swing.JLayeredPane" name="datesPanel">
+              <Properties>
+                <Property name="opaque" type="boolean" value="true"/>
+              </Properties>
               <Constraints>
                 <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.support.JTabbedPaneSupportLayout" value="org.netbeans.modules.form.compat2.layouts.support.JTabbedPaneSupportLayout$JTabbedPaneConstraintsDescription">
                   <JTabbedPaneConstraints tabName="Dates">
@@ -205,6 +220,9 @@
               </Layout>
             </Container>
             <Container class="javax.swing.JLayeredPane" name="datesPbcCorrPanel">
+              <Properties>
+                <Property name="opaque" type="boolean" value="true"/>
+              </Properties>
               <Constraints>
                 <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.support.JTabbedPaneSupportLayout" value="org.netbeans.modules.form.compat2.layouts.support.JTabbedPaneSupportLayout$JTabbedPaneConstraintsDescription">
                   <JTabbedPaneConstraints tabName="Dates PbcCorr">
@@ -227,6 +245,9 @@
               </Layout>
             </Container>
             <Container class="javax.swing.JLayeredPane" name="traceElementsPanel">
+              <Properties>
+                <Property name="opaque" type="boolean" value="true"/>
+              </Properties>
               <Constraints>
                 <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.support.JTabbedPaneSupportLayout" value="org.netbeans.modules.form.compat2.layouts.support.JTabbedPaneSupportLayout$JTabbedPaneConstraintsDescription">
                   <JTabbedPaneConstraints tabName="Trace Elements">
@@ -249,6 +270,9 @@
               </Layout>
             </Container>
             <Container class="javax.swing.JLayeredPane" name="customPanel">
+              <Properties>
+                <Property name="opaque" type="boolean" value="true"/>
+              </Properties>
               <Constraints>
                 <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.support.JTabbedPaneSupportLayout" value="org.netbeans.modules.form.compat2.layouts.support.JTabbedPaneSupportLayout$JTabbedPaneConstraintsDescription">
                   <JTabbedPaneConstraints tabName="Custom Ratios">

--- a/src/main/java/org/earthtime/UPb_Redux/dialogs/sampleManagers/heatMapManagers/HeatMapManager.java
+++ b/src/main/java/org/earthtime/UPb_Redux/dialogs/sampleManagers/heatMapManagers/HeatMapManager.java
@@ -39,13 +39,12 @@ import static javax.swing.SwingConstants.RIGHT;
 import static org.earthtime.UPb_Redux.ReduxConstants.sansSerif_11_Plain;
 import static org.earthtime.UPb_Redux.ReduxConstants.sansSerif_12_Plain;
 import org.earthtime.UPb_Redux.dateInterpretation.DateInterpretationUpdateViewI;
-import org.earthtime.dialogs.DialogEditor;
-import org.earthtime.UPb_Redux.reports.ReportCategory;
 import org.earthtime.UPb_Redux.user.SampleDateInterpretationGUIOptions;
 import org.earthtime.UPb_Redux.utilities.BrowserControl;
 import org.earthtime.beans.ET_JButton;
 import org.earthtime.colorViews.HeatMapMapper;
 import org.earthtime.colorViews.HeatMapView;
+import org.earthtime.dialogs.DialogEditor;
 import org.earthtime.reports.ReportCategoryInterface;
 import org.earthtime.reports.ReportColumnInterface;
 import org.earthtime.reports.ReportSettingsInterface;
@@ -88,8 +87,8 @@ public class HeatMapManager extends DialogEditor {
 
         this.reportSettings = sample.getReportSettingsModel();
 
-        this.heatMapOptions =//
-                sample.getSampleDateInterpretationGUISettings().getHeatMapOptions();
+        this.heatMapOptions
+                = sample.getSampleDateInterpretationGUISettings().getHeatMapOptions();
 
         this.heatMapActive = Boolean.valueOf(getStringEntryFromHeatMapOptions("activateHeatMap", "false"));
 
@@ -252,6 +251,8 @@ public class HeatMapManager extends DialogEditor {
                 btn.setActionCommand(varName);
                 btn.setBounds(10, layoutRow * 20, 300, 25);
                 btn.setFont(sansSerif_11_Plain);
+                btn.setOpaque(true);
+                btn.setBackground(categoryPanel.getBackground());
                 btn.addItemListener(new ItemListener() {
 
                     @Override
@@ -278,6 +279,8 @@ public class HeatMapManager extends DialogEditor {
                         btn.setActionCommand(varNameUnct);
                         btn.setBounds(325, layoutRow * 20, 300, 25);
                         btn.setFont(sansSerif_11_Plain);
+                        btn.setOpaque(true);
+                        btn.setBackground(categoryPanel.getBackground());
                         btn.addItemListener(new ItemListener() {
 
                             @Override
@@ -322,7 +325,7 @@ public class HeatMapManager extends DialogEditor {
         NumberFormat formatter = new DecimalFormat("0.0000E0");
         minLabel.setText(formatter.format(min));
         maxLabel.setText(formatter.format(max));
-        
+
         variableLabel.setText(selectedReportColumn.getDisplayName());
 
         if (selectedReportColumn.getRetrieveMethodName().contains("Date")) {
@@ -419,6 +422,8 @@ public class HeatMapManager extends DialogEditor {
         variablesChart_tabbedPane.setFont(new java.awt.Font("Arial", 0, 11)); // NOI18N
         variablesChart_tabbedPane.setOpaque(true);
 
+        compositionPanel.setOpaque(true);
+
         javax.swing.GroupLayout compositionPanelLayout = new javax.swing.GroupLayout(compositionPanel);
         compositionPanel.setLayout(compositionPanelLayout);
         compositionPanelLayout.setHorizontalGroup(
@@ -431,6 +436,8 @@ public class HeatMapManager extends DialogEditor {
         );
 
         variablesChart_tabbedPane.addTab("Compostion", compositionPanel);
+
+        ratiosPanel.setOpaque(true);
 
         javax.swing.GroupLayout ratiosPanelLayout = new javax.swing.GroupLayout(ratiosPanel);
         ratiosPanel.setLayout(ratiosPanelLayout);
@@ -445,6 +452,8 @@ public class HeatMapManager extends DialogEditor {
 
         variablesChart_tabbedPane.addTab("Ratios", ratiosPanel);
 
+        rhosPanel.setOpaque(true);
+
         javax.swing.GroupLayout rhosPanelLayout = new javax.swing.GroupLayout(rhosPanel);
         rhosPanel.setLayout(rhosPanelLayout);
         rhosPanelLayout.setHorizontalGroup(
@@ -457,6 +466,8 @@ public class HeatMapManager extends DialogEditor {
         );
 
         variablesChart_tabbedPane.addTab("rhos", rhosPanel);
+
+        ratiosPbcCorrPanel.setOpaque(true);
 
         javax.swing.GroupLayout ratiosPbcCorrPanelLayout = new javax.swing.GroupLayout(ratiosPbcCorrPanel);
         ratiosPbcCorrPanel.setLayout(ratiosPbcCorrPanelLayout);
@@ -471,6 +482,8 @@ public class HeatMapManager extends DialogEditor {
 
         variablesChart_tabbedPane.addTab("Ratios PbcCorr", ratiosPbcCorrPanel);
 
+        datesPanel.setOpaque(true);
+
         javax.swing.GroupLayout datesPanelLayout = new javax.swing.GroupLayout(datesPanel);
         datesPanel.setLayout(datesPanelLayout);
         datesPanelLayout.setHorizontalGroup(
@@ -483,6 +496,8 @@ public class HeatMapManager extends DialogEditor {
         );
 
         variablesChart_tabbedPane.addTab("Dates", datesPanel);
+
+        datesPbcCorrPanel.setOpaque(true);
 
         javax.swing.GroupLayout datesPbcCorrPanelLayout = new javax.swing.GroupLayout(datesPbcCorrPanel);
         datesPbcCorrPanel.setLayout(datesPbcCorrPanelLayout);
@@ -497,6 +512,8 @@ public class HeatMapManager extends DialogEditor {
 
         variablesChart_tabbedPane.addTab("Dates PbcCorr", datesPbcCorrPanel);
 
+        traceElementsPanel.setOpaque(true);
+
         javax.swing.GroupLayout traceElementsPanelLayout = new javax.swing.GroupLayout(traceElementsPanel);
         traceElementsPanel.setLayout(traceElementsPanelLayout);
         traceElementsPanelLayout.setHorizontalGroup(
@@ -509,6 +526,8 @@ public class HeatMapManager extends DialogEditor {
         );
 
         variablesChart_tabbedPane.addTab("Trace Elements", traceElementsPanel);
+
+        customPanel.setOpaque(true);
 
         javax.swing.GroupLayout customPanelLayout = new javax.swing.GroupLayout(customPanel);
         customPanel.setLayout(customPanelLayout);

--- a/src/main/java/org/earthtime/UPb_Redux/dialogs/sampleManagers/legacyManagers/AbstractSampleLegacyManagerDialog.form
+++ b/src/main/java/org/earthtime/UPb_Redux/dialogs/sampleManagers/legacyManagers/AbstractSampleLegacyManagerDialog.form
@@ -259,13 +259,16 @@
             <Property name="background" type="java.awt.Color" editor="org.netbeans.beaninfo.editors.ColorEditor">
               <Color blue="ce" green="ec" red="f5" type="rgb"/>
             </Property>
+            <Property name="font" type="java.awt.Font" editor="org.netbeans.beaninfo.editors.FontEditor">
+              <Font name="Lucida Grande" size="10" style="0"/>
+            </Property>
           </Properties>
           <AuxValues>
             <AuxValue name="JavaCodeGenerator_TypeParameters" type="java.lang.String" value="&lt;String&gt;"/>
           </AuxValues>
           <Constraints>
             <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.DesignAbsoluteLayout" value="org.netbeans.modules.form.compat2.layouts.DesignAbsoluteLayout$AbsoluteConstraintsDescription">
-              <AbsoluteConstraints x="193" y="115" width="270" height="-1"/>
+              <AbsoluteConstraints x="183" y="115" width="290" height="-1"/>
             </Constraint>
           </Constraints>
         </Component>
@@ -498,9 +501,12 @@
           <Events>
             <EventHandler event="actionPerformed" listener="java.awt.event.ActionListener" parameters="java.awt.event.ActionEvent" handler="validateIGSNActionPerformed"/>
           </Events>
+          <AuxValues>
+            <AuxValue name="JavaCodeGenerator_CreateCodeCustom" type="java.lang.String" value="new ET_JButton()"/>
+          </AuxValues>
           <Constraints>
             <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.DesignAbsoluteLayout" value="org.netbeans.modules.form.compat2.layouts.DesignAbsoluteLayout$AbsoluteConstraintsDescription">
-              <AbsoluteConstraints x="230" y="85" width="230" height="32"/>
+              <AbsoluteConstraints x="230" y="85" width="230" height="25"/>
             </Constraint>
           </Constraints>
         </Component>
@@ -530,8 +536,8 @@
         <DimensionLayout dim="1">
           <Group type="103" groupAlignment="0" attributes="0">
               <Group type="103" alignment="0" groupAlignment="3" attributes="0">
-                  <Component id="saveAndClose" alignment="3" min="-2" pref="32" max="-2" attributes="0"/>
-                  <Component id="close" alignment="3" min="-2" pref="32" max="-2" attributes="0"/>
+                  <Component id="saveAndClose" alignment="3" min="-2" pref="25" max="-2" attributes="0"/>
+                  <Component id="close" alignment="3" min="-2" pref="25" max="-2" attributes="0"/>
               </Group>
           </Group>
         </DimensionLayout>
@@ -553,6 +559,9 @@
           <Events>
             <EventHandler event="actionPerformed" listener="java.awt.event.ActionListener" parameters="java.awt.event.ActionEvent" handler="closeActionPerformed"/>
           </Events>
+          <AuxValues>
+            <AuxValue name="JavaCodeGenerator_CreateCodeCustom" type="java.lang.String" value="new ET_JButton()"/>
+          </AuxValues>
         </Component>
         <Component class="javax.swing.JButton" name="saveAndClose">
           <Properties>
@@ -570,6 +579,9 @@
           <Events>
             <EventHandler event="actionPerformed" listener="java.awt.event.ActionListener" parameters="java.awt.event.ActionEvent" handler="saveAndCloseActionPerformed"/>
           </Events>
+          <AuxValues>
+            <AuxValue name="JavaCodeGenerator_CreateCodeCustom" type="java.lang.String" value="new ET_JButton()"/>
+          </AuxValues>
         </Component>
       </SubComponents>
     </Container>

--- a/src/main/java/org/earthtime/UPb_Redux/dialogs/sampleManagers/legacyManagers/AbstractSampleLegacyManagerDialog.java
+++ b/src/main/java/org/earthtime/UPb_Redux/dialogs/sampleManagers/legacyManagers/AbstractSampleLegacyManagerDialog.java
@@ -28,22 +28,23 @@ import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.Vector;
 import org.earthtime.UPb_Redux.ReduxConstants.ANALYSIS_PURPOSE;
-import org.earthtime.UPb_Redux.aliquots.UPbReduxAliquot;
-import org.earthtime.dialogs.DialogEditor;
 import org.earthtime.UPb_Redux.exceptions.BadImportedCSVLegacyFileException;
 import org.earthtime.UPb_Redux.exceptions.BadLabDataException;
 import org.earthtime.UPb_Redux.fractions.FractionI;
 import org.earthtime.UPb_Redux.fractions.UPbReduxFractions.UPbFractionI;
-import org.earthtime.reduxLabData.ReduxLabData;
 import org.earthtime.UPb_Redux.samples.UPbSampleInterface;
 import org.earthtime.UPb_Redux.samples.sampleImporters.AbstractSampleImporterFromLegacyCSVFile;
 import org.earthtime.aliquots.AliquotInterface;
+import org.earthtime.aliquots.ReduxAliquotInterface;
+import org.earthtime.beans.ET_JButton;
 import org.earthtime.dataDictionaries.MineralTypes;
 import org.earthtime.dataDictionaries.SampleRegistries;
+import org.earthtime.dialogs.DialogEditor;
 import org.earthtime.exceptions.ETException;
 import org.earthtime.exceptions.ETWarningDialog;
 import org.earthtime.fractions.ETFractionInterface;
 import org.earthtime.ratioDataModels.AbstractRatiosDataModel;
+import org.earthtime.reduxLabData.ReduxLabData;
 import org.earthtime.samples.SampleInterface;
 
 /**
@@ -96,7 +97,8 @@ public abstract class AbstractSampleLegacyManagerDialog extends DialogEditor {
         this.converter = converter;
 
         // april 2011
-        validateSampleID();
+        // removed sept 2016
+        //       validateSampleID();
     }
 
     /**
@@ -124,17 +126,14 @@ public abstract class AbstractSampleLegacyManagerDialog extends DialogEditor {
 
     private void validateSampleID() {
 
-        try {
-            saveSampleData();
+        mySample.setSampleIGSN(((SampleRegistries) sampleRegistryChooser.getSelectedItem()).getCode() + "." + sampleIGSN_text.getText().trim());
+        mySample.setSampleRegistry((SampleRegistries) sampleRegistryChooser.getSelectedItem());
 
-            if (!mySample.isArchivedInRegistry()) {
-                boolean valid = SampleRegistries.isSampleIdentifierValidAtRegistry(//
-                        mySample.getSampleIGSN());
-                validSampleIGSN_label.setText((String) (valid ? "Sample IGSN is Valid at registry." : "Sample IGSN is NOT valid at registry."));
-                mySample.setValidatedSampleIGSN(valid);
-            }
-        } catch (ETException ex) {
-            new ETWarningDialog(ex).setVisible(true);
+        if (!mySample.isArchivedInRegistry()) {
+            boolean valid = SampleRegistries.isSampleIdentifierValidAtRegistry(//
+                    mySample.getSampleIGSN());
+            validSampleIGSN_label.setText((String) (valid ? "Sample IGSN is Valid at registry." : "Sample IGSN is NOT valid at registry."));
+            mySample.setValidatedSampleIGSN(valid);
         }
     }
 
@@ -276,8 +275,8 @@ public abstract class AbstractSampleLegacyManagerDialog extends DialogEditor {
         if (getMySample().getFractions().isEmpty()) {
             AliquotInterface myAliquot = getMySample().addNewAliquot(aliquotName_text.getText().trim());
             // May 2010 allows publication of legacy results
-            ((UPbReduxAliquot) myAliquot).setCompiled(false);
-            int myAliquotNumber = ((UPbReduxAliquot) myAliquot).getAliquotNumber();
+            ((ReduxAliquotInterface) myAliquot).setCompiled(false);
+            int myAliquotNumber = myAliquot.getAliquotNumber();
 
             // test for manual mode or bulk import from CSV file
             if (manualMode_radioBut.isSelected()) {
@@ -317,11 +316,11 @@ public abstract class AbstractSampleLegacyManagerDialog extends DialogEditor {
             try {
                 f.setPhysicalConstantsModel(getMySample().getPhysicalConstantsModel());
 
-                ((FractionI)f).setMineralName(mySample.getMineralName());
+                ((FractionI) f).setMineralName(mySample.getMineralName());
                 if (mySample.getMineralName().equalsIgnoreCase("zircon")) {
-                    ((FractionI)f).setZircon(true);
+                    ((FractionI) f).setZircon(true);
                 } else {
-                    ((FractionI)f).setZircon(false);
+                    ((FractionI) f).setZircon(false);
                 }
 
                 f.setLegacy(true);
@@ -422,25 +421,25 @@ public abstract class AbstractSampleLegacyManagerDialog extends DialogEditor {
         fractionDestinationPanel_panel = new javax.swing.JPanel();
         aliquotName_text = new javax.swing.JTextField();
         aliquotName_label = new javax.swing.JLabel();
-        physicalConstantsModelChooser = new javax.swing.JComboBox<String>();
+        physicalConstantsModelChooser = new javax.swing.JComboBox<>();
         defaultHeader_label = new javax.swing.JLabel();
         fractionSourcePanel_panel = new javax.swing.JPanel();
         manualMode_radioBut = new javax.swing.JRadioButton();
         bulkMode_radioBut = new javax.swing.JRadioButton();
-        standardMineralNameChooser = new javax.swing.JComboBox<String>();
+        standardMineralNameChooser = new javax.swing.JComboBox<>();
         chooseStandardMineral_label = new javax.swing.JLabel();
         chooseAnalysisPurpose_label = new javax.swing.JLabel();
-        analysisPurposeChooser = new javax.swing.JComboBox<String>();
+        analysisPurposeChooser = new javax.swing.JComboBox<>();
         chooseTWrho_label = new javax.swing.JLabel();
         TWZeroRho_radioBut = new javax.swing.JRadioButton();
         TWCalculateRho_radioBut = new javax.swing.JRadioButton();
         sampleIGSN_label1 = new javax.swing.JLabel();
-        sampleRegistryChooser = new javax.swing.JComboBox<SampleRegistries>();
+        sampleRegistryChooser = new javax.swing.JComboBox<>();
         validSampleIGSN_label = new javax.swing.JLabel();
-        validateIGSN = new javax.swing.JButton();
+        validateIGSN = new ET_JButton();
         jPanel2 = new javax.swing.JPanel();
-        close = new javax.swing.JButton();
-        saveAndClose = new javax.swing.JButton();
+        close = new ET_JButton();
+        saveAndClose = new ET_JButton();
         sampleType_panel = new javax.swing.JPanel();
         sampleType_label = new javax.swing.JLabel();
 
@@ -530,7 +529,8 @@ public abstract class AbstractSampleLegacyManagerDialog extends DialogEditor {
         jPanel1.add(fractionDestinationPanel_panel, new org.netbeans.lib.awtextra.AbsoluteConstraints(10, 210, 450, -1));
 
         physicalConstantsModelChooser.setBackground(new java.awt.Color(245, 236, 206));
-        jPanel1.add(physicalConstantsModelChooser, new org.netbeans.lib.awtextra.AbsoluteConstraints(193, 115, 270, -1));
+        physicalConstantsModelChooser.setFont(new java.awt.Font("Lucida Grande", 0, 10)); // NOI18N
+        jPanel1.add(physicalConstantsModelChooser, new org.netbeans.lib.awtextra.AbsoluteConstraints(183, 115, 290, -1));
 
         defaultHeader_label.setFont(new java.awt.Font("Tahoma", 1, 11)); // NOI18N
         defaultHeader_label.setForeground(new java.awt.Color(204, 51, 0));
@@ -617,7 +617,7 @@ public abstract class AbstractSampleLegacyManagerDialog extends DialogEditor {
                 validateIGSNActionPerformed(evt);
             }
         });
-        jPanel1.add(validateIGSN, new org.netbeans.lib.awtextra.AbsoluteConstraints(230, 85, 230, 32));
+        jPanel1.add(validateIGSN, new org.netbeans.lib.awtextra.AbsoluteConstraints(230, 85, 230, 25));
 
         jPanel2.setBorder(javax.swing.BorderFactory.createBevelBorder(javax.swing.border.BevelBorder.LOWERED));
 
@@ -655,8 +655,8 @@ public abstract class AbstractSampleLegacyManagerDialog extends DialogEditor {
         jPanel2Layout.setVerticalGroup(
             jPanel2Layout.createParallelGroup(org.jdesktop.layout.GroupLayout.LEADING)
             .add(jPanel2Layout.createParallelGroup(org.jdesktop.layout.GroupLayout.BASELINE)
-                .add(saveAndClose, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE, 32, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE)
-                .add(close, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE, 32, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE))
+                .add(saveAndClose, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE, 25, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE)
+                .add(close, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE, 25, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE))
         );
 
         sampleType_panel.setBorder(javax.swing.BorderFactory.createLineBorder(new java.awt.Color(0, 0, 0)));

--- a/src/main/java/org/earthtime/UPb_Redux/dialogs/sampleManagers/sampleDateInterpretationManagers/SampleDateInterpretationAny2AxesChooser.form
+++ b/src/main/java/org/earthtime/UPb_Redux/dialogs/sampleManagers/sampleDateInterpretationManagers/SampleDateInterpretationAny2AxesChooser.form
@@ -53,7 +53,7 @@
               <EmptySpace max="-2" attributes="0"/>
               <Component id="tracers_scrollPane" pref="297" max="32767" attributes="0"/>
               <EmptySpace min="-2" pref="24" max="-2" attributes="0"/>
-              <Component id="buttonsPanel" min="-2" max="-2" attributes="0"/>
+              <Component id="buttonsPanel" max="32767" attributes="0"/>
           </Group>
       </Group>
     </DimensionLayout>
@@ -103,8 +103,8 @@
         <DimensionLayout dim="1">
           <Group type="103" groupAlignment="0" attributes="0">
               <Group type="103" alignment="0" groupAlignment="3" attributes="0">
-                  <Component id="save_button" alignment="3" min="-2" pref="28" max="-2" attributes="0"/>
-                  <Component id="close_button" alignment="3" min="-2" pref="28" max="-2" attributes="0"/>
+                  <Component id="save_button" alignment="3" min="-2" pref="25" max="-2" attributes="0"/>
+                  <Component id="close_button" alignment="3" min="-2" pref="25" max="-2" attributes="0"/>
               </Group>
           </Group>
         </DimensionLayout>
@@ -126,6 +126,9 @@
           <Events>
             <EventHandler event="actionPerformed" listener="java.awt.event.ActionListener" parameters="java.awt.event.ActionEvent" handler="save_buttonActionPerformed"/>
           </Events>
+          <AuxValues>
+            <AuxValue name="JavaCodeGenerator_CreateCodeCustom" type="java.lang.String" value="new ET_JButton();"/>
+          </AuxValues>
         </Component>
         <Component class="javax.swing.JButton" name="close_button">
           <Properties>
@@ -143,6 +146,9 @@
           <Events>
             <EventHandler event="actionPerformed" listener="java.awt.event.ActionListener" parameters="java.awt.event.ActionEvent" handler="close_buttonActionPerformed"/>
           </Events>
+          <AuxValues>
+            <AuxValue name="JavaCodeGenerator_CreateCodeCustom" type="java.lang.String" value="new ET_JButton();"/>
+          </AuxValues>
         </Component>
       </SubComponents>
     </Container>

--- a/src/main/java/org/earthtime/UPb_Redux/dialogs/sampleManagers/sampleDateInterpretationManagers/SampleDateInterpretationAny2AxesChooser.java
+++ b/src/main/java/org/earthtime/UPb_Redux/dialogs/sampleManagers/sampleDateInterpretationManagers/SampleDateInterpretationAny2AxesChooser.java
@@ -19,6 +19,7 @@
 package org.earthtime.UPb_Redux.dialogs.sampleManagers.sampleDateInterpretationManagers;
 
 import java.util.Vector;
+import org.earthtime.beans.ET_JButton;
 import org.earthtime.dialogs.DialogEditor;
 
 /**
@@ -54,10 +55,10 @@ public class SampleDateInterpretationAny2AxesChooser extends DialogEditor {
     private void initComponents() {
 
         tracers_scrollPane = new javax.swing.JScrollPane();
-        axes_list = new javax.swing.JList<String>();
+        axes_list = new javax.swing.JList<>();
         buttonsPanel = new javax.swing.JPanel();
-        save_button = new javax.swing.JButton();
-        close_button = new javax.swing.JButton();
+        save_button = new ET_JButton();
+        close_button = new ET_JButton();
         chooseTracer_label = new javax.swing.JLabel();
 
         setDefaultCloseOperation(javax.swing.WindowConstants.DISPOSE_ON_CLOSE);
@@ -112,8 +113,8 @@ public class SampleDateInterpretationAny2AxesChooser extends DialogEditor {
         buttonsPanelLayout.setVerticalGroup(
             buttonsPanelLayout.createParallelGroup(org.jdesktop.layout.GroupLayout.LEADING)
             .add(buttonsPanelLayout.createParallelGroup(org.jdesktop.layout.GroupLayout.BASELINE)
-                .add(save_button, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE, 28, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE)
-                .add(close_button, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE, 28, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE))
+                .add(save_button, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE, 25, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE)
+                .add(close_button, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE, 25, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE))
         );
 
         chooseTracer_label.setText("Testing list of available axes:");
@@ -138,7 +139,7 @@ public class SampleDateInterpretationAny2AxesChooser extends DialogEditor {
                 .addPreferredGap(org.jdesktop.layout.LayoutStyle.RELATED)
                 .add(tracers_scrollPane, org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, 297, Short.MAX_VALUE)
                 .add(24, 24, 24)
-                .add(buttonsPanel, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE, org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE))
+                .add(buttonsPanel, org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE))
         );
 
         pack();

--- a/src/main/java/org/earthtime/UPb_Redux/dialogs/sampleManagers/sampleDateInterpretationManagers/SampleDateInterpretationChooserDialog.form
+++ b/src/main/java/org/earthtime/UPb_Redux/dialogs/sampleManagers/sampleDateInterpretationManagers/SampleDateInterpretationChooserDialog.form
@@ -95,9 +95,12 @@
           <Events>
             <EventHandler event="actionPerformed" listener="java.awt.event.ActionListener" parameters="java.awt.event.ActionEvent" handler="save_buttonActionPerformed"/>
           </Events>
+          <AuxValues>
+            <AuxValue name="JavaCodeGenerator_CreateCodeCustom" type="java.lang.String" value="new ET_JButton();"/>
+          </AuxValues>
           <Constraints>
             <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.DesignAbsoluteLayout" value="org.netbeans.modules.form.compat2.layouts.DesignAbsoluteLayout$AbsoluteConstraintsDescription">
-              <AbsoluteConstraints x="38" y="2" width="115" height="28"/>
+              <AbsoluteConstraints x="38" y="2" width="115" height="25"/>
             </Constraint>
           </Constraints>
         </Component>
@@ -117,9 +120,12 @@
           <Events>
             <EventHandler event="actionPerformed" listener="java.awt.event.ActionListener" parameters="java.awt.event.ActionEvent" handler="close_buttonActionPerformed"/>
           </Events>
+          <AuxValues>
+            <AuxValue name="JavaCodeGenerator_CreateCodeCustom" type="java.lang.String" value="new ET_JButton();"/>
+          </AuxValues>
           <Constraints>
             <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.DesignAbsoluteLayout" value="org.netbeans.modules.form.compat2.layouts.DesignAbsoluteLayout$AbsoluteConstraintsDescription">
-              <AbsoluteConstraints x="190" y="2" width="115" height="28"/>
+              <AbsoluteConstraints x="190" y="2" width="115" height="25"/>
             </Constraint>
           </Constraints>
         </Component>

--- a/src/main/java/org/earthtime/UPb_Redux/dialogs/sampleManagers/sampleDateInterpretationManagers/SampleDateInterpretationChooserDialog.java
+++ b/src/main/java/org/earthtime/UPb_Redux/dialogs/sampleManagers/sampleDateInterpretationManagers/SampleDateInterpretationChooserDialog.java
@@ -19,9 +19,10 @@
 package org.earthtime.UPb_Redux.dialogs.sampleManagers.sampleDateInterpretationManagers;
 
 import java.util.Vector;
-import org.earthtime.dialogs.DialogEditor;
 import org.earthtime.UPb_Redux.valueModels.SampleDateModel;
 import org.earthtime.UPb_Redux.valueModels.ValueModel;
+import org.earthtime.beans.ET_JButton;
+import org.earthtime.dialogs.DialogEditor;
 
 /**
  *
@@ -64,10 +65,10 @@ public class SampleDateInterpretationChooserDialog extends DialogEditor {
     private void initComponents() {
 
         tracers_scrollPane = new javax.swing.JScrollPane();
-        modelTypes_list = new javax.swing.JList<ValueModel>();
+        modelTypes_list = new javax.swing.JList<>();
         buttonsPanel = new javax.swing.JPanel();
-        save_button = new javax.swing.JButton();
-        close_button = new javax.swing.JButton();
+        save_button = new ET_JButton();
+        close_button = new ET_JButton();
         chooseTracer_label = new javax.swing.JLabel();
 
         setDefaultCloseOperation(javax.swing.WindowConstants.DISPOSE_ON_CLOSE);
@@ -101,7 +102,7 @@ public class SampleDateInterpretationChooserDialog extends DialogEditor {
                 save_buttonActionPerformed(evt);
             }
         });
-        buttonsPanel.add(save_button, new org.netbeans.lib.awtextra.AbsoluteConstraints(38, 2, 115, 28));
+        buttonsPanel.add(save_button, new org.netbeans.lib.awtextra.AbsoluteConstraints(38, 2, 115, 25));
 
         close_button.setForeground(new java.awt.Color(255, 51, 0));
         close_button.setText("Cancel");
@@ -112,7 +113,7 @@ public class SampleDateInterpretationChooserDialog extends DialogEditor {
                 close_buttonActionPerformed(evt);
             }
         });
-        buttonsPanel.add(close_button, new org.netbeans.lib.awtextra.AbsoluteConstraints(190, 2, 115, 28));
+        buttonsPanel.add(close_button, new org.netbeans.lib.awtextra.AbsoluteConstraints(190, 2, 115, 25));
 
         getContentPane().add(buttonsPanel, new org.netbeans.lib.awtextra.AbsoluteConstraints(0, 343, 340, -1));
 

--- a/src/main/java/org/earthtime/UPb_Redux/dialogs/sampleManagers/sampleDateInterpretationManagers/SampleDateInterpretationsManager.form
+++ b/src/main/java/org/earthtime/UPb_Redux/dialogs/sampleManagers/sampleDateInterpretationManagers/SampleDateInterpretationsManager.form
@@ -143,6 +143,9 @@
       <SubComponents>
         <Container class="javax.swing.JTabbedPane" name="dateTrees_tabs">
           <Properties>
+            <Property name="foreground" type="java.awt.Color" editor="org.netbeans.beaninfo.editors.ColorEditor">
+              <Color blue="33" green="33" red="ff" type="rgb"/>
+            </Property>
             <Property name="font" type="java.awt.Font" editor="org.netbeans.beaninfo.editors.FontEditor">
               <Font name="SansSerif" size="12" style="0"/>
             </Property>

--- a/src/main/java/org/earthtime/UPb_Redux/dialogs/sampleManagers/sampleDateInterpretationManagers/SampleDateInterpretationsManager.form
+++ b/src/main/java/org/earthtime/UPb_Redux/dialogs/sampleManagers/sampleDateInterpretationManagers/SampleDateInterpretationsManager.form
@@ -57,6 +57,14 @@
                 <EventHandler event="actionPerformed" listener="java.awt.event.ActionListener" parameters="java.awt.event.ActionEvent" handler="weightedMeansChooser_menuItemActionPerformed"/>
               </Events>
             </MenuItem>
+            <MenuItem class="javax.swing.JCheckBoxMenuItem" name="sortFractionsDateAsc_menuItemCheckBox">
+              <Properties>
+                <Property name="text" type="java.lang.String" value="Sort Fractions by Date Ascending in Weighted Means Chooser"/>
+              </Properties>
+              <Events>
+                <EventHandler event="actionPerformed" listener="java.awt.event.ActionListener" parameters="java.awt.event.ActionEvent" handler="sortFractionsDateAsc_menuItemCheckBoxActionPerformed"/>
+              </Events>
+            </MenuItem>
             <MenuItem class="javax.swing.JMenuItem" name="weightedMeansLookAndFeel_menuItem">
               <Properties>
                 <Property name="text" type="java.lang.String" value="Weighted Means Display Options"/>

--- a/src/main/java/org/earthtime/UPb_Redux/dialogs/sampleManagers/sampleDateInterpretationManagers/SampleDateInterpretationsManager.form
+++ b/src/main/java/org/earthtime/UPb_Redux/dialogs/sampleManagers/sampleDateInterpretationManagers/SampleDateInterpretationsManager.form
@@ -330,6 +330,9 @@
                     </Component>
                     <Component class="javax.swing.JCheckBox" name="ellipseCenters_checkbox">
                       <Properties>
+                        <Property name="background" type="java.awt.Color" editor="org.netbeans.beaninfo.editors.ColorEditor">
+                          <Color blue="e6" green="f1" red="ff" type="rgb"/>
+                        </Property>
                         <Property name="font" type="java.awt.Font" editor="org.netbeans.beaninfo.editors.FontEditor">
                           <Font name="SansSerif" size="10" style="1"/>
                         </Property>
@@ -347,6 +350,9 @@
                     </Component>
                     <Component class="javax.swing.JCheckBox" name="ellipseLabels_checkbox">
                       <Properties>
+                        <Property name="background" type="java.awt.Color" editor="org.netbeans.beaninfo.editors.ColorEditor">
+                          <Color blue="e6" green="f1" red="ff" type="rgb"/>
+                        </Property>
                         <Property name="font" type="java.awt.Font" editor="org.netbeans.beaninfo.editors.FontEditor">
                           <Font name="SansSerif" size="10" style="1"/>
                         </Property>
@@ -364,6 +370,9 @@
                     </Component>
                     <Component class="javax.swing.JCheckBox" name="concordiaErrors_checkbox">
                       <Properties>
+                        <Property name="background" type="java.awt.Color" editor="org.netbeans.beaninfo.editors.ColorEditor">
+                          <Color blue="e6" green="f1" red="ff" type="rgb"/>
+                        </Property>
                         <Property name="font" type="java.awt.Font" editor="org.netbeans.beaninfo.editors.FontEditor">
                           <Font name="SansSerif" size="10" style="1"/>
                         </Property>
@@ -456,7 +465,7 @@
                     <Component class="javax.swing.JRadioButton" name="concordiaFlavor_radioButton">
                       <Properties>
                         <Property name="background" type="java.awt.Color" editor="org.netbeans.beaninfo.editors.ColorEditor">
-                          <Color blue="ff" green="cc" red="cc" type="rgb"/>
+                          <Color blue="e6" green="f1" red="ff" type="rgb"/>
                         </Property>
                         <Property name="buttonGroup" type="javax.swing.ButtonGroup" editor="org.netbeans.modules.form.RADComponent$ButtonGroupPropertyEditor">
                           <ComponentRef name="concordiaTeraW_buttonGroup"/>
@@ -479,7 +488,7 @@
                     <Component class="javax.swing.JRadioButton" name="terraWasserburgFlavor_radioButton">
                       <Properties>
                         <Property name="background" type="java.awt.Color" editor="org.netbeans.beaninfo.editors.ColorEditor">
-                          <Color blue="ff" green="cc" red="cc" type="rgb"/>
+                          <Color blue="e6" green="f1" red="ff" type="rgb"/>
                         </Property>
                         <Property name="buttonGroup" type="javax.swing.ButtonGroup" editor="org.netbeans.modules.form.RADComponent$ButtonGroupPropertyEditor">
                           <ComponentRef name="concordiaTeraW_buttonGroup"/>
@@ -501,6 +510,9 @@
                     </Component>
                     <Component class="javax.swing.JCheckBox" name="thoriumCorrectionSelector_checkbox">
                       <Properties>
+                        <Property name="background" type="java.awt.Color" editor="org.netbeans.beaninfo.editors.ColorEditor">
+                          <Color blue="e6" green="f1" red="ff" type="rgb"/>
+                        </Property>
                         <Property name="font" type="java.awt.Font" editor="org.netbeans.beaninfo.editors.FontEditor">
                           <Font name="SansSerif" size="9" style="1"/>
                         </Property>
@@ -518,6 +530,9 @@
                     </Component>
                     <Component class="javax.swing.JCheckBox" name="protactiniumCorrectionSelector_checkbox">
                       <Properties>
+                        <Property name="background" type="java.awt.Color" editor="org.netbeans.beaninfo.editors.ColorEditor">
+                          <Color blue="e6" green="f1" red="ff" type="rgb"/>
+                        </Property>
                         <Property name="font" type="java.awt.Font" editor="org.netbeans.beaninfo.editors.FontEditor">
                           <Font name="SansSerif" size="9" style="1"/>
                         </Property>
@@ -535,6 +550,9 @@
                     </Component>
                     <Component class="javax.swing.JLabel" name="jLabel4">
                       <Properties>
+                        <Property name="background" type="java.awt.Color" editor="org.netbeans.beaninfo.editors.ColorEditor">
+                          <Color blue="e6" green="f1" red="ff" type="rgb"/>
+                        </Property>
                         <Property name="font" type="java.awt.Font" editor="org.netbeans.beaninfo.editors.FontEditor">
                           <Font name="SansSerif" size="9" style="1"/>
                         </Property>
@@ -588,6 +606,9 @@
                     </Component>
                     <Component class="javax.swing.JCheckBox" name="showExcludedFractions_checkbox">
                       <Properties>
+                        <Property name="background" type="java.awt.Color" editor="org.netbeans.beaninfo.editors.ColorEditor">
+                          <Color blue="e6" green="f1" red="ff" type="rgb"/>
+                        </Property>
                         <Property name="font" type="java.awt.Font" editor="org.netbeans.beaninfo.editors.FontEditor">
                           <Font name="SansSerif" size="10" style="1"/>
                         </Property>
@@ -606,7 +627,7 @@
                     <Component class="javax.swing.JRadioButton" name="thoriumConcordiaFlavor_radioButton">
                       <Properties>
                         <Property name="background" type="java.awt.Color" editor="org.netbeans.beaninfo.editors.ColorEditor">
-                          <Color blue="ff" green="cc" red="cc" type="rgb"/>
+                          <Color blue="e6" green="f1" red="ff" type="rgb"/>
                         </Property>
                         <Property name="buttonGroup" type="javax.swing.ButtonGroup" editor="org.netbeans.modules.form.RADComponent$ButtonGroupPropertyEditor">
                           <ComponentRef name="concordiaTeraW_buttonGroup"/>
@@ -628,6 +649,9 @@
                     </Component>
                     <Component class="javax.swing.JCheckBox" name="showFilteredFractions_checkbox">
                       <Properties>
+                        <Property name="background" type="java.awt.Color" editor="org.netbeans.beaninfo.editors.ColorEditor">
+                          <Color blue="e6" green="f1" red="ff" type="rgb"/>
+                        </Property>
                         <Property name="font" type="java.awt.Font" editor="org.netbeans.beaninfo.editors.FontEditor">
                           <Font name="SansSerif" size="10" style="1"/>
                         </Property>
@@ -644,6 +668,9 @@
                     </Component>
                     <Component class="javax.swing.JCheckBox" name="commonLeadCorrectionSelector_checkbox">
                       <Properties>
+                        <Property name="background" type="java.awt.Color" editor="org.netbeans.beaninfo.editors.ColorEditor">
+                          <Color blue="e6" green="f1" red="ff" type="rgb"/>
+                        </Property>
                         <Property name="font" type="java.awt.Font" editor="org.netbeans.beaninfo.editors.FontEditor">
                           <Font name="SansSerif" size="9" style="1"/>
                         </Property>
@@ -824,6 +851,9 @@
                     </Component>
                     <Component class="javax.swing.JLabel" name="jLabel1">
                       <Properties>
+                        <Property name="background" type="java.awt.Color" editor="org.netbeans.beaninfo.editors.ColorEditor">
+                          <Color blue="e5" green="fa" red="e5" type="rgb"/>
+                        </Property>
                         <Property name="font" type="java.awt.Font" editor="org.netbeans.beaninfo.editors.FontEditor">
                           <Font name="SansSerif" size="12" style="0"/>
                         </Property>
@@ -837,6 +867,9 @@
                     </Component>
                     <Component class="javax.swing.JRadioButton" name="fractionOrderByName_radioButton">
                       <Properties>
+                        <Property name="background" type="java.awt.Color" editor="org.netbeans.beaninfo.editors.ColorEditor">
+                          <Color blue="e5" green="fa" red="e5" type="rgb"/>
+                        </Property>
                         <Property name="buttonGroup" type="javax.swing.ButtonGroup" editor="org.netbeans.modules.form.RADComponent$ButtonGroupPropertyEditor">
                           <ComponentRef name="weightedMeanFractionOrderButtonGroup"/>
                         </Property>
@@ -858,6 +891,9 @@
                     </Component>
                     <Component class="javax.swing.JRadioButton" name="fractionOrderByWeight_radioButton">
                       <Properties>
+                        <Property name="background" type="java.awt.Color" editor="org.netbeans.beaninfo.editors.ColorEditor">
+                          <Color blue="e5" green="fa" red="e5" type="rgb"/>
+                        </Property>
                         <Property name="buttonGroup" type="javax.swing.ButtonGroup" editor="org.netbeans.modules.form.RADComponent$ButtonGroupPropertyEditor">
                           <ComponentRef name="weightedMeanFractionOrderButtonGroup"/>
                         </Property>
@@ -878,6 +914,9 @@
                     </Component>
                     <Component class="javax.swing.JRadioButton" name="fractionOrderByRandom_radioButton">
                       <Properties>
+                        <Property name="background" type="java.awt.Color" editor="org.netbeans.beaninfo.editors.ColorEditor">
+                          <Color blue="e5" green="fa" red="e5" type="rgb"/>
+                        </Property>
                         <Property name="buttonGroup" type="javax.swing.ButtonGroup" editor="org.netbeans.modules.form.RADComponent$ButtonGroupPropertyEditor">
                           <ComponentRef name="weightedMeanFractionOrderButtonGroup"/>
                         </Property>
@@ -899,6 +938,9 @@
                     </Component>
                     <Component class="javax.swing.JRadioButton" name="fractionOrderByDate_radioButton">
                       <Properties>
+                        <Property name="background" type="java.awt.Color" editor="org.netbeans.beaninfo.editors.ColorEditor">
+                          <Color blue="e5" green="fa" red="e5" type="rgb"/>
+                        </Property>
                         <Property name="buttonGroup" type="javax.swing.ButtonGroup" editor="org.netbeans.modules.form.RADComponent$ButtonGroupPropertyEditor">
                           <ComponentRef name="weightedMeanFractionOrderButtonGroup"/>
                         </Property>
@@ -1268,6 +1310,9 @@
                     </Component>
                     <Component class="javax.swing.JRadioButton" name="ageR207_206r_radioB">
                       <Properties>
+                        <Property name="background" type="java.awt.Color" editor="org.netbeans.beaninfo.editors.ColorEditor">
+                          <Color blue="ff" green="e6" red="f1" type="rgb"/>
+                        </Property>
                         <Property name="buttonGroup" type="javax.swing.ButtonGroup" editor="org.netbeans.modules.form.RADComponent$ButtonGroupPropertyEditor">
                           <ComponentRef name="probabilityDateButtonGroup"/>
                         </Property>
@@ -1285,6 +1330,9 @@
                     </Component>
                     <Component class="javax.swing.JRadioButton" name="ageR206_238r_radioB">
                       <Properties>
+                        <Property name="background" type="java.awt.Color" editor="org.netbeans.beaninfo.editors.ColorEditor">
+                          <Color blue="ff" green="e6" red="f1" type="rgb"/>
+                        </Property>
                         <Property name="buttonGroup" type="javax.swing.ButtonGroup" editor="org.netbeans.modules.form.RADComponent$ButtonGroupPropertyEditor">
                           <ComponentRef name="probabilityDateButtonGroup"/>
                         </Property>
@@ -1302,6 +1350,9 @@
                     </Component>
                     <Component class="javax.swing.JSlider" name="positivePctDiscordance_slider">
                       <Properties>
+                        <Property name="background" type="java.awt.Color" editor="org.netbeans.beaninfo.editors.ColorEditor">
+                          <Color blue="ff" green="e6" red="f1" type="rgb"/>
+                        </Property>
                         <Property name="font" type="java.awt.Font" editor="org.netbeans.beaninfo.editors.FontEditor">
                           <Font name="Arial" size="10" style="1"/>
                         </Property>
@@ -1315,12 +1366,15 @@
                       </Properties>
                       <Constraints>
                         <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.DesignAbsoluteLayout" value="org.netbeans.modules.form.compat2.layouts.DesignAbsoluteLayout$AbsoluteConstraintsDescription">
-                          <AbsoluteConstraints x="550" y="0" width="200" height="38"/>
+                          <AbsoluteConstraints x="550" y="5" width="200" height="38"/>
                         </Constraint>
                       </Constraints>
                     </Component>
                     <Component class="javax.swing.JSlider" name="percentUncertainty_slider">
                       <Properties>
+                        <Property name="background" type="java.awt.Color" editor="org.netbeans.beaninfo.editors.ColorEditor">
+                          <Color blue="ff" green="e6" red="f1" type="rgb"/>
+                        </Property>
                         <Property name="font" type="java.awt.Font" editor="org.netbeans.beaninfo.editors.FontEditor">
                           <Font name="Arial" size="10" style="1"/>
                         </Property>
@@ -1334,12 +1388,15 @@
                       </Properties>
                       <Constraints>
                         <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.DesignAbsoluteLayout" value="org.netbeans.modules.form.compat2.layouts.DesignAbsoluteLayout$AbsoluteConstraintsDescription">
-                          <AbsoluteConstraints x="750" y="0" width="168" height="38"/>
+                          <AbsoluteConstraints x="750" y="5" width="168" height="38"/>
                         </Constraint>
                       </Constraints>
                     </Component>
                     <Component class="javax.swing.JSlider" name="negativePctDiscordance_slider">
                       <Properties>
+                        <Property name="background" type="java.awt.Color" editor="org.netbeans.beaninfo.editors.ColorEditor">
+                          <Color blue="ff" green="e6" red="f1" type="rgb"/>
+                        </Property>
                         <Property name="font" type="java.awt.Font" editor="org.netbeans.beaninfo.editors.FontEditor">
                           <Font name="Arial" size="10" style="1"/>
                         </Property>
@@ -1355,7 +1412,7 @@
                       </Properties>
                       <Constraints>
                         <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.DesignAbsoluteLayout" value="org.netbeans.modules.form.compat2.layouts.DesignAbsoluteLayout$AbsoluteConstraintsDescription">
-                          <AbsoluteConstraints x="330" y="0" width="200" height="38"/>
+                          <AbsoluteConstraints x="330" y="5" width="200" height="38"/>
                         </Constraint>
                       </Constraints>
                     </Component>
@@ -1377,7 +1434,7 @@
                       </Properties>
                       <Constraints>
                         <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.DesignAbsoluteLayout" value="org.netbeans.modules.form.compat2.layouts.DesignAbsoluteLayout$AbsoluteConstraintsDescription">
-                          <AbsoluteConstraints x="568" y="40" width="160" height="15"/>
+                          <AbsoluteConstraints x="568" y="45" width="160" height="15"/>
                         </Constraint>
                       </Constraints>
                     </Component>
@@ -1399,7 +1456,7 @@
                       </Properties>
                       <Constraints>
                         <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.DesignAbsoluteLayout" value="org.netbeans.modules.form.compat2.layouts.DesignAbsoluteLayout$AbsoluteConstraintsDescription">
-                          <AbsoluteConstraints x="347" y="40" width="160" height="15"/>
+                          <AbsoluteConstraints x="347" y="45" width="160" height="15"/>
                         </Constraint>
                       </Constraints>
                     </Component>
@@ -1421,12 +1478,15 @@
                       </Properties>
                       <Constraints>
                         <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.DesignAbsoluteLayout" value="org.netbeans.modules.form.compat2.layouts.DesignAbsoluteLayout$AbsoluteConstraintsDescription">
-                          <AbsoluteConstraints x="767" y="40" width="140" height="15"/>
+                          <AbsoluteConstraints x="767" y="45" width="140" height="15"/>
                         </Constraint>
                       </Constraints>
                     </Component>
                     <Component class="javax.swing.JRadioButton" name="ageBest_radio">
                       <Properties>
+                        <Property name="background" type="java.awt.Color" editor="org.netbeans.beaninfo.editors.ColorEditor">
+                          <Color blue="ff" green="e6" red="f1" type="rgb"/>
+                        </Property>
                         <Property name="buttonGroup" type="javax.swing.ButtonGroup" editor="org.netbeans.modules.form.RADComponent$ButtonGroupPropertyEditor">
                           <ComponentRef name="probabilityDateButtonGroup"/>
                         </Property>
@@ -1479,7 +1539,7 @@
                       </Events>
                       <Constraints>
                         <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.DesignAbsoluteLayout" value="org.netbeans.modules.form.compat2.layouts.DesignAbsoluteLayout$AbsoluteConstraintsDescription">
-                          <AbsoluteConstraints x="530" y="0" width="20" height="20"/>
+                          <AbsoluteConstraints x="530" y="5" width="20" height="20"/>
                         </Constraint>
                       </Constraints>
                     </Component>
@@ -1643,6 +1703,9 @@
                     </Component>
                     <Component class="javax.swing.JCheckBox" name="commonLeadCorrectionSelectorPDF_checkbox">
                       <Properties>
+                        <Property name="background" type="java.awt.Color" editor="org.netbeans.beaninfo.editors.ColorEditor">
+                          <Color blue="ff" green="e6" red="f1" type="rgb"/>
+                        </Property>
                         <Property name="font" type="java.awt.Font" editor="org.netbeans.beaninfo.editors.FontEditor">
                           <Font name="SansSerif" size="9" style="1"/>
                         </Property>
@@ -1660,6 +1723,9 @@
                     </Component>
                     <Component class="javax.swing.JRadioButton" name="DatePbCorrSchemeA_radio">
                       <Properties>
+                        <Property name="background" type="java.awt.Color" editor="org.netbeans.beaninfo.editors.ColorEditor">
+                          <Color blue="ff" green="e6" red="f1" type="rgb"/>
+                        </Property>
                         <Property name="buttonGroup" type="javax.swing.ButtonGroup" editor="org.netbeans.modules.form.RADComponent$ButtonGroupPropertyEditor">
                           <ComponentRef name="probabilityDateButtonGroup"/>
                         </Property>

--- a/src/main/java/org/earthtime/UPb_Redux/dialogs/sampleManagers/sampleDateInterpretationManagers/SampleDateInterpretationsManager.java
+++ b/src/main/java/org/earthtime/UPb_Redux/dialogs/sampleManagers/sampleDateInterpretationManagers/SampleDateInterpretationsManager.java
@@ -1021,6 +1021,7 @@ public class SampleDateInterpretationsManager extends DialogEditor
         aliquotSpecificOptions_menu = new javax.swing.JMenu();
         weightedMeansPlotOptions_menu = new javax.swing.JMenu();
         weightedMeansChooser_menuItem = new javax.swing.JMenuItem();
+        sortFractionsDateAsc_menuItemCheckBox = new javax.swing.JCheckBoxMenuItem();
         weightedMeansLookAndFeel_menuItem = new javax.swing.JMenuItem();
         choosePDFPeaks_menu = new javax.swing.JMenu();
         heatMap_Menu = new javax.swing.JMenu();
@@ -1879,6 +1880,14 @@ public class SampleDateInterpretationsManager extends DialogEditor
         });
         weightedMeansPlotOptions_menu.add(weightedMeansChooser_menuItem);
 
+        sortFractionsDateAsc_menuItemCheckBox.setText("Sort Fractions by Date Ascending in Weighted Means Chooser");
+        sortFractionsDateAsc_menuItemCheckBox.addActionListener(new java.awt.event.ActionListener() {
+            public void actionPerformed(java.awt.event.ActionEvent evt) {
+                sortFractionsDateAsc_menuItemCheckBoxActionPerformed(evt);
+            }
+        });
+        weightedMeansPlotOptions_menu.add(sortFractionsDateAsc_menuItemCheckBox);
+
         weightedMeansLookAndFeel_menuItem.setText("Weighted Means Display Options");
         weightedMeansLookAndFeel_menuItem.setEnabled(false);
         weightedMeansPlotOptions_menu.add(weightedMeansLookAndFeel_menuItem);
@@ -2329,6 +2338,11 @@ private void lockUnlockHistogramBinsMouseEntered (java.awt.event.MouseEvent evt)
         ((PlottingDetailsDisplayInterface) concordiaGraphPanel).refreshPanel(true, false);
     }//GEN-LAST:event_commonLeadCorrectionSelector_checkboxActionPerformed
 
+    private void sortFractionsDateAsc_menuItemCheckBoxActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_sortFractionsDateAsc_menuItemCheckBoxActionPerformed
+        dateTreeByAliquot.toggleSortByDateAsc();
+        refreshSampleDateInterpretations(false, false);
+    }//GEN-LAST:event_sortFractionsDateAsc_menuItemCheckBoxActionPerformed
+
     // Variables declaration - do not modify//GEN-BEGIN:variables
     private javax.swing.JRadioButton DatePbCorrSchemeA_radio;
     private javax.swing.JRadioButton ageBest_radio;
@@ -2397,6 +2411,7 @@ private void lockUnlockHistogramBinsMouseEntered (java.awt.event.MouseEvent evt)
     private javax.swing.JButton showHistogram_button;
     private javax.swing.JButton showTightGraphProbability_button;
     private javax.swing.JToggleButton showTight_toggleButton;
+    private javax.swing.JCheckBoxMenuItem sortFractionsDateAsc_menuItemCheckBox;
     private javax.swing.JRadioButton terraWasserburgFlavor_radioButton;
     private javax.swing.JRadioButton thoriumConcordiaFlavor_radioButton;
     private javax.swing.JCheckBox thoriumCorrectionSelector_checkbox;

--- a/src/main/java/org/earthtime/UPb_Redux/dialogs/sampleManagers/sampleDateInterpretationManagers/SampleDateInterpretationsManager.java
+++ b/src/main/java/org/earthtime/UPb_Redux/dialogs/sampleManagers/sampleDateInterpretationManagers/SampleDateInterpretationsManager.java
@@ -199,8 +199,14 @@ public class SampleDateInterpretationsManager extends DialogEditor
     public void refreshSampleDateInterpretations(boolean doReScale, boolean inLiveMode) {
 
         String expansionHistory = "";
+        int selRow = 0;
+        int selRowX = 0;
+        int selRowY = 0;
         if (!doReScale) {
             expansionHistory = dateTreeByAliquot.collectExpansionHistory();
+            selRow = dateTreeByAliquot.getSelRow();
+            selRowX = dateTreeByAliquot.getSelRowX();
+            selRowY = dateTreeByAliquot.getSelRowY();
         }
         dateTreeByAliquot = new SampleTreeAnalysisMode(sample);
         dateTreeByAliquot.setSampleTreeChange(this);
@@ -208,6 +214,10 @@ public class SampleDateInterpretationsManager extends DialogEditor
         dateTreeByAliquot_ScrollPane.setViewportView((Component) dateTreeByAliquot);
         if (!doReScale) {
             dateTreeByAliquot.expandToHistory(expansionHistory);
+            ((JTree)dateTreeByAliquot).setSelectionRow(selRow);
+            ((JTree)dateTreeByAliquot).scrollRowToVisible(selRow);
+//            dateTreeByAliquot.mousePressed(new MouseEvent((Component)dateTreeByAliquot, 0, System.currentTimeMillis(), MouseEvent.BUTTON1, selRowX, selRowY, 1, false));
+//            ((PlottingDetailsDisplayInterface)concordiaGraphPanel).refreshPanel(true, false);
         }
 
         dateTreeBySample = new SampleTreeCompilationMode(sample);
@@ -514,31 +524,31 @@ public class SampleDateInterpretationsManager extends DialogEditor
             // zoom
             double rangeX = ((DateProbabilityDensityPanel) probabilityPanel).getRangeX_Display();
             //System.out.println( "RANGE OUT = " + rangeX + "   offset = " + ((DateProbabilityDensityPanel) probabilityPanel).getDisplayOffsetX());
-            
+
             double saveMinx = ((DateProbabilityDensityPanel) probabilityPanel).getMinX();
             double proposedMinX = saveMinx - rangeX / 2.0;
-            
+
             ((DateProbabilityDensityPanel) probabilityPanel).//
                     setMinX(//
                             Math.max(//
                                     proposedMinX, DateProbabilityDensityPanel.DEFAULT_DISPLAY_MINX));
-            
+
             // reset offset if hit the left wall
             double shiftMax = 0;
             if (proposedMinX <= DateProbabilityDensityPanel.DEFAULT_DISPLAY_MINX) {
                 ((DateProbabilityDensityPanel) probabilityPanel).setDisplayOffsetX(0);
                 shiftMax = DateProbabilityDensityPanel.DEFAULT_DISPLAY_MINX - proposedMinX;
             }
-            
+
             ((DateProbabilityDensityPanel) probabilityPanel).//
                     setMaxX(//
                             Math.min(//
                                     (((DateProbabilityDensityPanel) probabilityPanel).getMaxX()//
-                                            + rangeX / 2.0 + shiftMax), DateProbabilityDensityPanel.DEFAULT_DISPLAY_MAXX));
-            
+                                    + rangeX / 2.0 + shiftMax), DateProbabilityDensityPanel.DEFAULT_DISPLAY_MAXX));
+
             ((DateProbabilityDensityPanel) probabilityPanel).//
                     setSelectedHistogramBinCount(0);
-            
+
             probabilityPanel.repaint();
         });
 
@@ -1041,6 +1051,7 @@ public class SampleDateInterpretationsManager extends DialogEditor
 
         interpretations_SplitPane.setDividerLocation(250);
 
+        dateTrees_tabs.setForeground(new java.awt.Color(255, 51, 51));
         dateTrees_tabs.setFont(new java.awt.Font("SansSerif", 0, 12)); // NOI18N
         dateTrees_tabs.addMouseListener(new java.awt.event.MouseAdapter() {
             public void mouseClicked(java.awt.event.MouseEvent evt) {
@@ -2542,7 +2553,7 @@ private void lockUnlockHistogramBinsMouseEntered (java.awt.event.MouseEvent evt)
         } else if (nodeInfo instanceof ValueModel) { // sample date model *****************************
             // get aliquot and retrieve subset of fractions for this sample date
             Object aliquotNodeInfo
-                    = //
+                    = 
                     ((DefaultMutableTreeNode) ((TreeNode) node).getParent()).getUserObject();
 
             if (graphPanels_TabbedPane.getSelectedIndex() == graphPanels_TabbedPane.indexOfTab("Concordia")) {
@@ -3019,8 +3030,7 @@ private void lockUnlockHistogramBinsMouseEntered (java.awt.event.MouseEvent evt)
 
             try {
                 selectedFileSVG
-                        = 
-                        new File(selectedFile.getCanonicalPath().replaceFirst(".pdf", ".svg"));
+                        = new File(selectedFile.getCanonicalPath().replaceFirst(".pdf", ".svg"));
 
             } catch (IOException iOException) {
             }

--- a/src/main/java/org/earthtime/UPb_Redux/dialogs/sampleManagers/sampleDateInterpretationManagers/SampleDateInterpretationsManager.java
+++ b/src/main/java/org/earthtime/UPb_Redux/dialogs/sampleManagers/sampleDateInterpretationManagers/SampleDateInterpretationsManager.java
@@ -1112,6 +1112,7 @@ public class SampleDateInterpretationsManager extends DialogEditor
         });
         concordiaToolPanel.add(resetGraphDisplay_button, new org.netbeans.lib.awtextra.AbsoluteConstraints(60, 2, 35, 30));
 
+        ellipseCenters_checkbox.setBackground(new java.awt.Color(255, 241, 230));
         ellipseCenters_checkbox.setFont(new java.awt.Font("SansSerif", 1, 10)); // NOI18N
         ellipseCenters_checkbox.setSelected(true);
         ellipseCenters_checkbox.setText("<html>Ellipse<br> Centers</html>");
@@ -1122,6 +1123,7 @@ public class SampleDateInterpretationsManager extends DialogEditor
         });
         concordiaToolPanel.add(ellipseCenters_checkbox, new org.netbeans.lib.awtextra.AbsoluteConstraints(690, 2, 70, 25));
 
+        ellipseLabels_checkbox.setBackground(new java.awt.Color(255, 241, 230));
         ellipseLabels_checkbox.setFont(new java.awt.Font("SansSerif", 1, 10)); // NOI18N
         ellipseLabels_checkbox.setSelected(true);
         ellipseLabels_checkbox.setText("<html>Ellipse<br> Labels</html>");
@@ -1132,6 +1134,7 @@ public class SampleDateInterpretationsManager extends DialogEditor
         });
         concordiaToolPanel.add(ellipseLabels_checkbox, new org.netbeans.lib.awtextra.AbsoluteConstraints(760, 2, 70, 25));
 
+        concordiaErrors_checkbox.setBackground(new java.awt.Color(255, 241, 230));
         concordiaErrors_checkbox.setFont(new java.awt.Font("SansSerif", 1, 10)); // NOI18N
         concordiaErrors_checkbox.setSelected(true);
         concordiaErrors_checkbox.setText("<html>Concordia<br> Unct Env</html>");
@@ -1176,7 +1179,7 @@ public class SampleDateInterpretationsManager extends DialogEditor
         });
         concordiaToolPanel.add(zoomBox_toggleButton, new org.netbeans.lib.awtextra.AbsoluteConstraints(125, 2, 55, 30));
 
-        concordiaFlavor_radioButton.setBackground(new java.awt.Color(204, 204, 255));
+        concordiaFlavor_radioButton.setBackground(new java.awt.Color(255, 241, 230));
         concordiaTeraW_buttonGroup.add(concordiaFlavor_radioButton);
         concordiaFlavor_radioButton.setFont(new java.awt.Font("SansSerif", 1, 9)); // NOI18N
         concordiaFlavor_radioButton.setText("C");
@@ -1188,7 +1191,7 @@ public class SampleDateInterpretationsManager extends DialogEditor
         });
         concordiaToolPanel.add(concordiaFlavor_radioButton, new org.netbeans.lib.awtextra.AbsoluteConstraints(210, 1, -1, 28));
 
-        terraWasserburgFlavor_radioButton.setBackground(new java.awt.Color(204, 204, 255));
+        terraWasserburgFlavor_radioButton.setBackground(new java.awt.Color(255, 241, 230));
         concordiaTeraW_buttonGroup.add(terraWasserburgFlavor_radioButton);
         terraWasserburgFlavor_radioButton.setFont(new java.awt.Font("SansSerif", 1, 9)); // NOI18N
         terraWasserburgFlavor_radioButton.setText("TW");
@@ -1200,6 +1203,7 @@ public class SampleDateInterpretationsManager extends DialogEditor
         });
         concordiaToolPanel.add(terraWasserburgFlavor_radioButton, new org.netbeans.lib.awtextra.AbsoluteConstraints(295, 1, -1, 28));
 
+        thoriumCorrectionSelector_checkbox.setBackground(new java.awt.Color(255, 241, 230));
         thoriumCorrectionSelector_checkbox.setFont(new java.awt.Font("SansSerif", 1, 9)); // NOI18N
         thoriumCorrectionSelector_checkbox.setText("Th");
         thoriumCorrectionSelector_checkbox.setToolTipText("Correct for Thorium");
@@ -1210,6 +1214,7 @@ public class SampleDateInterpretationsManager extends DialogEditor
         });
         concordiaToolPanel.add(thoriumCorrectionSelector_checkbox, new org.netbeans.lib.awtextra.AbsoluteConstraints(435, 2, -1, 25));
 
+        protactiniumCorrectionSelector_checkbox.setBackground(new java.awt.Color(255, 241, 230));
         protactiniumCorrectionSelector_checkbox.setFont(new java.awt.Font("SansSerif", 1, 9)); // NOI18N
         protactiniumCorrectionSelector_checkbox.setText("Pa");
         protactiniumCorrectionSelector_checkbox.setToolTipText("Correct for Protactinium");
@@ -1220,6 +1225,7 @@ public class SampleDateInterpretationsManager extends DialogEditor
         });
         concordiaToolPanel.add(protactiniumCorrectionSelector_checkbox, new org.netbeans.lib.awtextra.AbsoluteConstraints(480, 2, -1, 25));
 
+        jLabel4.setBackground(new java.awt.Color(255, 241, 230));
         jLabel4.setFont(new java.awt.Font("SansSerif", 1, 9)); // NOI18N
         jLabel4.setForeground(new java.awt.Color(255, 0, 51));
         jLabel4.setText("Correct:");
@@ -1242,6 +1248,7 @@ public class SampleDateInterpretationsManager extends DialogEditor
         });
         concordiaToolPanel.add(showTight_toggleButton, new org.netbeans.lib.awtextra.AbsoluteConstraints(180, 2, 30, 30));
 
+        showExcludedFractions_checkbox.setBackground(new java.awt.Color(255, 241, 230));
         showExcludedFractions_checkbox.setFont(new java.awt.Font("SansSerif", 1, 10)); // NOI18N
         showExcludedFractions_checkbox.setSelected(true);
         showExcludedFractions_checkbox.setText("<html>Excluded<br> Fractions</html>");
@@ -1252,7 +1259,7 @@ public class SampleDateInterpretationsManager extends DialogEditor
         });
         concordiaToolPanel.add(showExcludedFractions_checkbox, new org.netbeans.lib.awtextra.AbsoluteConstraints(610, 2, 75, 25));
 
-        thoriumConcordiaFlavor_radioButton.setBackground(new java.awt.Color(204, 204, 255));
+        thoriumConcordiaFlavor_radioButton.setBackground(new java.awt.Color(255, 241, 230));
         concordiaTeraW_buttonGroup.add(thoriumConcordiaFlavor_radioButton);
         thoriumConcordiaFlavor_radioButton.setFont(new java.awt.Font("SansSerif", 1, 9)); // NOI18N
         thoriumConcordiaFlavor_radioButton.setText("Th");
@@ -1264,6 +1271,7 @@ public class SampleDateInterpretationsManager extends DialogEditor
         });
         concordiaToolPanel.add(thoriumConcordiaFlavor_radioButton, new org.netbeans.lib.awtextra.AbsoluteConstraints(250, 1, -1, 28));
 
+        showFilteredFractions_checkbox.setBackground(new java.awt.Color(255, 241, 230));
         showFilteredFractions_checkbox.setFont(new java.awt.Font("SansSerif", 1, 10)); // NOI18N
         showFilteredFractions_checkbox.setText("<html>Filtering ON<br> </html>");
         showFilteredFractions_checkbox.addActionListener(new java.awt.event.ActionListener() {
@@ -1273,6 +1281,7 @@ public class SampleDateInterpretationsManager extends DialogEditor
         });
         concordiaToolPanel.add(showFilteredFractions_checkbox, new org.netbeans.lib.awtextra.AbsoluteConstraints(530, 2, 80, 25));
 
+        commonLeadCorrectionSelector_checkbox.setBackground(new java.awt.Color(255, 241, 230));
         commonLeadCorrectionSelector_checkbox.setFont(new java.awt.Font("SansSerif", 1, 9)); // NOI18N
         commonLeadCorrectionSelector_checkbox.setText("Pbc");
         commonLeadCorrectionSelector_checkbox.setToolTipText("Correct for Common Lead");
@@ -1340,10 +1349,12 @@ public class SampleDateInterpretationsManager extends DialogEditor
         pan_WeightedMean_toggleButton.setOpaque(true);
         weightedMeanToolPanel.add(pan_WeightedMean_toggleButton, new org.netbeans.lib.awtextra.AbsoluteConstraints(113, 2, 28, 30));
 
+        jLabel1.setBackground(new java.awt.Color(229, 250, 229));
         jLabel1.setFont(new java.awt.Font("SansSerif", 0, 12)); // NOI18N
         jLabel1.setText("Order:");
         weightedMeanToolPanel.add(jLabel1, new org.netbeans.lib.awtextra.AbsoluteConstraints(369, 9, -1, -1));
 
+        fractionOrderByName_radioButton.setBackground(new java.awt.Color(229, 250, 229));
         weightedMeanFractionOrderButtonGroup.add(fractionOrderByName_radioButton);
         fractionOrderByName_radioButton.setFont(new java.awt.Font("SansSerif", 0, 12)); // NOI18N
         fractionOrderByName_radioButton.setSelected(true);
@@ -1352,6 +1363,7 @@ public class SampleDateInterpretationsManager extends DialogEditor
         fractionOrderByName_radioButton.setName("name"); // NOI18N
         weightedMeanToolPanel.add(fractionOrderByName_radioButton, new org.netbeans.lib.awtextra.AbsoluteConstraints(412, 6, -1, -1));
 
+        fractionOrderByWeight_radioButton.setBackground(new java.awt.Color(229, 250, 229));
         weightedMeanFractionOrderButtonGroup.add(fractionOrderByWeight_radioButton);
         fractionOrderByWeight_radioButton.setFont(new java.awt.Font("SansSerif", 0, 12)); // NOI18N
         fractionOrderByWeight_radioButton.setText("weight");
@@ -1359,6 +1371,7 @@ public class SampleDateInterpretationsManager extends DialogEditor
         fractionOrderByWeight_radioButton.setName("weight"); // NOI18N
         weightedMeanToolPanel.add(fractionOrderByWeight_radioButton, new org.netbeans.lib.awtextra.AbsoluteConstraints(476, 6, -1, -1));
 
+        fractionOrderByRandom_radioButton.setBackground(new java.awt.Color(229, 250, 229));
         weightedMeanFractionOrderButtonGroup.add(fractionOrderByRandom_radioButton);
         fractionOrderByRandom_radioButton.setFont(new java.awt.Font("SansSerif", 0, 12)); // NOI18N
         fractionOrderByRandom_radioButton.setText("RND");
@@ -1367,6 +1380,7 @@ public class SampleDateInterpretationsManager extends DialogEditor
         fractionOrderByRandom_radioButton.setName("random"); // NOI18N
         weightedMeanToolPanel.add(fractionOrderByRandom_radioButton, new org.netbeans.lib.awtextra.AbsoluteConstraints(555, 6, -1, -1));
 
+        fractionOrderByDate_radioButton.setBackground(new java.awt.Color(229, 250, 229));
         weightedMeanFractionOrderButtonGroup.add(fractionOrderByDate_radioButton);
         fractionOrderByDate_radioButton.setFont(new java.awt.Font("SansSerif", 0, 12)); // NOI18N
         fractionOrderByDate_radioButton.setText("date");
@@ -1560,18 +1574,21 @@ public class SampleDateInterpretationsManager extends DialogEditor
         });
         probabilityToolPanel.add(resetGraphProbability_button, new org.netbeans.lib.awtextra.AbsoluteConstraints(60, 40, 40, 25));
 
+        ageR207_206r_radioB.setBackground(new java.awt.Color(241, 230, 255));
         probabilityDateButtonGroup.add(ageR207_206r_radioB);
         ageR207_206r_radioB.setFont(new java.awt.Font("Arial", 1, 10)); // NOI18N
         ageR207_206r_radioB.setText("207/206");
         ageR207_206r_radioB.setName("age207_206r"); // NOI18N
         probabilityToolPanel.add(ageR207_206r_radioB, new org.netbeans.lib.awtextra.AbsoluteConstraints(175, 20, -1, -1));
 
+        ageR206_238r_radioB.setBackground(new java.awt.Color(241, 230, 255));
         probabilityDateButtonGroup.add(ageR206_238r_radioB);
         ageR206_238r_radioB.setFont(new java.awt.Font("Arial", 1, 10)); // NOI18N
         ageR206_238r_radioB.setText("206/238");
         ageR206_238r_radioB.setName("age206_238r"); // NOI18N
         probabilityToolPanel.add(ageR206_238r_radioB, new org.netbeans.lib.awtextra.AbsoluteConstraints(175, 0, -1, -1));
 
+        positivePctDiscordance_slider.setBackground(new java.awt.Color(241, 230, 255));
         positivePctDiscordance_slider.setFont(new java.awt.Font("Arial", 1, 10)); // NOI18N
         positivePctDiscordance_slider.setMajorTickSpacing(10);
         positivePctDiscordance_slider.setMinorTickSpacing(2);
@@ -1580,8 +1597,9 @@ public class SampleDateInterpretationsManager extends DialogEditor
         positivePctDiscordance_slider.setSnapToTicks(true);
         positivePctDiscordance_slider.setAutoscrolls(true);
         positivePctDiscordance_slider.setName("positivePerCentDiscordanceSliderValue"); // NOI18N
-        probabilityToolPanel.add(positivePctDiscordance_slider, new org.netbeans.lib.awtextra.AbsoluteConstraints(550, 0, 200, 38));
+        probabilityToolPanel.add(positivePctDiscordance_slider, new org.netbeans.lib.awtextra.AbsoluteConstraints(550, 5, 200, 38));
 
+        percentUncertainty_slider.setBackground(new java.awt.Color(241, 230, 255));
         percentUncertainty_slider.setFont(new java.awt.Font("Arial", 1, 10)); // NOI18N
         percentUncertainty_slider.setMajorTickSpacing(10);
         percentUncertainty_slider.setMinorTickSpacing(2);
@@ -1590,8 +1608,9 @@ public class SampleDateInterpretationsManager extends DialogEditor
         percentUncertainty_slider.setSnapToTicks(true);
         percentUncertainty_slider.setAutoscrolls(true);
         percentUncertainty_slider.setName("uncertaintyPerCentSliderValue"); // NOI18N
-        probabilityToolPanel.add(percentUncertainty_slider, new org.netbeans.lib.awtextra.AbsoluteConstraints(750, 0, 168, 38));
+        probabilityToolPanel.add(percentUncertainty_slider, new org.netbeans.lib.awtextra.AbsoluteConstraints(750, 5, 168, 38));
 
+        negativePctDiscordance_slider.setBackground(new java.awt.Color(241, 230, 255));
         negativePctDiscordance_slider.setFont(new java.awt.Font("Arial", 1, 10)); // NOI18N
         negativePctDiscordance_slider.setMajorTickSpacing(10);
         negativePctDiscordance_slider.setMaximum(0);
@@ -1602,7 +1621,7 @@ public class SampleDateInterpretationsManager extends DialogEditor
         negativePctDiscordance_slider.setSnapToTicks(true);
         negativePctDiscordance_slider.setValue(-50);
         negativePctDiscordance_slider.setName("negativePerCentDiscordanceSliderValue"); // NOI18N
-        probabilityToolPanel.add(negativePctDiscordance_slider, new org.netbeans.lib.awtextra.AbsoluteConstraints(330, 0, 200, 38));
+        probabilityToolPanel.add(negativePctDiscordance_slider, new org.netbeans.lib.awtextra.AbsoluteConstraints(330, 5, 200, 38));
 
         positivePctDiscordance_text.setBackground(new java.awt.Color(241, 230, 255));
         positivePctDiscordance_text.setFont(new java.awt.Font("Arial", 1, 10)); // NOI18N
@@ -1611,7 +1630,7 @@ public class SampleDateInterpretationsManager extends DialogEditor
         positivePctDiscordance_text.setAlignmentX(0.0F);
         positivePctDiscordance_text.setAlignmentY(0.0F);
         positivePctDiscordance_text.setBorder(null);
-        probabilityToolPanel.add(positivePctDiscordance_text, new org.netbeans.lib.awtextra.AbsoluteConstraints(568, 40, 160, 15));
+        probabilityToolPanel.add(positivePctDiscordance_text, new org.netbeans.lib.awtextra.AbsoluteConstraints(568, 45, 160, 15));
 
         negativePctDiscordance_text.setBackground(new java.awt.Color(241, 230, 255));
         negativePctDiscordance_text.setFont(new java.awt.Font("Arial", 1, 10)); // NOI18N
@@ -1620,7 +1639,7 @@ public class SampleDateInterpretationsManager extends DialogEditor
         negativePctDiscordance_text.setAlignmentX(0.0F);
         negativePctDiscordance_text.setAlignmentY(0.0F);
         negativePctDiscordance_text.setBorder(null);
-        probabilityToolPanel.add(negativePctDiscordance_text, new org.netbeans.lib.awtextra.AbsoluteConstraints(347, 40, 160, 15));
+        probabilityToolPanel.add(negativePctDiscordance_text, new org.netbeans.lib.awtextra.AbsoluteConstraints(347, 45, 160, 15));
 
         pctUncertainty_text.setBackground(new java.awt.Color(241, 230, 255));
         pctUncertainty_text.setFont(new java.awt.Font("Arial", 1, 10)); // NOI18N
@@ -1629,8 +1648,9 @@ public class SampleDateInterpretationsManager extends DialogEditor
         pctUncertainty_text.setAlignmentX(0.0F);
         pctUncertainty_text.setAlignmentY(0.0F);
         pctUncertainty_text.setBorder(null);
-        probabilityToolPanel.add(pctUncertainty_text, new org.netbeans.lib.awtextra.AbsoluteConstraints(767, 40, 140, 15));
+        probabilityToolPanel.add(pctUncertainty_text, new org.netbeans.lib.awtextra.AbsoluteConstraints(767, 45, 140, 15));
 
+        ageBest_radio.setBackground(new java.awt.Color(241, 230, 255));
         probabilityDateButtonGroup.add(ageBest_radio);
         ageBest_radio.setFont(new java.awt.Font("Arial", 1, 10)); // NOI18N
         ageBest_radio.setText("best");
@@ -1657,7 +1677,7 @@ public class SampleDateInterpretationsManager extends DialogEditor
                 linkedUnlinkedDiscordanceActionPerformed(evt);
             }
         });
-        probabilityToolPanel.add(linkedUnlinkedDiscordance, new org.netbeans.lib.awtextra.AbsoluteConstraints(530, 0, 20, 20));
+        probabilityToolPanel.add(linkedUnlinkedDiscordance, new org.netbeans.lib.awtextra.AbsoluteConstraints(530, 5, 20, 20));
 
         showHistogram_button.setBackground(new java.awt.Color(241, 230, 255));
         showHistogram_button.setFont(new java.awt.Font("Braggadocio", 1, 24)); // NOI18N
@@ -1728,6 +1748,7 @@ public class SampleDateInterpretationsManager extends DialogEditor
         jLabel2.setText(" ?Hist    #Bins      ?WidthMa  ?Lock");
         probabilityToolPanel.add(jLabel2, new org.netbeans.lib.awtextra.AbsoluteConstraints(0, 0, 170, 15));
 
+        commonLeadCorrectionSelectorPDF_checkbox.setBackground(new java.awt.Color(241, 230, 255));
         commonLeadCorrectionSelectorPDF_checkbox.setFont(new java.awt.Font("SansSerif", 1, 9)); // NOI18N
         commonLeadCorrectionSelectorPDF_checkbox.setText("PbcCorr");
         commonLeadCorrectionSelectorPDF_checkbox.setToolTipText("Correct for Common Lead");
@@ -1738,6 +1759,7 @@ public class SampleDateInterpretationsManager extends DialogEditor
         });
         probabilityToolPanel.add(commonLeadCorrectionSelectorPDF_checkbox, new org.netbeans.lib.awtextra.AbsoluteConstraints(250, 2, -1, 25));
 
+        DatePbCorrSchemeA_radio.setBackground(new java.awt.Color(241, 230, 255));
         probabilityDateButtonGroup.add(DatePbCorrSchemeA_radio);
         DatePbCorrSchemeA_radio.setFont(new java.awt.Font("Arial", 1, 10)); // NOI18N
         DatePbCorrSchemeA_radio.setText("<html>UPb Date PbcCorr</html>");

--- a/src/main/java/org/earthtime/UPb_Redux/dialogs/sessionManagers/SessionAnalysisWorkflowManagerLAICPMS.form
+++ b/src/main/java/org/earthtime/UPb_Redux/dialogs/sessionManagers/SessionAnalysisWorkflowManagerLAICPMS.form
@@ -246,7 +246,7 @@
                   </AuxValues>
                   <Constraints>
                     <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.DesignAbsoluteLayout" value="org.netbeans.modules.form.compat2.layouts.DesignAbsoluteLayout$AbsoluteConstraintsDescription">
-                      <AbsoluteConstraints x="0" y="435" width="110" height="-1"/>
+                      <AbsoluteConstraints x="1" y="435" width="110" height="-1"/>
                     </Constraint>
                   </Constraints>
                 </Component>
@@ -277,7 +277,7 @@
                   </Events>
                   <Constraints>
                     <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.DesignAbsoluteLayout" value="org.netbeans.modules.form.compat2.layouts.DesignAbsoluteLayout$AbsoluteConstraintsDescription">
-                      <AbsoluteConstraints x="0" y="70" width="190" height="-1"/>
+                      <AbsoluteConstraints x="1" y="70" width="190" height="-1"/>
                     </Constraint>
                   </Constraints>
                 </Component>
@@ -308,7 +308,7 @@
                   </Events>
                   <Constraints>
                     <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.DesignAbsoluteLayout" value="org.netbeans.modules.form.compat2.layouts.DesignAbsoluteLayout$AbsoluteConstraintsDescription">
-                      <AbsoluteConstraints x="0" y="90" width="190" height="-1"/>
+                      <AbsoluteConstraints x="1" y="90" width="190" height="-1"/>
                     </Constraint>
                   </Constraints>
                 </Component>
@@ -340,7 +340,7 @@
                   </Events>
                   <Constraints>
                     <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.DesignAbsoluteLayout" value="org.netbeans.modules.form.compat2.layouts.DesignAbsoluteLayout$AbsoluteConstraintsDescription">
-                      <AbsoluteConstraints x="0" y="110" width="190" height="-1"/>
+                      <AbsoluteConstraints x="1" y="110" width="190" height="-1"/>
                     </Constraint>
                   </Constraints>
                 </Component>
@@ -454,7 +454,7 @@
                   </AuxValues>
                   <Constraints>
                     <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.DesignAbsoluteLayout" value="org.netbeans.modules.form.compat2.layouts.DesignAbsoluteLayout$AbsoluteConstraintsDescription">
-                      <AbsoluteConstraints x="0" y="480" width="150" height="20"/>
+                      <AbsoluteConstraints x="1" y="480" width="150" height="20"/>
                     </Constraint>
                   </Constraints>
                 </Component>
@@ -473,7 +473,7 @@
                   </AuxValues>
                   <Constraints>
                     <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.DesignAbsoluteLayout" value="org.netbeans.modules.form.compat2.layouts.DesignAbsoluteLayout$AbsoluteConstraintsDescription">
-                      <AbsoluteConstraints x="0" y="575" width="150" height="20"/>
+                      <AbsoluteConstraints x="1" y="575" width="150" height="20"/>
                     </Constraint>
                   </Constraints>
                 </Component>
@@ -492,7 +492,7 @@
                   </AuxValues>
                   <Constraints>
                     <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.DesignAbsoluteLayout" value="org.netbeans.modules.form.compat2.layouts.DesignAbsoluteLayout$AbsoluteConstraintsDescription">
-                      <AbsoluteConstraints x="0" y="595" width="150" height="20"/>
+                      <AbsoluteConstraints x="1" y="595" width="150" height="20"/>
                     </Constraint>
                   </Constraints>
                 </Component>
@@ -512,7 +512,7 @@
                   </AuxValues>
                   <Constraints>
                     <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.DesignAbsoluteLayout" value="org.netbeans.modules.form.compat2.layouts.DesignAbsoluteLayout$AbsoluteConstraintsDescription">
-                      <AbsoluteConstraints x="0" y="540" width="150" height="20"/>
+                      <AbsoluteConstraints x="1" y="540" width="150" height="20"/>
                     </Constraint>
                   </Constraints>
                 </Component>
@@ -525,7 +525,7 @@
                   </Properties>
                   <Constraints>
                     <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.DesignAbsoluteLayout" value="org.netbeans.modules.form.compat2.layouts.DesignAbsoluteLayout$AbsoluteConstraintsDescription">
-                      <AbsoluteConstraints x="0" y="145" width="190" height="-1"/>
+                      <AbsoluteConstraints x="10" y="145" width="170" height="-1"/>
                     </Constraint>
                   </Constraints>
                 </Component>
@@ -538,7 +538,7 @@
                   </Properties>
                   <Constraints>
                     <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.DesignAbsoluteLayout" value="org.netbeans.modules.form.compat2.layouts.DesignAbsoluteLayout$AbsoluteConstraintsDescription">
-                      <AbsoluteConstraints x="0" y="420" width="20" height="-1"/>
+                      <AbsoluteConstraints x="1" y="420" width="20" height="-1"/>
                     </Constraint>
                   </Constraints>
                 </Component>
@@ -560,7 +560,7 @@
                   </Properties>
                   <Constraints>
                     <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.DesignAbsoluteLayout" value="org.netbeans.modules.form.compat2.layouts.DesignAbsoluteLayout$AbsoluteConstraintsDescription">
-                      <AbsoluteConstraints x="0" y="165" width="190" height="180"/>
+                      <AbsoluteConstraints x="1" y="165" width="189" height="180"/>
                     </Constraint>
                   </Constraints>
 
@@ -937,7 +937,7 @@
                   </AuxValues>
                   <Constraints>
                     <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.DesignAbsoluteLayout" value="org.netbeans.modules.form.compat2.layouts.DesignAbsoluteLayout$AbsoluteConstraintsDescription">
-                      <AbsoluteConstraints x="0" y="500" width="150" height="20"/>
+                      <AbsoluteConstraints x="1" y="500" width="150" height="20"/>
                     </Constraint>
                   </Constraints>
                 </Component>
@@ -987,7 +987,7 @@
                       </Events>
                       <Constraints>
                         <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.DesignAbsoluteLayout" value="org.netbeans.modules.form.compat2.layouts.DesignAbsoluteLayout$AbsoluteConstraintsDescription">
-                          <AbsoluteConstraints x="0" y="8" width="50" height="-1"/>
+                          <AbsoluteConstraints x="1" y="8" width="50" height="-1"/>
                         </Constraint>
                       </Constraints>
                     </Component>
@@ -1018,7 +1018,7 @@
                       </Events>
                       <Constraints>
                         <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.DesignAbsoluteLayout" value="org.netbeans.modules.form.compat2.layouts.DesignAbsoluteLayout$AbsoluteConstraintsDescription">
-                          <AbsoluteConstraints x="50" y="8" width="65" height="-1"/>
+                          <AbsoluteConstraints x="51" y="8" width="65" height="-1"/>
                         </Constraint>
                       </Constraints>
                     </Component>
@@ -1049,7 +1049,7 @@
                       </Events>
                       <Constraints>
                         <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.DesignAbsoluteLayout" value="org.netbeans.modules.form.compat2.layouts.DesignAbsoluteLayout$AbsoluteConstraintsDescription">
-                          <AbsoluteConstraints x="115" y="8" width="75" height="-1"/>
+                          <AbsoluteConstraints x="116" y="8" width="75" height="-1"/>
                         </Constraint>
                       </Constraints>
                     </Component>
@@ -1091,7 +1091,7 @@
                   </Properties>
                   <Constraints>
                     <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.DesignAbsoluteLayout" value="org.netbeans.modules.form.compat2.layouts.DesignAbsoluteLayout$AbsoluteConstraintsDescription">
-                      <AbsoluteConstraints x="0" y="350" width="160" height="-1"/>
+                      <AbsoluteConstraints x="1" y="350" width="160" height="-1"/>
                     </Constraint>
                   </Constraints>
                 </Component>
@@ -1118,7 +1118,7 @@
                   </Events>
                   <Constraints>
                     <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.DesignAbsoluteLayout" value="org.netbeans.modules.form.compat2.layouts.DesignAbsoluteLayout$AbsoluteConstraintsDescription">
-                      <AbsoluteConstraints x="0" y="365" width="75" height="20"/>
+                      <AbsoluteConstraints x="1" y="365" width="75" height="20"/>
                     </Constraint>
                   </Constraints>
                 </Component>
@@ -1144,7 +1144,7 @@
                   </Events>
                   <Constraints>
                     <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.DesignAbsoluteLayout" value="org.netbeans.modules.form.compat2.layouts.DesignAbsoluteLayout$AbsoluteConstraintsDescription">
-                      <AbsoluteConstraints x="75" y="365" width="115" height="20"/>
+                      <AbsoluteConstraints x="76" y="365" width="115" height="20"/>
                     </Constraint>
                   </Constraints>
                 </Component>
@@ -1171,7 +1171,7 @@
                   </Events>
                   <Constraints>
                     <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.DesignAbsoluteLayout" value="org.netbeans.modules.form.compat2.layouts.DesignAbsoluteLayout$AbsoluteConstraintsDescription">
-                      <AbsoluteConstraints x="0" y="405" width="75" height="20"/>
+                      <AbsoluteConstraints x="1" y="405" width="75" height="20"/>
                     </Constraint>
                   </Constraints>
                 </Component>
@@ -1184,7 +1184,7 @@
                   </Properties>
                   <Constraints>
                     <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.DesignAbsoluteLayout" value="org.netbeans.modules.form.compat2.layouts.DesignAbsoluteLayout$AbsoluteConstraintsDescription">
-                      <AbsoluteConstraints x="0" y="390" width="150" height="-1"/>
+                      <AbsoluteConstraints x="1" y="390" width="150" height="-1"/>
                     </Constraint>
                   </Constraints>
                 </Component>
@@ -1210,7 +1210,7 @@
                   </Events>
                   <Constraints>
                     <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.DesignAbsoluteLayout" value="org.netbeans.modules.form.compat2.layouts.DesignAbsoluteLayout$AbsoluteConstraintsDescription">
-                      <AbsoluteConstraints x="75" y="405" width="115" height="20"/>
+                      <AbsoluteConstraints x="76" y="405" width="115" height="20"/>
                     </Constraint>
                   </Constraints>
                 </Component>
@@ -1230,7 +1230,7 @@
                   </AuxValues>
                   <Constraints>
                     <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.DesignAbsoluteLayout" value="org.netbeans.modules.form.compat2.layouts.DesignAbsoluteLayout$AbsoluteConstraintsDescription">
-                      <AbsoluteConstraints x="0" y="520" width="150" height="20"/>
+                      <AbsoluteConstraints x="1" y="520" width="150" height="20"/>
                     </Constraint>
                   </Constraints>
                 </Component>

--- a/src/main/java/org/earthtime/UPb_Redux/dialogs/sessionManagers/SessionAnalysisWorkflowManagerLAICPMS.java
+++ b/src/main/java/org/earthtime/UPb_Redux/dialogs/sessionManagers/SessionAnalysisWorkflowManagerLAICPMS.java
@@ -909,7 +909,7 @@ public class SessionAnalysisWorkflowManagerLAICPMS extends DialogEditor //
         fractionsShownLabel.setText("Fractions Shown:");
         controlPanel_panel.setLayer(fractionsShownLabel, javax.swing.JLayeredPane.PALETTE_LAYER);
         controlPanel_panel.add(fractionsShownLabel);
-        fractionsShownLabel.setBounds(0, 435, 110, 16);
+        fractionsShownLabel.setBounds(1, 435, 110, 16);
 
         rawIsotopes_radioButton.setBackground(new java.awt.Color(173, 204, 182));
         viewChooser_buttonGroup.add(rawIsotopes_radioButton);
@@ -926,7 +926,7 @@ public class SessionAnalysisWorkflowManagerLAICPMS extends DialogEditor //
             }
         });
         controlPanel_panel.add(rawIsotopes_radioButton);
-        rawIsotopes_radioButton.setBounds(0, 70, 190, 20);
+        rawIsotopes_radioButton.setBounds(1, 70, 190, 20);
 
         correctedIsotopes_radioButton.setBackground(new java.awt.Color(204, 199, 173));
         viewChooser_buttonGroup.add(correctedIsotopes_radioButton);
@@ -943,7 +943,7 @@ public class SessionAnalysisWorkflowManagerLAICPMS extends DialogEditor //
             }
         });
         controlPanel_panel.add(correctedIsotopes_radioButton);
-        correctedIsotopes_radioButton.setBounds(0, 90, 190, 20);
+        correctedIsotopes_radioButton.setBounds(1, 90, 190, 20);
 
         rawRatios_radioButton.setBackground(new java.awt.Color(204, 184, 173));
         viewChooser_buttonGroup.add(rawRatios_radioButton);
@@ -965,7 +965,7 @@ public class SessionAnalysisWorkflowManagerLAICPMS extends DialogEditor //
             }
         });
         controlPanel_panel.add(rawRatios_radioButton);
-        rawRatios_radioButton.setBounds(0, 110, 190, 20);
+        rawRatios_radioButton.setBounds(1, 110, 190, 20);
 
         lockUnlockZoomSliders.setBackground(new java.awt.Color(51, 51, 51));
         lockUnlockZoomSliders.setFont(new java.awt.Font("Braggadocio", 1, 24)); // NOI18N
@@ -1032,7 +1032,7 @@ public class SessionAnalysisWorkflowManagerLAICPMS extends DialogEditor //
         });
         controlPanel_panel.setLayer(includeAllFractions_button, javax.swing.JLayeredPane.PALETTE_LAYER);
         controlPanel_panel.add(includeAllFractions_button);
-        includeAllFractions_button.setBounds(0, 480, 150, 20);
+        includeAllFractions_button.setBounds(1, 480, 150, 20);
 
         refreshView_button.setFont(new java.awt.Font("Arial", 0, 12)); // NOI18N
         refreshView_button.setText("Refresh View");
@@ -1042,7 +1042,7 @@ public class SessionAnalysisWorkflowManagerLAICPMS extends DialogEditor //
             }
         });
         controlPanel_panel.add(refreshView_button);
-        refreshView_button.setBounds(0, 575, 150, 20);
+        refreshView_button.setBounds(1, 575, 150, 20);
 
         defaultZoom_button.setFont(new java.awt.Font("Arial", 0, 12)); // NOI18N
         defaultZoom_button.setText("Default Zoom");
@@ -1052,7 +1052,7 @@ public class SessionAnalysisWorkflowManagerLAICPMS extends DialogEditor //
             }
         });
         controlPanel_panel.add(defaultZoom_button);
-        defaultZoom_button.setBounds(0, 595, 150, 20);
+        defaultZoom_button.setBounds(1, 595, 150, 20);
 
         removeAllIndividualYAxisPanes_button.setFont(new java.awt.Font("SansSerif", 0, 12)); // NOI18N
         removeAllIndividualYAxisPanes_button.setText("Remove all Local Y-Axis");
@@ -1063,19 +1063,19 @@ public class SessionAnalysisWorkflowManagerLAICPMS extends DialogEditor //
         });
         controlPanel_panel.setLayer(removeAllIndividualYAxisPanes_button, javax.swing.JLayeredPane.PALETTE_LAYER);
         controlPanel_panel.add(removeAllIndividualYAxisPanes_button);
-        removeAllIndividualYAxisPanes_button.setBounds(0, 540, 150, 20);
+        removeAllIndividualYAxisPanes_button.setBounds(1, 540, 150, 20);
 
         jLabel4.setFont(new java.awt.Font("SansSerif", 3, 10)); // NOI18N
         jLabel4.setText("   Select fractionation technique:");
         controlPanel_panel.add(jLabel4);
-        jLabel4.setBounds(0, 145, 190, 13);
+        jLabel4.setBounds(10, 145, 170, 13);
 
         yAxisZoomSlider.setMaximum(320);
         yAxisZoomSlider.setMinimum(64);
         yAxisZoomSlider.setOrientation(javax.swing.JSlider.VERTICAL);
         yAxisZoomSlider.setValue(128);
         controlPanel_panel.add(yAxisZoomSlider);
-        yAxisZoomSlider.setBounds(0, 420, 20, 190);
+        yAxisZoomSlider.setBounds(1, 420, 20, 190);
 
         fractionationTechniqueTabbedPane.setBackground(new java.awt.Color(250, 240, 230));
         fractionationTechniqueTabbedPane.setBorder(javax.swing.BorderFactory.createLineBorder(new java.awt.Color(0, 0, 0)));
@@ -1256,7 +1256,7 @@ public class SessionAnalysisWorkflowManagerLAICPMS extends DialogEditor //
         fractionationTechniqueTabbedPane.addTab("Intercept", interceptPanel);
 
         controlPanel_panel.add(fractionationTechniqueTabbedPane);
-        fractionationTechniqueTabbedPane.setBounds(0, 165, 190, 180);
+        fractionationTechniqueTabbedPane.setBounds(1, 165, 189, 180);
 
         restoreAllAquisitions.setFont(new java.awt.Font("SansSerif", 0, 12)); // NOI18N
         restoreAllAquisitions.setText("Restore all Aquisitions");
@@ -1267,7 +1267,7 @@ public class SessionAnalysisWorkflowManagerLAICPMS extends DialogEditor //
         });
         controlPanel_panel.setLayer(restoreAllAquisitions, javax.swing.JLayeredPane.PALETTE_LAYER);
         controlPanel_panel.add(restoreAllAquisitions);
-        restoreAllAquisitions.setBounds(0, 500, 150, 20);
+        restoreAllAquisitions.setBounds(1, 500, 150, 20);
 
         jPanel1.setBackground(new java.awt.Color(250, 240, 230));
         jPanel1.setPreferredSize(new java.awt.Dimension(191, 70));
@@ -1287,7 +1287,7 @@ public class SessionAnalysisWorkflowManagerLAICPMS extends DialogEditor //
                 gridPlot_radioButtonActionPerformed(evt);
             }
         });
-        jPanel1.add(gridPlot_radioButton, new org.netbeans.lib.awtextra.AbsoluteConstraints(0, 8, 50, -1));
+        jPanel1.add(gridPlot_radioButton, new org.netbeans.lib.awtextra.AbsoluteConstraints(1, 8, 50, -1));
 
         graphPlot_radioButton.setBackground(new java.awt.Color(204, 255, 204));
         plotStyleFractions_buttonGroup.add(graphPlot_radioButton);
@@ -1303,7 +1303,7 @@ public class SessionAnalysisWorkflowManagerLAICPMS extends DialogEditor //
                 graphPlot_radioButtonActionPerformed(evt);
             }
         });
-        jPanel1.add(graphPlot_radioButton, new org.netbeans.lib.awtextra.AbsoluteConstraints(50, 8, 65, -1));
+        jPanel1.add(graphPlot_radioButton, new org.netbeans.lib.awtextra.AbsoluteConstraints(51, 8, 65, -1));
 
         overlayPlot_radioButton.setBackground(new java.awt.Color(204, 255, 204));
         plotStyleFractions_buttonGroup.add(overlayPlot_radioButton);
@@ -1319,7 +1319,7 @@ public class SessionAnalysisWorkflowManagerLAICPMS extends DialogEditor //
                 overlayPlot_radioButtonActionPerformed(evt);
             }
         });
-        jPanel1.add(overlayPlot_radioButton, new org.netbeans.lib.awtextra.AbsoluteConstraints(115, 8, 75, -1));
+        jPanel1.add(overlayPlot_radioButton, new org.netbeans.lib.awtextra.AbsoluteConstraints(116, 8, 75, -1));
         jPanel1.add(samplesCompboBox, new org.netbeans.lib.awtextra.AbsoluteConstraints(2, 27, 185, -1));
 
         amPrimaryRefMaterial_label.setFont(new java.awt.Font("Arial", 0, 12)); // NOI18N
@@ -1334,7 +1334,7 @@ public class SessionAnalysisWorkflowManagerLAICPMS extends DialogEditor //
         yAxisOptionsLabel.setFont(new java.awt.Font("SansSerif", 0, 13)); // NOI18N
         yAxisOptionsLabel.setText("Y-axis Scaling Options:");
         controlPanel_panel.add(yAxisOptionsLabel);
-        yAxisOptionsLabel.setBounds(0, 350, 160, 16);
+        yAxisOptionsLabel.setBounds(1, 350, 160, 16);
 
         yAxisScalingOptions.add(uniformYaxis);
         uniformYaxis.setFont(new java.awt.Font("SansSerif", 0, 12)); // NOI18N
@@ -1349,7 +1349,7 @@ public class SessionAnalysisWorkflowManagerLAICPMS extends DialogEditor //
             }
         });
         controlPanel_panel.add(uniformYaxis);
-        uniformYaxis.setBounds(0, 365, 75, 20);
+        uniformYaxis.setBounds(1, 365, 75, 20);
 
         yAxisScalingOptions.add(independentYaxis);
         independentYaxis.setFont(new java.awt.Font("SansSerif", 0, 12)); // NOI18N
@@ -1363,7 +1363,7 @@ public class SessionAnalysisWorkflowManagerLAICPMS extends DialogEditor //
             }
         });
         controlPanel_panel.add(independentYaxis);
-        independentYaxis.setBounds(75, 365, 115, 20);
+        independentYaxis.setBounds(76, 365, 115, 20);
 
         dataScalingOptions.add(allDataUsedForScaling);
         allDataUsedForScaling.setFont(new java.awt.Font("SansSerif", 0, 12)); // NOI18N
@@ -1378,12 +1378,12 @@ public class SessionAnalysisWorkflowManagerLAICPMS extends DialogEditor //
             }
         });
         controlPanel_panel.add(allDataUsedForScaling);
-        allDataUsedForScaling.setBounds(0, 405, 75, 20);
+        allDataUsedForScaling.setBounds(1, 405, 75, 20);
 
         dataScalingOptionsLabel.setFont(new java.awt.Font("SansSerif", 0, 13)); // NOI18N
         dataScalingOptionsLabel.setText("Data Scaling Options:");
         controlPanel_panel.add(dataScalingOptionsLabel);
-        dataScalingOptionsLabel.setBounds(0, 390, 150, 16);
+        dataScalingOptionsLabel.setBounds(1, 390, 150, 16);
 
         dataScalingOptions.add(includedDataUsedForScaling);
         includedDataUsedForScaling.setFont(new java.awt.Font("SansSerif", 0, 12)); // NOI18N
@@ -1397,7 +1397,7 @@ public class SessionAnalysisWorkflowManagerLAICPMS extends DialogEditor //
             }
         });
         controlPanel_panel.add(includedDataUsedForScaling);
-        includedDataUsedForScaling.setBounds(75, 405, 115, 20);
+        includedDataUsedForScaling.setBounds(76, 405, 115, 20);
 
         setAllIndividualYAxisPanes_button.setFont(new java.awt.Font("SansSerif", 0, 12)); // NOI18N
         setAllIndividualYAxisPanes_button.setText("Show all Local Y-Axis");
@@ -1408,7 +1408,7 @@ public class SessionAnalysisWorkflowManagerLAICPMS extends DialogEditor //
         });
         controlPanel_panel.setLayer(setAllIndividualYAxisPanes_button, javax.swing.JLayeredPane.PALETTE_LAYER);
         controlPanel_panel.add(setAllIndividualYAxisPanes_button);
-        setAllIndividualYAxisPanes_button.setBounds(0, 520, 150, 20);
+        setAllIndividualYAxisPanes_button.setBounds(1, 520, 150, 20);
 
         tripoliTab_layeredPane.add(controlPanel_panel);
         controlPanel_panel.setBounds(0, 0, 191, 620);

--- a/src/main/java/org/earthtime/UPb_Redux/samples/Sample.java
+++ b/src/main/java/org/earthtime/UPb_Redux/samples/Sample.java
@@ -300,7 +300,7 @@ public class Sample implements
         // April 2011 we are altering SampleIGSN to be of form rrr.IGSN
         //  where rrr is registry as per enum SampleRegistries
         // this means that if sample is already flagged as validated - i.e. at SESAR
-        // we check that it is valid at GeochronID and change SampleIGSN and percolate it
+        // we check that it is valid at registry and change SampleIGSN and percolate it
         // down to all Aliquots
         updateWithRegistrySampleIGSN();
 

--- a/src/main/java/org/earthtime/UPb_Redux/valueModels/SampleDateModel.java
+++ b/src/main/java/org/earthtime/UPb_Redux/valueModels/SampleDateModel.java
@@ -1274,7 +1274,7 @@ public class SampleDateModel extends ValueModel implements
 //
 //            logWMresults.setLogRatioMeanOneSigmaAnalyticalPlusInterStdPlusStdPlusLambda(logRatioMeanOneSigmaAnalyticalPlusInterStdPlusStdPlusLambda);
 //
-                System.out.println("Logratio based WM have ARRIVED !!");
+//                System.out.println("Logratio based WM have ARRIVED !!");
             } catch (Exception e) {
             }
         }

--- a/src/main/java/org/earthtime/aliquots/ReduxAliquotInterface.java
+++ b/src/main/java/org/earthtime/aliquots/ReduxAliquotInterface.java
@@ -16,10 +16,12 @@
 package org.earthtime.aliquots;
 
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.Vector;
 import org.earthtime.UPb_Redux.utilities.comparators.IntuitiveStringComparator;
 import org.earthtime.archivingTools.AnalysisImageInterface;
 import org.earthtime.dataDictionaries.AnalysisImageTypes;
+import org.earthtime.dataDictionaries.RadDates;
 import org.earthtime.fractions.ETFractionInterface;
 
 /**
@@ -80,8 +82,30 @@ public interface ReduxAliquotInterface {
         getAliquotFractions().stream().filter((f) -> (!f.isRejected())).forEach((f) -> {
             retVal.add(f.getFractionID());
         });
-        
+
         Collections.sort(retVal, new IntuitiveStringComparator<>());
+        return retVal;
+    }
+
+    public default Vector<String> getAliquotFractionIDsSortedByDateAsc() {
+        Vector<ETFractionInterface> dateOrderedFractions = new Vector<>();
+        getAliquotFractions().stream().filter((f) -> (!f.isRejected())).forEach((f) -> {
+            dateOrderedFractions.add(f);
+        });
+
+        Collections.sort(dateOrderedFractions, new Comparator<ETFractionInterface>() {
+            @Override
+            public int compare(ETFractionInterface frac1, ETFractionInterface frac2) {
+                return frac1.getRadiogenicIsotopeDateByName(RadDates.age206_238r.getName()).getValue()//
+                        .compareTo(frac2.getRadiogenicIsotopeDateByName(RadDates.age206_238r.getName()).getValue());
+            }
+        });
+
+        Vector<String> retVal = new Vector<>();
+        for (int i = 0; i < dateOrderedFractions.size(); i ++){
+            retVal.add(dateOrderedFractions.get(i).getFractionID());
+        }
+        
         return retVal;
     }
 
@@ -133,8 +157,8 @@ public interface ReduxAliquotInterface {
      * @param inLiveMode the value of inLiveMode
      */
     public void reduceData(boolean inLiveMode);
-    
-        /**
+
+    /**
      *
      * @param imageType
      * @return

--- a/src/main/java/org/earthtime/archivingTools/GeochronAliquotManager.java
+++ b/src/main/java/org/earthtime/archivingTools/GeochronAliquotManager.java
@@ -39,7 +39,7 @@ import javax.swing.JPanel;
 import javax.swing.JTextField;
 import org.earthtime.UPb_Redux.ReduxConstants;
 import org.earthtime.aliquots.AliquotInterface;
-import static org.earthtime.archivingTools.GeoSamplesWebServices.isSampleRegistered;
+import static org.earthtime.archivingTools.GeoSamplesWebServices.isSampleRegisteredToParentAtTestGeoSamples;
 import static org.earthtime.archivingTools.GeochronUploaderUtility.produceConcordiaGraphForUploading;
 import static org.earthtime.archivingTools.GeochronUploaderUtility.producePDFImageForUploading;
 import org.earthtime.archivingTools.forSESAR.SesarSampleManager;
@@ -48,7 +48,7 @@ import org.earthtime.dialogs.DialogEditor;
 import org.earthtime.projects.ProjectInterface;
 import org.earthtime.samples.SampleInterface;
 import org.geosamples.samples.Samples;
-import static org.earthtime.archivingTools.GeoSamplesWebServices.isSampleRegisteredToParentAtTestGeoSamples;
+import static org.earthtime.archivingTools.GeoSamplesWebServices.isSampleRegisteredAtTestSesar;
 
 /**
  *
@@ -236,7 +236,7 @@ public class GeochronAliquotManager extends JPanel {
             public void actionPerformed(ActionEvent e) {
                 saveSample();
                 // get the igsn record and create a SesarSample to view
-                sesarSample = GeoSamplesWebServices.getSampleMetaDataFromGeoSamplesIGSN(sampleIGSN, userName, password, false).getSample().get(0);
+                sesarSample = GeoSamplesWebServices.getSampleMetaDataFromTestSesarIGSN(sampleIGSN, userName, password, false).getSample().get(0);
                 if (sesarSample != null) {
                     DialogEditor sesarSampleManager
                             = new SesarSampleManager(null, true, sesarSample, sample.getSampleName(), false, userName, password);
@@ -570,7 +570,7 @@ public class GeochronAliquotManager extends JPanel {
         public void actionPerformed(ActionEvent e) {
             saveAliquot(aliquot, aliquotIGSN_TextField.getText(), aliquotName_TextField);
             // get the igsn record and create a SesarSample to view
-            sesarAliquot = GeoSamplesWebServices.getSampleMetaDataFromGeoSamplesIGSN(aliquotIGSN_TextField.getText(), userName, password, false).getSample().get(0);
+            sesarAliquot = GeoSamplesWebServices.getSampleMetaDataFromTestSesarIGSN(aliquotIGSN_TextField.getText(), userName, password, false).getSample().get(0);
             if (sesarAliquot != null) {
                 DialogEditor sesarSampleManager
                         = new SesarSampleManager(null, true, sesarAliquot, aliquot.getAliquotName(), false, userName, password);
@@ -663,7 +663,7 @@ public class GeochronAliquotManager extends JPanel {
             boolean isValid = false;
             sampleIGSN = "IGSN";
             if (proposedIGSN.length() == 9) {
-                isValid = isSampleRegistered(proposedIGSN);
+                isValid = isSampleRegisteredAtTestSesar(proposedIGSN);
                 if (isValid) {
                     sampleIGSN = proposedIGSN.trim().toUpperCase();
                 } else if (userCode.trim().length() == 0) {

--- a/src/main/java/org/earthtime/archivingTools/URIHelper.java
+++ b/src/main/java/org/earthtime/archivingTools/URIHelper.java
@@ -252,35 +252,37 @@ public class URIHelper {
      */
     public static org.w3c.dom.Document RetrieveXMLfromServerAsDOMdocument(String connectionString) {
 
-        org.w3c.dom.Document doc = null;
-
+        Document convertedDocument = null;
         String tempSESARcontents = URIHelper.getTextFromURI(connectionString);
 
-        // write this to a file
-        String tempSESARFileName = "TempXMLfromServer.xml";
-        FileOutputStream fos = null;
-        try {
-            fos = new FileOutputStream(tempSESARFileName);
-        } catch (FileNotFoundException ex) {
-        }
+        // sept 2016 SESAR started returning 400 for bad igsn
+        if (tempSESARcontents.length() > 0) {
+            // write this to a file
+            String tempSESARFileName = "TempXMLfromServer.xml";
+            FileOutputStream fos = null;
+            try {
+                fos = new FileOutputStream(tempSESARFileName);
+            } catch (FileNotFoundException ex) {
+            }
 
-        OutputStreamWriter out = new OutputStreamWriter(fos);
-        try {
-            out.write(tempSESARcontents);
-            out.flush();
-            out.close();
-        } catch (IOException ex) {
-            JOptionPane.showMessageDialog(null,
-                    new String[]{
-                        "Error reaching server: "//
-                        + ex.getMessage()
-                    });
-            ex.printStackTrace();
-        }
+            OutputStreamWriter out = new OutputStreamWriter(fos);
+            try {
+                out.write(tempSESARcontents);
+                out.flush();
+                out.close();
+            } catch (IOException ex) {
+                JOptionPane.showMessageDialog(null,
+                        new String[]{
+                            "Error reaching server: "//
+                            + ex.getMessage()
+                        });
+                ex.printStackTrace();
+            }
 
-        File tempFile = new File(tempSESARFileName);
-        Document convertedDocument = convertXMLTextToDOMdocument(tempFile);
-        tempFile.delete();
+            File tempFile = new File(tempSESARFileName);
+            convertedDocument = convertXMLTextToDOMdocument(tempFile);
+            tempFile.delete();
+        }
 
         return convertedDocument;
     }

--- a/src/main/java/org/earthtime/archivingTools/forSESAR/SesarSampleManager.java
+++ b/src/main/java/org/earthtime/archivingTools/forSESAR/SesarSampleManager.java
@@ -35,13 +35,13 @@ import static javax.swing.SwingConstants.RIGHT;
 import org.earthtime.UPb_Redux.ReduxConstants;
 import org.earthtime.UPb_Redux.utilities.BrowserControl;
 import static org.earthtime.archivingTools.GeoSamplesWebServices.CURRENT_GEOSAMPLES_WEBSERVICE_FOR_DOWNLOAD_IGSN;
-import static org.earthtime.archivingTools.GeoSamplesWebServices.isSampleRegistered;
 import static org.earthtime.archivingTools.GeoSamplesWebServices.isWellFormedIGSN;
-import static org.earthtime.archivingTools.GeoSamplesWebServices.registerSampleAtGeoSamplesIGSN;
+import static org.earthtime.archivingTools.GeoSamplesWebServices.registerSampleAtTestSesarIGSN;
 import org.earthtime.beans.ET_JButton;
 import org.earthtime.dialogs.DialogEditor;
 import org.geosamples.XMLDocumentInterface;
 import org.geosamples.samples.Samples;
+import static org.earthtime.archivingTools.GeoSamplesWebServices.isSampleRegisteredAtTestSesar;
 
 /**
  *
@@ -265,7 +265,7 @@ public class SesarSampleManager extends DialogEditor {
                     String proposedIGSN = sampleIGSNText.getText();
                     if (!proposedIGSN.toUpperCase().startsWith(sesarSample.getUserCode().toUpperCase())) {
                         messageText = "User code prefix of IGSN should be: " + sesarSample.getUserCode();
-                    } else if (isSampleRegistered(proposedIGSN)) {
+                    } else if (isSampleRegisteredAtTestSesar(proposedIGSN)) {
                         messageText = "The IGSN: " + proposedIGSN + " is already in use.";
                     } else if (!isWellFormedIGSN(proposedIGSN, sesarSample.getUserCode())) {
                         messageText = "The IGSN: " + proposedIGSN + " is not of the form " + sesarSample.getUserCode() + "NNNNNNN\".substring(0, (9 - userCode.length())) + \", where N is any digit or any capital letter.";
@@ -283,7 +283,7 @@ public class SesarSampleManager extends DialogEditor {
                     sesarSample.setLatitude(new BigDecimal(decimalLatitude.getText()));
                     sesarSample.setLongitude(new BigDecimal(decimalLongitude.getText()));
                     // register at SESAR
-                    XMLDocumentInterface success = registerSampleAtGeoSamplesIGSN(sesarSample, true, userName, password);
+                    XMLDocumentInterface success = registerSampleAtTestSesarIGSN(sesarSample, true, userName, password);
                     if (success != null) {
                         sesarSample.setIgsn(success.getSample().get(0).getIgsn());
                     } else {

--- a/src/main/java/org/earthtime/dataDictionaries/SampleRegistries.java
+++ b/src/main/java/org/earthtime/dataDictionaries/SampleRegistries.java
@@ -30,9 +30,6 @@ public enum SampleRegistries {
     /**
      * 
      */
-    /**
-     * 
-     */
     SESAR( "SESAR", "SSR", "https://app.geosamples.org/webservices/display.php?igsn=" ),
 
     /**
@@ -126,7 +123,7 @@ public enum SampleRegistries {
     public static String updateSampleID ( String sampleID ) {
         String retVal = sampleID;
         if ( !sampleID.contains(".") ) {
-            retVal = GeochronID.code + "." + sampleID;
+            retVal = SESAR.code + "." + sampleID;
         }
 
         return retVal;
@@ -138,7 +135,7 @@ public enum SampleRegistries {
      * @return
      */
     public static boolean isSampleIdentifierValidAtRegistry ( String sampleID ) {
-        // if missing or bad registry code, default to SampleRegistries.GeochronID
+        // if missing or bad registry code, default to SampleRegistries.SESAR
         boolean retVal = false;
         String[] parsed = new String[2];
         SampleRegistries registry = null;
@@ -170,18 +167,6 @@ public enum SampleRegistries {
                                 retVal = doc.getElementsByTagName( "error" ).getLength() == 0;
                             }
                         }
-                        
-//                        
-//                        // As of Aug 15 2011 SESAR uses <results>, GeochronID uses <sample> for positive result
-//                        // however, both use <results><error> for negative result
-//                        boolean resultsElementPresent = doc.getFirstChild().getNodeName().equalsIgnoreCase( "results" );
-//                        // for now, take negative approach
-//                        if ( resultsElementPresent ) {
-//                            retVal = doc.getElementsByTagName( "error" ).getLength() == 0;
-//                        } else {
-//                            // got GeochronID <sample> 
-//                            retVal = true;
-//                        }
                     }
                 }
             }

--- a/src/main/java/org/earthtime/dialogs/DialogEditor.java
+++ b/src/main/java/org/earthtime/dialogs/DialogEditor.java
@@ -65,14 +65,31 @@ public abstract class DialogEditor extends JDialog {
     public DialogEditor(java.awt.Frame parent, boolean modal) {
         super(parent, modal);
 
-        JDialog.setDefaultLookAndFeelDecorated(true);
+//        JDialog.setDefaultLookAndFeelDecorated(true);
+        /* Set the Metal look and feel */
+        //<editor-fold defaultstate="collapsed" desc=" Look and feel setting code (optional) ">
+        /* If Metal is not available, stay with the default look and feel.
+         * For details see http://download.oracle.com/javase/tutorial/uiswing/lookandfeel/plaf.html 
+         */
+        try {
+            for (javax.swing.UIManager.LookAndFeelInfo info : javax.swing.UIManager.getInstalledLookAndFeels()) {
+                if ("Metal".equals(info.getName())) { //Nimbus (original), Motif, Metal
+                    javax.swing.UIManager.setLookAndFeel(info.getClassName());
+                    break;
+                }
+            }
+        } catch (ClassNotFoundException | InstantiationException | IllegalAccessException | javax.swing.UnsupportedLookAndFeelException ex) {
+            java.util.logging.Logger.getLogger(org.earthtime.dialogs.DialogEditor.class.getName()).log(java.util.logging.Level.WARNING, null, ex);
+        }
+        //</editor-fold>        
+
         initComponents();
     }
 
-    public void initDialogContent(){
-        
+    public void initDialogContent() {
+
     }
-    
+
     /**
      *
      * @param preferredWidth
@@ -146,16 +163,16 @@ public abstract class DialogEditor extends JDialog {
             textComp.getActionMap().put("Undo",
                     new AbstractAction("Undo") {
 
-                        @Override
-                        public void actionPerformed(ActionEvent evt) {
-                            try {
-                                if (undo.canUndo()) {
-                                    undo.undo();
-                                }
-                            } catch (CannotUndoException e) {
-                            }
+                @Override
+                public void actionPerformed(ActionEvent evt) {
+                    try {
+                        if (undo.canUndo()) {
+                            undo.undo();
                         }
-                    });
+                    } catch (CannotUndoException e) {
+                    }
+                }
+            });
 
             // Bind the undo action to ctl-Z
             textComp.getInputMap().put(KeyStroke.getKeyStroke("control Z"), "Undo");
@@ -164,16 +181,16 @@ public abstract class DialogEditor extends JDialog {
             textComp.getActionMap().put("Redo",
                     new AbstractAction("Redo") {
 
-                        @Override
-                        public void actionPerformed(ActionEvent evt) {
-                            try {
-                                if (undo.canRedo()) {
-                                    undo.redo();
-                                }
-                            } catch (CannotRedoException e) {
-                            }
+                @Override
+                public void actionPerformed(ActionEvent evt) {
+                    try {
+                        if (undo.canRedo()) {
+                            undo.redo();
                         }
-                    });
+                    } catch (CannotRedoException e) {
+                    }
+                }
+            });
 
             // Bind the redo action to ctl-Y
             textComp.getInputMap().put(KeyStroke.getKeyStroke("control Y"), "Redo");

--- a/src/main/java/org/earthtime/dialogs/projectManagers/projectLegacyManagers/AbstractProjectOfLegacySamplesDataManagerDialog.form
+++ b/src/main/java/org/earthtime/dialogs/projectManagers/projectLegacyManagers/AbstractProjectOfLegacySamplesDataManagerDialog.form
@@ -45,7 +45,7 @@
           <Group type="102" attributes="0">
               <Component id="sampleType_panel" min="-2" max="-2" attributes="0"/>
               <EmptySpace min="6" pref="6" max="-2" attributes="0"/>
-              <Component id="infoPanel" pref="380" max="32767" attributes="0"/>
+              <Component id="infoPanel" pref="387" max="32767" attributes="0"/>
               <EmptySpace min="6" pref="6" max="-2" attributes="0"/>
               <Component id="jPanel2" min="-2" max="-2" attributes="0"/>
           </Group>
@@ -270,9 +270,12 @@
           <Events>
             <EventHandler event="actionPerformed" listener="java.awt.event.ActionListener" parameters="java.awt.event.ActionEvent" handler="closeActionPerformed"/>
           </Events>
+          <AuxValues>
+            <AuxValue name="JavaCodeGenerator_CreateCodeCustom" type="java.lang.String" value="new ET_JButton()"/>
+          </AuxValues>
           <Constraints>
             <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.DesignAbsoluteLayout" value="org.netbeans.modules.form.compat2.layouts.DesignAbsoluteLayout$AbsoluteConstraintsDescription">
-              <AbsoluteConstraints x="470" y="0" width="168" height="32"/>
+              <AbsoluteConstraints x="470" y="0" width="168" height="25"/>
             </Constraint>
           </Constraints>
         </Component>
@@ -293,9 +296,12 @@
           <Events>
             <EventHandler event="actionPerformed" listener="java.awt.event.ActionListener" parameters="java.awt.event.ActionEvent" handler="saveAndCloseActionPerformed"/>
           </Events>
+          <AuxValues>
+            <AuxValue name="JavaCodeGenerator_CreateCodeCustom" type="java.lang.String" value="new ET_JButton()"/>
+          </AuxValues>
           <Constraints>
             <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.DesignAbsoluteLayout" value="org.netbeans.modules.form.compat2.layouts.DesignAbsoluteLayout$AbsoluteConstraintsDescription">
-              <AbsoluteConstraints x="8" y="2" width="168" height="32"/>
+              <AbsoluteConstraints x="8" y="2" width="168" height="25"/>
             </Constraint>
           </Constraints>
         </Component>

--- a/src/main/java/org/earthtime/dialogs/projectManagers/projectLegacyManagers/AbstractProjectOfLegacySamplesDataManagerDialog.java
+++ b/src/main/java/org/earthtime/dialogs/projectManagers/projectLegacyManagers/AbstractProjectOfLegacySamplesDataManagerDialog.java
@@ -319,8 +319,8 @@ public abstract class AbstractProjectOfLegacySamplesDataManagerDialog extends Di
         dataSourceLabel = new javax.swing.JLabel();
         dataSourceNameLabel = new javax.swing.JLabel();
         jPanel2 = new javax.swing.JPanel();
-        close = new javax.swing.JButton();
-        saveAndClose = new javax.swing.JButton();
+        close = new ET_JButton();
+        saveAndClose = new ET_JButton();
         sampleType_panel = new javax.swing.JPanel();
         sampleType_label = new javax.swing.JLabel();
 
@@ -408,7 +408,7 @@ public abstract class AbstractProjectOfLegacySamplesDataManagerDialog extends Di
                 closeActionPerformed(evt);
             }
         });
-        jPanel2.add(close, new org.netbeans.lib.awtextra.AbsoluteConstraints(470, 0, 168, 32));
+        jPanel2.add(close, new org.netbeans.lib.awtextra.AbsoluteConstraints(470, 0, 168, 25));
 
         saveAndClose.setForeground(new java.awt.Color(255, 51, 0));
         saveAndClose.setText("Save and Close");
@@ -420,7 +420,7 @@ public abstract class AbstractProjectOfLegacySamplesDataManagerDialog extends Di
                 saveAndCloseActionPerformed(evt);
             }
         });
-        jPanel2.add(saveAndClose, new org.netbeans.lib.awtextra.AbsoluteConstraints(8, 2, 168, 32));
+        jPanel2.add(saveAndClose, new org.netbeans.lib.awtextra.AbsoluteConstraints(8, 2, 168, 25));
 
         sampleType_panel.setBorder(javax.swing.BorderFactory.createLineBorder(new java.awt.Color(0, 0, 0)));
 
@@ -453,7 +453,7 @@ public abstract class AbstractProjectOfLegacySamplesDataManagerDialog extends Di
             .add(layout.createSequentialGroup()
                 .add(sampleType_panel, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE, org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE)
                 .add(6, 6, 6)
-                .add(infoPanel, org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, 380, Short.MAX_VALUE)
+                .add(infoPanel, org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, 387, Short.MAX_VALUE)
                 .add(6, 6, 6)
                 .add(jPanel2, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE, org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE))
         );

--- a/src/main/java/org/earthtime/reportViews/ReportAliquotFractionsView.java
+++ b/src/main/java/org/earthtime/reportViews/ReportAliquotFractionsView.java
@@ -474,6 +474,7 @@ public class ReportAliquotFractionsView extends JLayeredPane implements ReportUp
         reportFractionIDsScrollPane.getVerticalScrollBar().setPreferredSize(new Dimension(0, 0));
         // eliminate default "crawl"
         reportFractionIDsScrollPane.getVerticalScrollBar().setUnitIncrement(64);
+        reportFractionIDsScrollPane.getVerticalScrollBar().setBlockIncrement(2);
         reportFractionIDsScrollPane.getHorizontalScrollBar().setUnitIncrement(64);
 
         reportFractionIDsScrollPane.setLocation(0, DATATABLE_TOP_HEIGHT);
@@ -503,6 +504,7 @@ public class ReportAliquotFractionsView extends JLayeredPane implements ReportUp
         reportBodyScrollPane.setVerticalScrollBarPolicy(ScrollPaneConstants.VERTICAL_SCROLLBAR_AS_NEEDED);
         // eliminate default "crawl"
         reportBodyScrollPane.getVerticalScrollBar().setUnitIncrement(64);
+        reportBodyScrollPane.getVerticalScrollBar().setBlockIncrement(2);
         reportBodyScrollPane.getHorizontalScrollBar().setUnitIncrement(64);
 
         reportBodyScrollPane.setLocation(fractionColumnWidth, DATATABLE_TOP_HEIGHT);

--- a/src/main/java/org/earthtime/reportViews/TabbedReportViews.java
+++ b/src/main/java/org/earthtime/reportViews/TabbedReportViews.java
@@ -67,6 +67,7 @@ public class TabbedReportViews extends JTabbedPane {
     public void initializeTabs() {
 
         setBackground(Color.white);
+        setForeground(Color.red);
 
         viewTabulatedAliquotActiveFractions = new ReportAliquotFractionsView(parentFrame, true);
         add("Active Fractions", viewTabulatedAliquotActiveFractions);

--- a/src/main/java/org/earthtime/reports/ReportSettingsInterface.java
+++ b/src/main/java/org/earthtime/reports/ReportSettingsInterface.java
@@ -78,7 +78,7 @@ public interface ReportSettingsInterface extends Comparable<ReportSettingsInterf
     public void assembleReportCategories();
 
     public ReportSettingsInterface deepCopy();
-    
+
     /**
      *
      * @return
@@ -167,15 +167,15 @@ public interface ReportSettingsInterface extends Comparable<ReportSettingsInterf
     @Override
     boolean equals(Object reportSettingsModel);
 
-    public default void toggleMeasuredRatiosInCompositionCategory(){
+    public default void toggleMeasuredRatiosInCompositionCategory() {
         ReportCategoryInterface composition = getCompositionCategory();
-        for (ReportColumnInterface column : composition.getCategoryColumns()){
-            if (column.getDisplayName1().contains("meas")){
+        for (ReportColumnInterface column : composition.getCategoryColumns()) {
+            if (column.getDisplayName1().contains("meas")) {
                 column.ToggleIsVisible();
             }
-        }      
+        }
     }
-    
+
     /**
      *
      * @return
@@ -415,11 +415,9 @@ public interface ReportSettingsInterface extends Comparable<ReportSettingsInterf
 
             // get first activityValue and first Th_Umagma value and set standard footnote entries
             BigDecimal savedActivityValue
-                    = //
-                    fractions.get(0).getAnalysisMeasure(AnalysisMeasures.ar231_235sample.getName()).getValue();
+                    = fractions.get(0).getAnalysisMeasure(AnalysisMeasures.ar231_235sample.getName()).getValue();
             BigDecimal savedMagmaValue
-                    = //
-                    fractions.get(0).getAnalysisMeasure(AnalysisMeasures.rTh_Umagma.getName()).getValue();
+                    = fractions.get(0).getAnalysisMeasure(AnalysisMeasures.rTh_Umagma.getName()).getValue();
 
             activityFootnoteEntry = "= " + savedActivityValue.toString();
             thU_MagmaFootnoteEntry = "= " + savedMagmaValue.toString();
@@ -650,8 +648,7 @@ public interface ReportSettingsInterface extends Comparable<ReportSettingsInterf
                                     }
 
                                     retVal[fractionRowCount][1]
-                                            = //
-                                            sample.getAliquotByNumber(f.getAliquotNumber()).getAliquotName();
+                                            = sample.getAliquotByNumber(f.getAliquotNumber()).getAliquotName();
                                 }
 
                                 // field contains the Value in field[0]
@@ -709,12 +706,10 @@ public interface ReportSettingsInterface extends Comparable<ReportSettingsInterf
             String lambda235Ref = "";
             try {
                 lambda238Ref
-                        = //
-                        " (" + ((ValueModelReferenced) sample.getPhysicalConstantsModel()//
+                        = " (" + ((ValueModelReferenced) sample.getPhysicalConstantsModel()//
                         .getDatumByName(Lambdas.lambda238.getName())).getReference() + ")";
                 lambda235Ref
-                        = //
-                        " (" + ((ValueModelReferenced) sample.getPhysicalConstantsModel()//
+                        = " (" + ((ValueModelReferenced) sample.getPhysicalConstantsModel()//
                         .getDatumByName(Lambdas.lambda235.getName())).getReference() + ")";
             } catch (BadLabDataException badLabDataException) {
             }

--- a/src/main/java/org/earthtime/samples/SampleInterface.java
+++ b/src/main/java/org/earthtime/samples/SampleInterface.java
@@ -339,12 +339,17 @@ public interface SampleInterface {
      * @return
      */
     public default boolean isAnalysisTypeLAICPMS() {
-        boolean retVal = false;
-        try {
-            retVal = SampleAnalysisTypesEnum.LAICPMS.equals(SampleAnalysisTypesEnum.valueOf(getSampleAnalysisType()));
-        } catch (Exception e) {
-        }
-        return retVal;
+//        boolean retVal = false;
+//        try {
+//            retVal = SampleAnalysisTypesEnum.LAICPMS.equals(SampleAnalysisTypesEnum.valueOf(getSampleAnalysisType()));
+//        } catch (Exception e) {
+//        }
+//
+//        return retVal;
+//        
+                
+        // sept 2016
+        return getSampleAnalysisType().startsWith("LAICPMS");
     }
 
     /**

--- a/src/test/java/org/earthtime/dataDictionaries/SampleRegistriesTest.java
+++ b/src/test/java/org/earthtime/dataDictionaries/SampleRegistriesTest.java
@@ -115,7 +115,7 @@ public class SampleRegistriesTest {
     public void test_UpdateSampleID() {
         System.out.println("Testing SampleRegistries's gupdateSampleID(String sampleId)");
         String sampleID = "hello";
-        String expResult = "GCH.hello";
+        String expResult = "SSR.hello";
         String result = SampleRegistries.updateSampleID(sampleID);
         assertEquals(expResult, result);
         


### PR DESCRIPTION
Probability density plot histograms in probability density plot are now working properly (fixes #114), but we are not addressing issue #113 for opening probability  density plots with older versions of Illustrator. 

Fixes #111 for legacy importing.  For issue #115 about uploading legacy data to Geochron, currently opening the aliquot manager and then the publishing tab will allow for interaction and uploading to Geochron (production, not test mode).  However, the user currently has to get an IGSN from SESAR independently.  We will provide the same seamless interface as we have for LA ICP MS data processing in a later release.  The plan is to provide that functionality when we move the LA ICP MS registration and uploading from test to production.

Improves the handling of LA ICP MS lead.  Previously, bad lead 204 acquisitions turned off all ratios associated with that acquisition.  Now, only ratios with 204 in the denominator are affected.  A side-effect is that correlation coefficients (rho) are now calculated in all cases.

Issue #110 asked for a way to group fractions for selection into weighted means.  This is addressed partially with a new menu item for sample dates under weighted means that toggles sorting the fractions in a weighted mean by date ascending in the left hand panel.  Further work on designing the appropriate user interface is requested for a future issue after evaluation of this enhancement.