### PR TITLE
Provide for greyed-out report table entries when fractions filtered.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
     <groupId>org.cirdles</groupId>
     <artifactId>ET_Redux</artifactId>
     <name>ET_Redux</name>
-    <version>3.6.7</version>
+    <version>3.6.8</version>
     <description>Successor to U-Pb_Redux</description>
     <url>https://cirdles.org</url>
     <inceptionYear>2006</inceptionYear>

--- a/src/main/java/org/earthtime/ETReduxFrame.java
+++ b/src/main/java/org/earthtime/ETReduxFrame.java
@@ -1493,8 +1493,15 @@ public class ETReduxFrame extends javax.swing.JFrame implements ReportPainterI, 
      */
     @Override
     public void loadAndShowReportTableData(String fractionIdToFocus) {
-
         ((TabbedReportViews) getReportTableTabbedPane()).prepareTabs();
+    }
+
+    /**
+     *
+     */
+    @Override
+    public void refreshReportTableData() {
+        ((TabbedReportViews) getReportTableTabbedPane()).refreshTabs();
     }
 
     private void openTheSample(File selFile, boolean checkSavedStatus) {

--- a/src/main/java/org/earthtime/Tripoli/dataViews/dataMonitorViews/AbstractDataMonitorView.java
+++ b/src/main/java/org/earthtime/Tripoli/dataViews/dataMonitorViews/AbstractDataMonitorView.java
@@ -232,7 +232,7 @@ public class AbstractDataMonitorView extends AbstractRawDataView
         saveMonitoredTime = 0L;
         tripoliFractions = new TreeSet<>();
 
-        parentDimension = new Dimension(2050, 1275);
+        parentDimension = new Dimension(2050, 1300);
 
         initView();
     }
@@ -335,6 +335,13 @@ public class AbstractDataMonitorView extends AbstractRawDataView
 
         this.add(rawDataFilePathTextArea, JLayeredPane.DEFAULT_LAYER);
 
+        reportTableTabbedPane = new TabbedReportViews(uPbReduxFrame, project.getSuperSample());
+        ((TabbedReportViews) reportTableTabbedPane).initializeTabs();
+        ((TabbedReportViews) reportTableTabbedPane).prepareTabs();
+
+        reportTableTabbedPane.setBounds(leftMargin, topMargin + 705, 1930, 500);
+        this.add(reportTableTabbedPane, LAYER_FIVE);
+
         if (tripoliFractions.size() > 0) {
 
             if (showSessions) {
@@ -351,13 +358,6 @@ public class AbstractDataMonitorView extends AbstractRawDataView
         buttonFactory();
 
         savedCountOfFractions = tripoliFractions.size();
-
-        reportTableTabbedPane = new TabbedReportViews(uPbReduxFrame, project.getSuperSample());
-        ((TabbedReportViews) reportTableTabbedPane).initializeTabs();
-        ((TabbedReportViews) reportTableTabbedPane).prepareTabs();
-
-        reportTableTabbedPane.setBounds(leftMargin, topMargin + 705, 1930, 500);
-        this.add(reportTableTabbedPane, LAYER_FIVE);
 
         this.add(mostRecentFractionData);
 
@@ -460,7 +460,7 @@ public class AbstractDataMonitorView extends AbstractRawDataView
         // show rawdatafile path
         mostRecentFractionData = new JLabel("Latest:");
 
-        mostRecentFractionData.setBounds(leftMargin -10, topMargin + 648, 650, 21);
+        mostRecentFractionData.setBounds(leftMargin - 10, topMargin + 648, 650, 21);
         mostRecentFractionData.setBorder(new LineBorder(Color.black));
 
         mostRecentFractionData.setForeground(Color.blue);
@@ -590,7 +590,7 @@ public class AbstractDataMonitorView extends AbstractRawDataView
         }
 
         setConcordiaBounds(showSessions ? 725 : leftMargin + 135, showSessions ? 620 : 900, 625);
-        
+
         kwikiConcordiaToolBar = new KwikiConcordiaToolBar(//
                 940, topMargin + concordiaGraphPanel.getHeight() + topMargin + 50, concordiaGraphPanel, null);
 
@@ -616,6 +616,8 @@ public class AbstractDataMonitorView extends AbstractRawDataView
         showFilteredFractions_checkbox.setFont(new java.awt.Font("SansSerif", 1, 10));
         showFilteredFractions_checkbox.setText("<html>Filtering ON<br> </html>");
         showFilteredFractions_checkbox.setBounds(leftMargin + 1075, topMargin + 660, 120, 25);
+        showFilteredFractions_checkbox.setOpaque(true);
+        showFilteredFractions_checkbox.setBackground(Color.white);
         showFilteredFractions_checkbox.addActionListener((java.awt.event.ActionEvent evt) -> {
             boolean state = ((AliquotDetailsDisplayInterface) concordiaGraphPanel).isShowFilteredEllipses();
             ((AliquotDetailsDisplayInterface) concordiaGraphPanel).setShowFilteredEllipses(!state);
@@ -662,7 +664,7 @@ public class AbstractDataMonitorView extends AbstractRawDataView
         ((DateProbabilityDensityPanel) probabilityPanel).//
                 setSelectedFractions(filterActiveUPbFractions(project.getSuperSample().getUpbFractionsUnknown()));
 
-        probabilityPanel.setBounds(showSessions ? 1355: leftMargin + 1050 , topMargin + 60, showSessions ? pdfWidth: 875, pdfHeight - 5);
+        probabilityPanel.setBounds(showSessions ? 1355 : leftMargin + 1050, topMargin + 60, showSessions ? pdfWidth : 875, pdfHeight - 5);
 
         ((DateProbabilityDensityPanel) probabilityPanel).setChosenDateName("age206_238r");
 
@@ -674,7 +676,8 @@ public class AbstractDataMonitorView extends AbstractRawDataView
 
         add(probabilityPanel, javax.swing.JLayeredPane.DEFAULT_LAYER);
 
-        kwikiPDFToolBar = new KwikiPDFToolBar(1350, concordiaGraphPanel.getHeight() + topMargin + 50, probabilityPanel, concordiaGraphPanel, project.getSuperSample(), dateTreeByAliquot);
+        kwikiPDFToolBar = new KwikiPDFToolBar(//
+                1250, concordiaGraphPanel.getHeight() + topMargin + 52, probabilityPanel, concordiaGraphPanel, project.getSuperSample(), dateTreeByAliquot, reportTableTabbedPane);
         add(kwikiPDFToolBar, javax.swing.JLayeredPane.DEFAULT_LAYER);
 
     }
@@ -684,7 +687,7 @@ public class AbstractDataMonitorView extends AbstractRawDataView
         JScrollPane dateTreeByAliquot_ScrollPane = new javax.swing.JScrollPane();
         dateTreeByAliquot_ScrollPane.setBounds(showSessions ? 600 : leftMargin + 10, topMargin + 50, 125, 500);
         dateTreeByAliquot = new SampleTreeAnalysisMode(project.getSuperSample());
-        
+
         dateTreeByAliquot.setSampleTreeChange(this);
         dateTreeByAliquot.buildTree();
         dateTreeByAliquot.expandAllNodes();
@@ -697,22 +700,8 @@ public class AbstractDataMonitorView extends AbstractRawDataView
 
         Vector<ETFractionInterface> filteredFractions = new Vector<>();
 
-        String dateName = ((DateProbabilityDensityPanel) probabilityPanel).getChosenDateName();
-
         for (ETFractionInterface f : fractions) {
             boolean doAddFraction = !f.isRejected();
-//            double pctDiscordance = f.getRadiogenicIsotopeDateByName(RadDates.percentDiscordance).getValue().doubleValue();
-//
-//            if (pctDiscordance >= 0.0) {  //
-//                // positive percent discordance
-//                doAddFraction = doAddFraction && (pctDiscordance <= positivePctDiscordance_slider.getValue());
-//            } else {
-//                // negative percent discordance
-//                doAddFraction = doAddFraction && (pctDiscordance >= negativePctDiscordance_slider.getValue());
-//            }
-//            doAddFraction = doAddFraction //
-//                    && f.getRadiogenicIsotopeDateByName(dateName).getOneSigmaPct().doubleValue() //
-//                    <= percentUncertainty_slider.getValue();
 
             if (doAddFraction) {
                 filteredFractions.add(f);
@@ -997,7 +986,7 @@ public class AbstractDataMonitorView extends AbstractRawDataView
         paintInit(g2d);
 
         // draw box around possibly missing pdf
-        g2d.drawRect(showSessions ? 1350: leftMargin + 1045, topMargin + 50, (showSessions ? pdfWidth : 875 ) + 5, pdfHeight + 5);
+        g2d.drawRect(showSessions ? 1350 : leftMargin + 1045, topMargin + 50, (showSessions ? pdfWidth : 875) + 5, pdfHeight + 5);
     }
 
     /**

--- a/src/main/java/org/earthtime/UPb_Redux/dateInterpretation/kwiki/KwikiConcordiaToolBar.java
+++ b/src/main/java/org/earthtime/UPb_Redux/dateInterpretation/kwiki/KwikiConcordiaToolBar.java
@@ -24,7 +24,6 @@ import java.awt.Graphics2D;
 import java.awt.Insets;
 import java.awt.RenderingHints;
 import java.awt.event.ActionEvent;
-import java.awt.event.ActionListener;
 import java.beans.PropertyChangeListener;
 import java.beans.PropertyChangeSupport;
 import javax.swing.AbstractButton;
@@ -32,12 +31,12 @@ import javax.swing.JButton;
 import javax.swing.JCheckBox;
 import javax.swing.JLayeredPane;
 import javax.swing.event.ChangeEvent;
-import javax.swing.event.ChangeListener;
 import org.earthtime.UPb_Redux.ReduxConstants;
 import org.earthtime.UPb_Redux.dateInterpretation.concordia.ConcordiaGraphPanel;
 import org.earthtime.UPb_Redux.dateInterpretation.concordia.GraphPanelModeChangeI;
 import org.earthtime.UPb_Redux.dateInterpretation.concordia.PlottingDetailsDisplayInterface;
 import org.earthtime.UPb_Redux.dateInterpretation.graphPersistence.GraphAxesSetup;
+import org.earthtime.beans.ET_JButton;
 
 /**
  *
@@ -56,12 +55,13 @@ public class KwikiConcordiaToolBar extends JLayeredPane implements GraphPanelMod
     private JCheckBox concordiaErrorsToggle;
     private final JLayeredPane concordiaGraphPanel;
 
-
-    /** Creates a new instance of KwikiConcordiaToolBar
-     * @param x 
+    /**
+     * Creates a new instance of KwikiConcordiaToolBar
+     *
+     * @param x
      * @param kwikiDateModesSelectorListener
-     * @param concordiaGraphPanel 
-     * @param y  
+     * @param concordiaGraphPanel
+     * @param y
      */
     public KwikiConcordiaToolBar(
             int x,
@@ -85,18 +85,13 @@ public class KwikiConcordiaToolBar extends JLayeredPane implements GraphPanelMod
         SetupZoomToggleButtons();
         SetupOptionsCheckBoxes();
 
-        ((ConcordiaGraphPanel)concordiaGraphPanel).setGraphPanelModeChanger( this);
+        ((ConcordiaGraphPanel) concordiaGraphPanel).setGraphPanelModeChanger(this);
 
     }
 
     private void SetupZoomToggleButtons() {
-        zoomInX2 = new JButton("+");
-        zoomInX2.setOpaque(false);
-        zoomInX2.setForeground(Color.black);
-        zoomInX2.setFont(ReduxConstants.sansSerif_12_Bold);
-        zoomInX2.setBounds(1, 1, 55, 15);
-        zoomInX2.setMargin(new Insets(0, 0, 0, 0));
-
+        zoomInX2 = new ET_JButton("+");
+        zoomInX2.setBounds(1, 1, 55, 16);
 
         zoomInX2.addActionListener((ActionEvent arg0) -> {
             ((ConcordiaGraphPanel) concordiaGraphPanel).performZoom(4.0);
@@ -105,13 +100,8 @@ public class KwikiConcordiaToolBar extends JLayeredPane implements GraphPanelMod
 
         add(zoomInX2, javax.swing.JLayeredPane.DEFAULT_LAYER);
 
-        zoomOutX2 = new JButton("-");
-        zoomOutX2.setOpaque(false);
-        zoomOutX2.setForeground(Color.black);
-        zoomOutX2.setFont(ReduxConstants.sansSerif_12_Bold);
-        zoomOutX2.setBounds(1, 17, 55, 15);
-        zoomOutX2.setMargin(new Insets(0, 0, 0, 0));
-
+        zoomOutX2 = new ET_JButton("-");
+        zoomOutX2.setBounds(1, 16, 55, 16);
 
         zoomOutX2.addActionListener((ActionEvent arg0) -> {
             ((ConcordiaGraphPanel) concordiaGraphPanel).performZoom(-2.0);
@@ -120,12 +110,8 @@ public class KwikiConcordiaToolBar extends JLayeredPane implements GraphPanelMod
 
         add(zoomOutX2, javax.swing.JLayeredPane.DEFAULT_LAYER);
 
-        restoreZoom = new JButton("R");
-        restoreZoom.setOpaque(false);
-        restoreZoom.setForeground(Color.black);
-        restoreZoom.setFont(ReduxConstants.sansSerif_12_Bold);
-        restoreZoom.setBounds(1, 32, 55, 15);
-        restoreZoom.setMargin(new Insets(0, 0, 0, 0));
+        restoreZoom = new ET_JButton("Reset");
+        restoreZoom.setBounds(1, 31, 55, 16);
 
         restoreZoom.addActionListener((ActionEvent arg0) -> {
             ((PlottingDetailsDisplayInterface) concordiaGraphPanel).resetPanel(true, false);
@@ -133,14 +119,8 @@ public class KwikiConcordiaToolBar extends JLayeredPane implements GraphPanelMod
 
         add(restoreZoom, javax.swing.JLayeredPane.DEFAULT_LAYER);
 
-
-        panToggle = new JButton("Pan");
-        panToggle.setOpaque(false);
-        panToggle.setForeground(Color.black);
-        panToggle.setFont(ReduxConstants.sansSerif_12_Bold);
-        panToggle.setBounds(55, 1, 68, 24);
-        panToggle.setMargin(new Insets(0, 0, 0, 0));
-
+        panToggle = new ET_JButton("Pan");
+        panToggle.setBounds(55, 1, 65, 24);
 
         panToggle.addActionListener((ActionEvent arg0) -> {
             ((ConcordiaGraphPanel) concordiaGraphPanel).setImageMode("PAN");
@@ -149,13 +129,8 @@ public class KwikiConcordiaToolBar extends JLayeredPane implements GraphPanelMod
 
         add(panToggle, javax.swing.JLayeredPane.DEFAULT_LAYER);
 
-        zoomBoxToggle = new JButton("Zbox");
-        zoomBoxToggle.setOpaque(false);
-        zoomBoxToggle.setForeground(Color.black);
-        zoomBoxToggle.setFont(ReduxConstants.sansSerif_12_Bold);
-        zoomBoxToggle.setBounds(55, 24, 68, 24);
-        zoomBoxToggle.setMargin(new Insets(0, 0, 0, 0));
-
+        zoomBoxToggle = new ET_JButton("Zbox");
+        zoomBoxToggle.setBounds(55, 24, 65, 24);
 
         zoomBoxToggle.addActionListener((ActionEvent arg0) -> {
             ((ConcordiaGraphPanel) concordiaGraphPanel).setImageMode("ZOOM");
@@ -216,9 +191,8 @@ public class KwikiConcordiaToolBar extends JLayeredPane implements GraphPanelMod
         add(concordiaErrorsToggle, javax.swing.JLayeredPane.DEFAULT_LAYER);
     }
 
-
     /**
-     * 
+     *
      * @param g
      */
     @Override
@@ -229,7 +203,7 @@ public class KwikiConcordiaToolBar extends JLayeredPane implements GraphPanelMod
     }
 
     /**
-     * 
+     *
      * @param g2d
      */
     public void paint(Graphics2D g2d) {
@@ -242,7 +216,6 @@ public class KwikiConcordiaToolBar extends JLayeredPane implements GraphPanelMod
 
         DrawBounds(g2d);
 
-
     }
 
     private void DrawBounds(Graphics2D g2d) {
@@ -252,7 +225,7 @@ public class KwikiConcordiaToolBar extends JLayeredPane implements GraphPanelMod
     }
 
     /**
-     * 
+     *
      * @param listener
      */
     @Override
@@ -261,7 +234,7 @@ public class KwikiConcordiaToolBar extends JLayeredPane implements GraphPanelMod
     }
 
     /**
-     * 
+     *
      * @param listener
      */
     @Override
@@ -270,15 +243,15 @@ public class KwikiConcordiaToolBar extends JLayeredPane implements GraphPanelMod
     }
 
     /**
-     * 
+     *
      */
     @Override
-    public void switchToPanMode () {
+    public void switchToPanMode() {
         panToggle.doClick();
     }
 
     /**
-     * 
+     *
      * @param currentGraphAxesSetup
      */
     @Override

--- a/src/main/java/org/earthtime/UPb_Redux/dateInterpretation/kwiki/KwikiPDFToolBar.java
+++ b/src/main/java/org/earthtime/UPb_Redux/dateInterpretation/kwiki/KwikiPDFToolBar.java
@@ -21,11 +21,13 @@ package org.earthtime.UPb_Redux.dateInterpretation.kwiki;
 import java.awt.Color;
 import java.awt.Graphics;
 import java.awt.Graphics2D;
-import java.awt.Insets;
 import java.awt.RenderingHints;
 import java.awt.event.ActionEvent;
+import java.util.Collections;
 import java.util.Enumeration;
 import java.util.Map;
+import java.util.SortedSet;
+import java.util.TreeSet;
 import java.util.Vector;
 import javax.swing.ButtonGroup;
 import javax.swing.Icon;
@@ -33,10 +35,10 @@ import javax.swing.JButton;
 import javax.swing.JLayeredPane;
 import javax.swing.JRadioButton;
 import javax.swing.JSlider;
+import javax.swing.JTabbedPane;
 import javax.swing.JTextField;
 import javax.swing.event.ChangeEvent;
 import javax.swing.event.ChangeListener;
-import org.earthtime.UPb_Redux.ReduxConstants;
 import org.earthtime.UPb_Redux.dateInterpretation.DateProbabilityDensityPanel;
 import org.earthtime.UPb_Redux.dateInterpretation.SampleTreeI;
 import org.earthtime.UPb_Redux.dateInterpretation.concordia.AliquotDetailsDisplayInterface;
@@ -46,6 +48,7 @@ import org.earthtime.UPb_Redux.dateInterpretation.graphPersistence.GraphAxesSetu
 import org.earthtime.UPb_Redux.dialogs.sampleManagers.sampleDateInterpretationManagers.SampleDateInterpretationsUtilities;
 import org.earthtime.beans.ET_JButton;
 import org.earthtime.fractions.ETFractionInterface;
+import org.earthtime.reportViews.TabbedReportViews;
 import org.earthtime.samples.SampleInterface;
 
 /**
@@ -75,6 +78,8 @@ public class KwikiPDFToolBar extends JLayeredPane implements GraphPanelModeChang
     private final JButton linkedUnlinkedDiscordance;
     private boolean doLinkDiscordances;
     private final SampleTreeI dateTreeByAliquot;
+    private JTabbedPane reportTableTabbedPane;
+    private final JButton clearFilters;
 
     /**
      * Creates a new instance of KwikiConcordiaToolBar
@@ -85,9 +90,10 @@ public class KwikiPDFToolBar extends JLayeredPane implements GraphPanelModeChang
      * @param aConcordiaGraphPanel
      * @param sample the value of sample
      * @param dateTreeByAliquot
+     * @param reportTableTabbedPane
      */
     public KwikiPDFToolBar(
-            int x, int y, JLayeredPane aPDFGraphPanel, JLayeredPane aConcordiaGraphPanel, SampleInterface sample, SampleTreeI dateTreeByAliquot) {
+            int x, int y, JLayeredPane aPDFGraphPanel, JLayeredPane aConcordiaGraphPanel, SampleInterface sample, SampleTreeI dateTreeByAliquot, JTabbedPane reportTableTabbedPane) {
 
         super();
 
@@ -95,7 +101,7 @@ public class KwikiPDFToolBar extends JLayeredPane implements GraphPanelModeChang
 
         setBackground(Color.white);
 
-        setBounds(x, y, aPDFGraphPanel.getWidth() + 7, 56);
+        setBounds(x, y, 700, 56);
 
         this.probabilityPanel = aPDFGraphPanel;
         this.concordiaGraphPanel = aConcordiaGraphPanel;
@@ -103,6 +109,9 @@ public class KwikiPDFToolBar extends JLayeredPane implements GraphPanelModeChang
         this.sample = sample;
 
         this.dateTreeByAliquot = dateTreeByAliquot;
+
+        this.reportTableTabbedPane = reportTableTabbedPane;
+
         probabilityChartOptions = sample.getSampleDateInterpretationGUISettings().getProbabilityChartOptions();
 
         doLinkDiscordances = true;
@@ -122,7 +131,10 @@ public class KwikiPDFToolBar extends JLayeredPane implements GraphPanelModeChang
         negativePctDiscordance_slider.setAutoscrolls(true);
         negativePctDiscordance_slider.setValue(Integer.parseInt(probabilityChartOptions.get("negativePerCentDiscordanceSliderValue")));
         negativePctDiscordance_slider.setName("negativePerCentDiscordanceSliderValue");
-        negativePctDiscordance_slider.setBounds(105, 1, 175, 38);
+        negativePctDiscordance_slider.setBounds(110, 1, 175, 38);
+        negativePctDiscordance_slider.setOpaque(true);
+        negativePctDiscordance_slider.setBackground(Color.white);
+
         negativePctDiscordance_slider.addChangeListener(new SliderChangeListener());
         add(negativePctDiscordance_slider);
 
@@ -134,7 +146,7 @@ public class KwikiPDFToolBar extends JLayeredPane implements GraphPanelModeChang
         negativePctDiscordance_text.setAlignmentX(0.0F);
         negativePctDiscordance_text.setAlignmentY(0.0F);
         negativePctDiscordance_text.setBorder(null);
-        negativePctDiscordance_text.setBounds(105, 38, 175, 17);
+        negativePctDiscordance_text.setBounds(110, 38, 175, 17);
         add(negativePctDiscordance_text);
 
         linkedUnlinkedDiscordance = new JButton();
@@ -152,7 +164,10 @@ public class KwikiPDFToolBar extends JLayeredPane implements GraphPanelModeChang
         linkedUnlinkedDiscordance.setOpaque(true);
         linkedUnlinkedDiscordance.setPressedIcon(new javax.swing.ImageIcon(getClass().getResource("/org/earthtime/images/linked.png")));
         linkedUnlinkedDiscordance.setVerticalTextPosition(javax.swing.SwingConstants.BOTTOM);
-        linkedUnlinkedDiscordance.setBounds(278, 5, 20, 20);
+        linkedUnlinkedDiscordance.setBounds(285, 5, 20, 20);
+        linkedUnlinkedDiscordance.setOpaque(true);
+        linkedUnlinkedDiscordance.setBackground(Color.white);
+
         linkedUnlinkedDiscordance.addActionListener((java.awt.event.ActionEvent evt) -> {
             linkedUnlinkedDiscordanceActionPerformed(evt);
         });
@@ -170,7 +185,10 @@ public class KwikiPDFToolBar extends JLayeredPane implements GraphPanelModeChang
         positivePctDiscordance_slider.setAutoscrolls(true);
         positivePctDiscordance_slider.setValue(Integer.parseInt(probabilityChartOptions.get("positivePerCentDiscordanceSliderValue")));
         positivePctDiscordance_slider.setName("positivePerCentDiscordanceSliderValue");
-        positivePctDiscordance_slider.setBounds(295, 1, 175, 38);
+        positivePctDiscordance_slider.setBounds(310, 1, 175, 38);
+        positivePctDiscordance_slider.setOpaque(true);
+        positivePctDiscordance_slider.setBackground(Color.white);
+
         positivePctDiscordance_slider.addChangeListener(new SliderChangeListener());
         add(positivePctDiscordance_slider);
 
@@ -182,7 +200,7 @@ public class KwikiPDFToolBar extends JLayeredPane implements GraphPanelModeChang
         positivePctDiscordance_text.setAlignmentX(0.0F);
         positivePctDiscordance_text.setAlignmentY(0.0F);
         positivePctDiscordance_text.setBorder(null);
-        positivePctDiscordance_text.setBounds(295, 38, 175, 17);
+        positivePctDiscordance_text.setBounds(310, 38, 175, 17);
         add(positivePctDiscordance_text);
 
         percentUncertainty_slider = new javax.swing.JSlider();
@@ -196,7 +214,10 @@ public class KwikiPDFToolBar extends JLayeredPane implements GraphPanelModeChang
         percentUncertainty_slider.setSnapToTicks(true);
         percentUncertainty_slider.setAutoscrolls(true);
         percentUncertainty_slider.setName("uncertaintyPerCentSliderValue");
-        percentUncertainty_slider.setBounds(460, 1, 175, 38);
+        percentUncertainty_slider.setBounds(490, 1, 175, 38);
+        percentUncertainty_slider.setOpaque(true);
+        percentUncertainty_slider.setBackground(Color.white);
+
         percentUncertainty_slider.addChangeListener(new SliderChangeListener());
         add(percentUncertainty_slider);
 
@@ -208,8 +229,27 @@ public class KwikiPDFToolBar extends JLayeredPane implements GraphPanelModeChang
         pctUncertainty_text.setAlignmentX(0.0F);
         pctUncertainty_text.setAlignmentY(0.0F);
         pctUncertainty_text.setBorder(null);
-        pctUncertainty_text.setBounds(460, 38, 175, 17);
+        pctUncertainty_text.setBounds(490, 38, 175, 17);
         add(pctUncertainty_text);
+
+        clearFilters = new ET_JButton("Clear");
+        clearFilters.setBounds(278, 37, 39, 16);
+
+        clearFilters.addActionListener((ActionEvent arg0) -> {
+            negativePctDiscordance_slider.setValue(-100);
+            positivePctDiscordance_slider.setValue(100);
+            percentUncertainty_slider.setValue(100);
+
+            performFilteringPerSliders(true);
+
+            try {
+                ((TabbedReportViews) reportTableTabbedPane).refreshTabs();
+            } catch (Exception noTabs) {
+            }
+        });
+
+        add(clearFilters, javax.swing.JLayeredPane.DEFAULT_LAYER);
+        this.setComponentZOrder(clearFilters, 0);
 
         try {
             int uncertaintyPerCentSliderValue = Integer.parseInt(probabilityChartOptions.get("uncertaintyPerCentSliderValue"));
@@ -242,10 +282,10 @@ public class KwikiPDFToolBar extends JLayeredPane implements GraphPanelModeChang
             jrb.addActionListener((ActionEvent arg0) -> {
                 // oct 2014 handle new Pbc corrections
                 String chosenDateName = jrb.getName();
-                
+
                 ((DateProbabilityDensityPanel) probabilityPanel).setChosenDateName(chosenDateName);
                 probabilityChartOptions.put("chosenDateName", chosenDateName);
-                performFilteringPerSliders();
+                performFilteringPerSliders(false);
                 ((DateProbabilityDensityPanel) probabilityPanel).prepareAndPaintPanel();
             });
             if (((DateProbabilityDensityPanel) probabilityPanel).getChosenDateName().replace("r", "").startsWith(jrb.getName().replace("r", ""))) {
@@ -289,7 +329,13 @@ public class KwikiPDFToolBar extends JLayeredPane implements GraphPanelModeChang
 
                 probabilityChartOptions.put(slider.getName(), Integer.toString(slider.getValue()));
 
-                performFilteringPerSliders();
+                performFilteringPerSliders(false);
+
+                // oct 2016
+                try {
+                    ((TabbedReportViews) reportTableTabbedPane).refreshTabs();
+                } catch (Exception noTabs) {
+                }
 
                 wasChanging = false;
             }
@@ -332,14 +378,36 @@ public class KwikiPDFToolBar extends JLayeredPane implements GraphPanelModeChang
         }
     }
 
-    public void performFilteringPerSliders() {
+    /**
+     *
+     * @param clearFiltering the value of clearFiltering
+     */
+    public void performFilteringPerSliders(boolean clearFiltering) {
 
-        Vector<ETFractionInterface> filteredFractions = SampleDateInterpretationsUtilities.filterActiveUPbFractions(//
-                sample.getUpbFractionsUnknown(),//
-                ((DateProbabilityDensityPanel) probabilityPanel).getChosenDateName(),//
-                positivePctDiscordance_slider.getValue(), //
-                negativePctDiscordance_slider.getValue(), //
-                percentUncertainty_slider.getValue());
+        Vector<ETFractionInterface> filteredFractions;
+        if (clearFiltering) {
+            filteredFractions = sample.getUpbFractionsUnknown();
+        } else {
+            filteredFractions = SampleDateInterpretationsUtilities.filterActiveUPbFractions(//
+                    sample.getUpbFractionsUnknown(),//
+                    ((DateProbabilityDensityPanel) probabilityPanel).getChosenDateName(),//
+                    positivePctDiscordance_slider.getValue(), //
+                    negativePctDiscordance_slider.getValue(), //
+                    percentUncertainty_slider.getValue());
+        }
+
+        // oct 2016 collect filtered fractions (those that still count) so that report table can show filtered out
+        SortedSet<String> filteredFractionIDs = Collections.synchronizedSortedSet(new TreeSet<>());
+        for (int i = 0; i < filteredFractions.size(); i++) {
+            filteredFractionIDs.add(filteredFractions.get(i).getFractionID());
+        }
+        //need to also include reference material as all filtered in for report table
+        Vector<ETFractionInterface> filteredRefMats = sample.getUpbFractionsReferenceMaterial();
+        for (int i = 0; i < filteredRefMats.size(); i++) {
+            filteredFractionIDs.add(filteredRefMats.get(i).getFractionID());
+        }
+
+        sample.setFilteredFractionIDs(filteredFractionIDs);
 
         ((AliquotDetailsDisplayInterface) concordiaGraphPanel).//
                 setFilteredFractions(filteredFractions);
@@ -364,8 +432,10 @@ public class KwikiPDFToolBar extends JLayeredPane implements GraphPanelModeChang
         date206_238_radioButton.setFont(new java.awt.Font("Arial", 1, 10));
         date206_238_radioButton.setText("206/238");
         date206_238_radioButton.setName("age206_238r");
-        date206_238_radioButton.setBounds(40, 1, 75, 17);
+        date206_238_radioButton.setBounds(40, 1, 70, 17);
         date206_238_radioButton.setSelected(true);
+        date206_238_radioButton.setOpaque(true);
+        date206_238_radioButton.setBackground(Color.white);
         add(date206_238_radioButton);
 
         date207_206_radioButton = new JRadioButton("207/206");
@@ -373,7 +443,9 @@ public class KwikiPDFToolBar extends JLayeredPane implements GraphPanelModeChang
         date207_206_radioButton.setFont(new java.awt.Font("Arial", 1, 10));
         date207_206_radioButton.setText("207/206");
         date207_206_radioButton.setName("age207_206r");
-        date207_206_radioButton.setBounds(40, 19, 75, 17);
+        date207_206_radioButton.setBounds(40, 19, 70, 17);
+        date207_206_radioButton.setOpaque(true);
+        date207_206_radioButton.setBackground(Color.white);
         add(date207_206_radioButton);
 
         dateBest_radioButton = new JRadioButton("best");
@@ -381,7 +453,10 @@ public class KwikiPDFToolBar extends JLayeredPane implements GraphPanelModeChang
         dateBest_radioButton.setFont(new java.awt.Font("Arial", 1, 10));
         dateBest_radioButton.setText("best");
         dateBest_radioButton.setName("bestAge");
-        dateBest_radioButton.setBounds(40, 37, 75, 17);
+        dateBest_radioButton.setOpaque(true);
+        dateBest_radioButton.setBackground(Color.white);
+        dateBest_radioButton.setBounds(40, 37, 70, 17);
+
         add(dateBest_radioButton);
 
         // choose date
@@ -402,11 +477,7 @@ public class KwikiPDFToolBar extends JLayeredPane implements GraphPanelModeChang
 
     private void SetupZoomToggleButtons() {
         zoomInProbability_button = new ET_JButton("+");
-        zoomInProbability_button.setOpaque(false);
-        zoomInProbability_button.setForeground(Color.black);
-        zoomInProbability_button.setFont(ReduxConstants.sansSerif_12_Bold);
         zoomInProbability_button.setBounds(1, 1, 35, 17);
-        zoomInProbability_button.setMargin(new Insets(0, 0, 0, 0));
 
         zoomInProbability_button.addActionListener((ActionEvent arg0) -> {
             // zoom
@@ -416,16 +487,11 @@ public class KwikiPDFToolBar extends JLayeredPane implements GraphPanelModeChang
         add(zoomInProbability_button, javax.swing.JLayeredPane.DEFAULT_LAYER);
 
         zoomOutProbability_button = new ET_JButton("-");
-        zoomOutProbability_button.setOpaque(false);
-        zoomOutProbability_button.setForeground(Color.black);
-        zoomOutProbability_button.setFont(ReduxConstants.sansSerif_12_Bold);
         zoomOutProbability_button.setBounds(1, 19, 35, 17);
-        zoomOutProbability_button.setMargin(new Insets(0, 0, 0, 0));
 
         zoomOutProbability_button.addActionListener((ActionEvent arg0) -> {
             // zoom
             double rangeX = ((DateProbabilityDensityPanel) probabilityPanel).getRangeX_Display();
-            //System.out.println( "RANGE OUT = " + rangeX + "   offset = " + ((DateProbabilityDensityPanel) probabilityPanel).getDisplayOffsetX());
 
             double saveMinx = ((DateProbabilityDensityPanel) probabilityPanel).getMinX();
             double proposedMinX = saveMinx - rangeX / 2.0;
@@ -457,11 +523,7 @@ public class KwikiPDFToolBar extends JLayeredPane implements GraphPanelModeChang
         add(zoomOutProbability_button, javax.swing.JLayeredPane.DEFAULT_LAYER);
 
         restoreZoom = new ET_JButton("R");
-        restoreZoom.setOpaque(false);
-        restoreZoom.setForeground(Color.black);
-        restoreZoom.setFont(ReduxConstants.sansSerif_12_Bold);
         restoreZoom.setBounds(1, 37, 35, 17);
-        restoreZoom.setMargin(new Insets(0, 0, 0, 0));
 
         restoreZoom.addActionListener((ActionEvent arg0) -> {
             ((PlottingDetailsDisplayInterface) probabilityPanel).refreshPanel(true, false);

--- a/src/main/java/org/earthtime/UPb_Redux/dialogs/graphManagers/ConcordiaOptionsDialog.form
+++ b/src/main/java/org/earthtime/UPb_Redux/dialogs/graphManagers/ConcordiaOptionsDialog.form
@@ -375,10 +375,10 @@
         <DimensionLayout dim="1">
           <Group type="103" groupAlignment="0" attributes="0">
               <Group type="103" alignment="0" groupAlignment="3" attributes="0">
-                  <Component id="save_button" alignment="3" min="-2" pref="28" max="-2" attributes="0"/>
-                  <Component id="close_button" alignment="3" min="-2" pref="28" max="-2" attributes="0"/>
-                  <Component id="restoreDefaults_button" alignment="3" min="-2" pref="28" max="-2" attributes="0"/>
-                  <Component id="revert_button" alignment="3" min="-2" pref="28" max="-2" attributes="0"/>
+                  <Component id="save_button" alignment="3" min="-2" pref="25" max="-2" attributes="0"/>
+                  <Component id="close_button" alignment="3" min="-2" pref="25" max="-2" attributes="0"/>
+                  <Component id="restoreDefaults_button" alignment="3" min="-2" pref="25" max="-2" attributes="0"/>
+                  <Component id="revert_button" alignment="3" min="-2" pref="25" max="-2" attributes="0"/>
               </Group>
           </Group>
         </DimensionLayout>
@@ -400,6 +400,9 @@
           <Events>
             <EventHandler event="actionPerformed" listener="java.awt.event.ActionListener" parameters="java.awt.event.ActionEvent" handler="close_buttonActionPerformed"/>
           </Events>
+          <AuxValues>
+            <AuxValue name="JavaCodeGenerator_CreateCodeCustom" type="java.lang.String" value="new ET_JButton()"/>
+          </AuxValues>
         </Component>
         <Component class="javax.swing.JButton" name="restoreDefaults_button">
           <Properties>
@@ -417,6 +420,9 @@
           <Events>
             <EventHandler event="actionPerformed" listener="java.awt.event.ActionListener" parameters="java.awt.event.ActionEvent" handler="restoreDefaults_buttonActionPerformed"/>
           </Events>
+          <AuxValues>
+            <AuxValue name="JavaCodeGenerator_CreateCodeCustom" type="java.lang.String" value="new ET_JButton()"/>
+          </AuxValues>
         </Component>
         <Component class="javax.swing.JButton" name="save_button">
           <Properties>
@@ -434,6 +440,9 @@
           <Events>
             <EventHandler event="actionPerformed" listener="java.awt.event.ActionListener" parameters="java.awt.event.ActionEvent" handler="save_buttonActionPerformed"/>
           </Events>
+          <AuxValues>
+            <AuxValue name="JavaCodeGenerator_CreateCodeCustom" type="java.lang.String" value="new ET_JButton()"/>
+          </AuxValues>
         </Component>
         <Component class="javax.swing.JButton" name="revert_button">
           <Properties>
@@ -451,6 +460,9 @@
           <Events>
             <EventHandler event="actionPerformed" listener="java.awt.event.ActionListener" parameters="java.awt.event.ActionEvent" handler="revert_buttonActionPerformed"/>
           </Events>
+          <AuxValues>
+            <AuxValue name="JavaCodeGenerator_CreateCodeCustom" type="java.lang.String" value="new ET_JButton()"/>
+          </AuxValues>
         </Component>
       </SubComponents>
     </Container>

--- a/src/main/java/org/earthtime/UPb_Redux/dialogs/graphManagers/ConcordiaOptionsDialog.java
+++ b/src/main/java/org/earthtime/UPb_Redux/dialogs/graphManagers/ConcordiaOptionsDialog.java
@@ -29,6 +29,7 @@ import javax.swing.SpinnerModel;
 import javax.swing.SpinnerNumberModel;
 import org.earthtime.UPb_Redux.listeners.ColorChooserListener;
 import org.earthtime.UPb_Redux.user.SampleDateInterpretationGUIOptions;
+import org.earthtime.beans.ET_JButton;
 import org.earthtime.dialogs.DialogEditor;
 
 /**
@@ -382,10 +383,10 @@ public class ConcordiaOptionsDialog extends DialogEditor {
         concordiaTickShape_buttonGroup = new javax.swing.ButtonGroup();
         interceptErrorLineStyle_btnGroup = new javax.swing.ButtonGroup();
         buttonsPanel = new javax.swing.JPanel();
-        close_button = new javax.swing.JButton();
-        restoreDefaults_button = new javax.swing.JButton();
-        save_button = new javax.swing.JButton();
-        revert_button = new javax.swing.JButton();
+        close_button = new ET_JButton();
+        restoreDefaults_button = new ET_JButton();
+        save_button = new ET_JButton();
+        revert_button = new ET_JButton();
         jLabel19 = new javax.swing.JLabel();
         jLabel15 = new javax.swing.JLabel();
         jLabel3 = new javax.swing.JLabel();
@@ -508,10 +509,10 @@ public class ConcordiaOptionsDialog extends DialogEditor {
         buttonsPanelLayout.setVerticalGroup(
             buttonsPanelLayout.createParallelGroup(org.jdesktop.layout.GroupLayout.LEADING)
             .add(buttonsPanelLayout.createParallelGroup(org.jdesktop.layout.GroupLayout.BASELINE)
-                .add(save_button, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE, 28, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE)
-                .add(close_button, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE, 28, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE)
-                .add(restoreDefaults_button, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE, 28, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE)
-                .add(revert_button, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE, 28, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE))
+                .add(save_button, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE, 25, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE)
+                .add(close_button, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE, 25, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE)
+                .add(restoreDefaults_button, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE, 25, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE)
+                .add(revert_button, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE, 25, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE))
         );
 
         jLabel19.setFont(new java.awt.Font("Lucida Grande", 1, 16)); // NOI18N

--- a/src/main/java/org/earthtime/UPb_Redux/dialogs/sampleManagers/sampleDateInterpretationManagers/SampleDateInterpretationSubscribeInterface.java
+++ b/src/main/java/org/earthtime/UPb_Redux/dialogs/sampleManagers/sampleDateInterpretationManagers/SampleDateInterpretationSubscribeInterface.java
@@ -25,32 +25,36 @@ import org.earthtime.fractions.ETFractionInterface;
  * @author James F. Bowring
  */
 public interface SampleDateInterpretationSubscribeInterface {
-    
+
     /**
      *
      */
     public void publishClosingOfSampleDateInterpretation();
-    
+
     /**
      *
      */
     public void updateReportTable();
-    
-        /**
+
+    /**
+     *
+     */
+    public void refreshReportTableData();
+
+    /**
      * opens a modal editor for the <code>Fraction</code> indicated by argument
      * <code>fraction</code> and opened to the editing tab indicated by argument
      * <code>selectedTab</code>. <code>selectedTab</code> is valid only if it
      * contains a number between zero and seven inclusive.
      *
-     * @pre     the <code>Fraction</code> corresponding to <code>fraction</code>
-     * exists in this <code>Sample</code> and <code>selectedTab</code>
-     * is a valid tab number
-     * @post    an editor for the specified <code>Fraction</code> is opened to
-     * the specified tab
-     * @param   fraction    the <code>Fraction</code> to be edited
-     * @param   selectedTab the tab to open the editor to
+     * @pre the <code>Fraction</code> corresponding to <code>fraction</code>
+     * exists in this <code>Sample</code> and <code>selectedTab</code> is a
+     * valid tab number
+     * @post an editor for the specified <code>Fraction</code> is opened to the
+     * specified tab
+     * @param fraction the <code>Fraction</code> to be edited
+     * @param selectedTab the tab to open the editor to
      */
     void editFraction(ETFractionInterface fraction, int selectedTab);
 
-    
 }

--- a/src/main/java/org/earthtime/UPb_Redux/dialogs/sampleManagers/sampleDateInterpretationManagers/SampleDateInterpretationsManager.form
+++ b/src/main/java/org/earthtime/UPb_Redux/dialogs/sampleManagers/sampleDateInterpretationManagers/SampleDateInterpretationsManager.form
@@ -1445,7 +1445,7 @@
                       </Properties>
                       <Constraints>
                         <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.DesignAbsoluteLayout" value="org.netbeans.modules.form.compat2.layouts.DesignAbsoluteLayout$AbsoluteConstraintsDescription">
-                          <AbsoluteConstraints x="568" y="45" width="160" height="15"/>
+                          <AbsoluteConstraints x="586" y="45" width="130" height="15"/>
                         </Constraint>
                       </Constraints>
                     </Component>
@@ -1467,7 +1467,7 @@
                       </Properties>
                       <Constraints>
                         <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.DesignAbsoluteLayout" value="org.netbeans.modules.form.compat2.layouts.DesignAbsoluteLayout$AbsoluteConstraintsDescription">
-                          <AbsoluteConstraints x="347" y="45" width="160" height="15"/>
+                          <AbsoluteConstraints x="365" y="45" width="130" height="15"/>
                         </Constraint>
                       </Constraints>
                     </Component>
@@ -1750,6 +1750,38 @@
                       <Constraints>
                         <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.DesignAbsoluteLayout" value="org.netbeans.modules.form.compat2.layouts.DesignAbsoluteLayout$AbsoluteConstraintsDescription">
                           <AbsoluteConstraints x="250" y="33" width="80" height="30"/>
+                        </Constraint>
+                      </Constraints>
+                    </Component>
+                    <Component class="javax.swing.JButton" name="clearFilters_button">
+                      <Properties>
+                        <Property name="background" type="java.awt.Color" editor="org.netbeans.beaninfo.editors.ColorEditor">
+                          <Color blue="ff" green="ff" red="ff" type="rgb"/>
+                        </Property>
+                        <Property name="font" type="java.awt.Font" editor="org.netbeans.beaninfo.editors.FontEditor">
+                          <Font name="Helvetica" size="10" style="1"/>
+                        </Property>
+                        <Property name="text" type="java.lang.String" value="Clear Filters"/>
+                        <Property name="border" type="javax.swing.border.Border" editor="org.netbeans.modules.form.editors2.BorderEditor">
+                          <Border info="org.netbeans.modules.form.compat2.border.LineBorderInfo">
+                            <LineBorder/>
+                          </Border>
+                        </Property>
+                        <Property name="contentAreaFilled" type="boolean" value="false"/>
+                        <Property name="margin" type="java.awt.Insets" editor="org.netbeans.beaninfo.editors.InsetsEditor">
+                          <Insets value="[0, 0, 0, 0]"/>
+                        </Property>
+                        <Property name="opaque" type="boolean" value="true"/>
+                      </Properties>
+                      <Events>
+                        <EventHandler event="actionPerformed" listener="java.awt.event.ActionListener" parameters="java.awt.event.ActionEvent" handler="clearFilters_buttonActionPerformed"/>
+                      </Events>
+                      <AuxValues>
+                        <AuxValue name="JavaCodeGenerator_CreateCodeCustom" type="java.lang.String" value=" new ET_JButton();"/>
+                      </AuxValues>
+                      <Constraints>
+                        <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.DesignAbsoluteLayout" value="org.netbeans.modules.form.compat2.layouts.DesignAbsoluteLayout$AbsoluteConstraintsDescription">
+                          <AbsoluteConstraints x="505" y="45" width="75" height="20"/>
                         </Constraint>
                       </Constraints>
                     </Component>

--- a/src/main/java/org/earthtime/UPb_Redux/dialogs/sampleManagers/sampleDateInterpretationManagers/SampleDateInterpretationsManager.java
+++ b/src/main/java/org/earthtime/UPb_Redux/dialogs/sampleManagers/sampleDateInterpretationManagers/SampleDateInterpretationsManager.java
@@ -28,9 +28,12 @@ import java.io.File;
 import java.io.IOException;
 import java.net.MalformedURLException;
 import java.text.DecimalFormat;
+import java.util.Collections;
 import java.util.Enumeration;
 import java.util.Iterator;
 import java.util.Map;
+import java.util.SortedSet;
+import java.util.TreeSet;
 import java.util.Vector;
 import javax.swing.Icon;
 import javax.swing.JCheckBoxMenuItem;
@@ -214,8 +217,8 @@ public class SampleDateInterpretationsManager extends DialogEditor
         dateTreeByAliquot_ScrollPane.setViewportView((Component) dateTreeByAliquot);
         if (!doReScale) {
             dateTreeByAliquot.expandToHistory(expansionHistory);
-            ((JTree)dateTreeByAliquot).setSelectionRow(selRow);
-            ((JTree)dateTreeByAliquot).scrollRowToVisible(selRow);
+            ((JTree) dateTreeByAliquot).setSelectionRow(selRow);
+            ((JTree) dateTreeByAliquot).scrollRowToVisible(selRow);
 //            dateTreeByAliquot.mousePressed(new MouseEvent((Component)dateTreeByAliquot, 0, System.currentTimeMillis(), MouseEvent.BUTTON1, selRowX, selRowY, 1, false));
 //            ((PlottingDetailsDisplayInterface)concordiaGraphPanel).refreshPanel(true, false);
         }
@@ -710,12 +713,24 @@ public class SampleDateInterpretationsManager extends DialogEditor
     public void performFilteringPerSliders() {
         Vector<ETFractionInterface> filteredFractions = filterActiveUPbFractions(sample.getUpbFractionsUnknown());
 
+        // oct 2016 collect filtered fractions (those that still count) so that report table can show filtered out
+        SortedSet<String> filteredFractionIDs = Collections.synchronizedSortedSet(new TreeSet<>());
+        for (int i = 0; i < filteredFractions.size(); i++) {
+            filteredFractionIDs.add(filteredFractions.get(i).getFractionID());
+        }
+        //need to also include reference material as all filtered in for report table
+        Vector<ETFractionInterface> filteredRefMats = sample.getUpbFractionsReferenceMaterial();
+        for (int i = 0; i < filteredRefMats.size(); i++) {
+            filteredFractionIDs.add(filteredRefMats.get(i).getFractionID());
+        }
+
+        sample.setFilteredFractionIDs(filteredFractionIDs);
+
         ((AliquotDetailsDisplayInterface) concordiaGraphPanel).//
                 setFilteredFractions(filteredFractions);
 
         ((DateProbabilityDensityPanel) probabilityPanel).//
                 setSelectedFractions(filteredFractions);
-//                probabilityChartOptions.put(slider.getName(), Integer.toString(slider.getValue()));
 
         // fire off date model to filter its deselected fractions
         try {
@@ -2553,8 +2568,7 @@ private void lockUnlockHistogramBinsMouseEntered (java.awt.event.MouseEvent evt)
         } else if (nodeInfo instanceof ValueModel) { // sample date model *****************************
             // get aliquot and retrieve subset of fractions for this sample date
             Object aliquotNodeInfo
-                    = 
-                    ((DefaultMutableTreeNode) ((TreeNode) node).getParent()).getUserObject();
+                    = ((DefaultMutableTreeNode) ((TreeNode) node).getParent()).getUserObject();
 
             if (graphPanels_TabbedPane.getSelectedIndex() == graphPanels_TabbedPane.indexOfTab("Concordia")) {
 

--- a/src/main/java/org/earthtime/UPb_Redux/dialogs/sampleManagers/sampleDateInterpretationManagers/SampleDateInterpretationsManager.java
+++ b/src/main/java/org/earthtime/UPb_Redux/dialogs/sampleManagers/sampleDateInterpretationManagers/SampleDateInterpretationsManager.java
@@ -608,7 +608,7 @@ public class SampleDateInterpretationsManager extends DialogEditor
 
         normedProbabilityLayeredPane.add(probabilityPanel, javax.swing.JLayeredPane.DEFAULT_LAYER);
 
-        performFilteringPerSliders();
+        performFilteringPerSliders(false);
 
     } // initNormedProbabilityPanel
 
@@ -645,7 +645,7 @@ public class SampleDateInterpretationsManager extends DialogEditor
                 // test for linkage
                 updateSlidersStatus(slider);
 
-                performFilteringPerSliders();
+                performFilteringPerSliders(false);
 
 ////                ((DateProbabilityDensityPanel) probabilityPanel).//
 ////                        setSelectedFractions(filterActiveUPbFractions(sample.getUpbFractionsUnknown()));
@@ -682,36 +682,28 @@ public class SampleDateInterpretationsManager extends DialogEditor
 
                 probabilityChartOptions.put(slider.getName(), Integer.toString(slider.getValue()));
 
-                performFilteringPerSliders();
-////                // oct 2014 make choices stick to data table
-////                Vector<ETFractionInterface> filteredFractions = filterActiveUPbFractions(sample.getUpbFractionsUnknown());
-////                // April 2016 do not reject fractions, merely disappear them from plots
-////                // TODO: button that allows filtering to be on
-//////                sample.updateSetOfActiveFractions(filteredFractions);
-//////                // oct 2014 repaint table
-//////                parentFrame.updateReportTable();
-//////                Vector<ETFractionInterface> filteredFractions = filterActiveUPbFractions(((DateProbabilityDensityPanel) probabilityPanel).getSelectedFractions());
-////                
-////                ((AliquotDetailsDisplayInterface) concordiaGraphPanel).//
-////                        setFilteredFractions(filteredFractions);
-////
-////                ((DateProbabilityDensityPanel) probabilityPanel).//
-////                        setSelectedFractions(filteredFractions);
-////                probabilityChartOptions.put(slider.getName(), Integer.toString(slider.getValue()));
-////
-////                // fire off date model to filter its deselected fractions
-////                try {
-////                    dateTreeByAliquot.performLastUserSelectionOfSampleDate();
-////                } catch (Exception selectionError) {
-////                }
-////                ((DateProbabilityDensityPanel) probabilityPanel).prepareAndPaintPanel();
+                performFilteringPerSliders(false);
+
+                // oct 2016
+                parentFrame.refreshReportTableData();
+
                 wasChanging = false;
             }
         }
     }
 
-    public void performFilteringPerSliders() {
-        Vector<ETFractionInterface> filteredFractions = filterActiveUPbFractions(sample.getUpbFractionsUnknown());
+    /**
+     *
+     * @param clearFiltering the value of clearFiltering
+     */
+    public void performFilteringPerSliders(boolean clearFiltering) {
+
+        Vector<ETFractionInterface> filteredFractions;
+        if (clearFiltering) {
+            filteredFractions = sample.getUpbFractionsUnknown();
+        } else {
+            filteredFractions = filterActiveUPbFractions(sample.getUpbFractionsUnknown());
+        }
 
         // oct 2016 collect filtered fractions (those that still count) so that report table can show filtered out
         SortedSet<String> filteredFractionIDs = Collections.synchronizedSortedSet(new TreeSet<>());
@@ -1034,6 +1026,7 @@ public class SampleDateInterpretationsManager extends DialogEditor
         jLabel2 = new javax.swing.JLabel();
         commonLeadCorrectionSelectorPDF_checkbox = new javax.swing.JCheckBox();
         DatePbCorrSchemeA_radio = new javax.swing.JRadioButton();
+        clearFilters_button =  new ET_JButton();
         jPanel1 = new javax.swing.JPanel();
         writeConcordiaPDF_button =  new ET_JButton();
         close_button =  new ET_JButton();
@@ -1657,7 +1650,7 @@ public class SampleDateInterpretationsManager extends DialogEditor
         positivePctDiscordance_text.setAlignmentX(0.0F);
         positivePctDiscordance_text.setAlignmentY(0.0F);
         positivePctDiscordance_text.setBorder(null);
-        probabilityToolPanel.add(positivePctDiscordance_text, new org.netbeans.lib.awtextra.AbsoluteConstraints(568, 45, 160, 15));
+        probabilityToolPanel.add(positivePctDiscordance_text, new org.netbeans.lib.awtextra.AbsoluteConstraints(586, 45, 130, 15));
 
         negativePctDiscordance_text.setBackground(new java.awt.Color(241, 230, 255));
         negativePctDiscordance_text.setFont(new java.awt.Font("Arial", 1, 10)); // NOI18N
@@ -1666,7 +1659,7 @@ public class SampleDateInterpretationsManager extends DialogEditor
         negativePctDiscordance_text.setAlignmentX(0.0F);
         negativePctDiscordance_text.setAlignmentY(0.0F);
         negativePctDiscordance_text.setBorder(null);
-        probabilityToolPanel.add(negativePctDiscordance_text, new org.netbeans.lib.awtextra.AbsoluteConstraints(347, 45, 160, 15));
+        probabilityToolPanel.add(negativePctDiscordance_text, new org.netbeans.lib.awtextra.AbsoluteConstraints(365, 45, 130, 15));
 
         pctUncertainty_text.setBackground(new java.awt.Color(241, 230, 255));
         pctUncertainty_text.setFont(new java.awt.Font("Arial", 1, 10)); // NOI18N
@@ -1793,6 +1786,20 @@ public class SampleDateInterpretationsManager extends DialogEditor
         DatePbCorrSchemeA_radio.setActionCommand("bestAge");
         DatePbCorrSchemeA_radio.setName("PbcCorr_UPb_Date"); // NOI18N
         probabilityToolPanel.add(DatePbCorrSchemeA_radio, new org.netbeans.lib.awtextra.AbsoluteConstraints(250, 33, 80, 30));
+
+        clearFilters_button.setBackground(new java.awt.Color(255, 255, 255));
+        clearFilters_button.setFont(new java.awt.Font("Helvetica", 1, 10)); // NOI18N
+        clearFilters_button.setText("Clear Filters");
+        clearFilters_button.setBorder(javax.swing.BorderFactory.createLineBorder(new java.awt.Color(0, 0, 0)));
+        clearFilters_button.setContentAreaFilled(false);
+        clearFilters_button.setMargin(new java.awt.Insets(0, 0, 0, 0));
+        clearFilters_button.setOpaque(true);
+        clearFilters_button.addActionListener(new java.awt.event.ActionListener() {
+            public void actionPerformed(java.awt.event.ActionEvent evt) {
+                clearFilters_buttonActionPerformed(evt);
+            }
+        });
+        probabilityToolPanel.add(clearFilters_button, new org.netbeans.lib.awtextra.AbsoluteConstraints(505, 45, 75, 20));
 
         normedProbabilityLayeredPane.add(probabilityToolPanel);
         probabilityToolPanel.setBounds(0, 560, 920, 70);
@@ -2200,12 +2207,15 @@ private void zoomInProbability_buttonActionPerformed (java.awt.event.ActionEvent
 }//GEN-LAST:event_zoomInProbability_buttonActionPerformed
 
 private void resetGraphProbability_buttonActionPerformed (java.awt.event.ActionEvent evt) {//GEN-FIRST:event_resetGraphProbability_buttonActionPerformed
-    positivePctDiscordance_slider.setValue(100);
-    negativePctDiscordance_slider.setValue(-100);
-    percentUncertainty_slider.setValue(100);
 
-    ((DateProbabilityDensityPanel) probabilityPanel).//
-            setSelectedFractions(filterActiveUPbFractions(sample.getUpbFractionsUnknown()));
+// oct 2016 removed this behavior and moved it to new button "clear filters"
+
+//    positivePctDiscordance_slider.setValue(100);
+//    negativePctDiscordance_slider.setValue(-100);
+//    percentUncertainty_slider.setValue(100);
+//
+//    ((DateProbabilityDensityPanel) probabilityPanel).//
+//            setSelectedFractions(filterActiveUPbFractions(sample.getUpbFractionsUnknown()));
 
     ((PlottingDetailsDisplayInterface) probabilityPanel).refreshPanel(true, false);
 }//GEN-LAST:event_resetGraphProbability_buttonActionPerformed
@@ -2369,6 +2379,16 @@ private void lockUnlockHistogramBinsMouseEntered (java.awt.event.MouseEvent evt)
         refreshSampleDateInterpretations(false, false);
     }//GEN-LAST:event_sortFractionsDateAsc_menuItemCheckBoxActionPerformed
 
+    private void clearFilters_buttonActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_clearFilters_buttonActionPerformed
+        negativePctDiscordance_slider.setValue(-100);
+        positivePctDiscordance_slider.setValue(100);
+        percentUncertainty_slider.setValue(100);
+
+        performFilteringPerSliders(true);
+
+        parentFrame.refreshReportTableData();
+    }//GEN-LAST:event_clearFilters_buttonActionPerformed
+
     // Variables declaration - do not modify//GEN-BEGIN:variables
     private javax.swing.JRadioButton DatePbCorrSchemeA_radio;
     private javax.swing.JRadioButton ageBest_radio;
@@ -2381,6 +2401,7 @@ private void lockUnlockHistogramBinsMouseEntered (java.awt.event.MouseEvent evt)
     private javax.swing.JLayeredPane any3LayeredPane;
     private javax.swing.JTextField binWidth_text;
     private javax.swing.JMenu choosePDFPeaks_menu;
+    private javax.swing.JButton clearFilters_button;
     private javax.swing.JButton close_button;
     private javax.swing.JCheckBox commonLeadCorrectionSelectorPDF_checkbox;
     private javax.swing.JCheckBox commonLeadCorrectionSelector_checkbox;
@@ -2946,35 +2967,7 @@ private void lockUnlockHistogramBinsMouseEntered (java.awt.event.MouseEvent evt)
     }
 
     private Vector<ETFractionInterface> filterActiveUPbFractions(Vector<ETFractionInterface> fractions) {
-//
-//        Vector<ETFractionInterface> filteredFractions = new Vector<>();
-//
-//        String dateName = ((DateProbabilityDensityPanel) probabilityPanel).getChosenDateName();
-//
-//        for (ETFractionInterface f : fractions) {
-//            boolean doAddFraction = !f.isRejected();
-//            double pctDiscordance = f.getRadiogenicIsotopeDateByName(RadDates.percentDiscordance).getValue().doubleValue();
-//
-//            if (pctDiscordance >= 0.0) {  //
-//                // positive percent discordance
-//                doAddFraction = doAddFraction && (pctDiscordance <= positivePctDiscordance_slider.getValue());
-//            } else {
-//                // negative percent discordance
-//                doAddFraction = doAddFraction && (pctDiscordance >= negativePctDiscordance_slider.getValue());
-//            }
-//
-//            doAddFraction = doAddFraction //
-//                    && f.getRadiogenicIsotopeDateByName(dateName).getOneSigmaPct().doubleValue() //
-//                    <= percentUncertainty_slider.getValue();
-//
-//            //oct 2014
-//            doAddFraction = doAddFraction //
-//                    && f.getRadiogenicIsotopeDateByName(dateName).getOneSigmaPct().doubleValue() != 0.0;
-//
-//            if (doAddFraction) {
-//                filteredFractions.add(f);
-//            }
-//        }
+
         return SampleDateInterpretationsUtilities.filterActiveUPbFractions(//
                 fractions,//
                 ((DateProbabilityDensityPanel) probabilityPanel).getChosenDateName(),//

--- a/src/main/java/org/earthtime/UPb_Redux/samples/Sample.java
+++ b/src/main/java/org/earthtime/UPb_Redux/samples/Sample.java
@@ -25,7 +25,10 @@ import java.io.IOException;
 import java.io.Serializable;
 import java.math.BigDecimal;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Date;
+import java.util.SortedSet;
+import java.util.TreeSet;
 import java.util.Vector;
 import javax.swing.JOptionPane;
 import org.earthtime.Tripoli.sessions.TripoliSession;
@@ -193,6 +196,7 @@ public class Sample implements
     private SampleRegistries sampleRegistry;
     // July 2011
     private TripoliSession tripoliSession;
+    private SortedSet<String> filteredFractionIDs;
 
     /**
      *
@@ -263,6 +267,8 @@ public class Sample implements
         this.archivedInRegistry = false;
 
         this.sampleRegistry = SampleRegistries.SESAR;
+
+        this.filteredFractionIDs = Collections.synchronizedSortedSet(new TreeSet<>());
     }
 
     @Override
@@ -307,7 +313,8 @@ public class Sample implements
         if (!isSampleTypeLegacy()) {
             SampleInterface.registerSampleWithLabData(this);
         } else // dec 2012
-         if (getFractions().size() > 0) {
+        {
+            if (getFractions().size() > 0) {
                 // June 2010 fix for old legacy fractions
                 Vector<ETFractionInterface> convertedF = new Vector<>();
                 for (ETFractionInterface f : getFractions()) {
@@ -359,6 +366,7 @@ public class Sample implements
                     }
                 }
             }
+        }
 
         // June 2010 be sure lab name is updated to labdata labname when used in reduction
         if (isSampleTypeAnalysis() || isSampleTypeLiveWorkflow() || isSampleTypeLegacy()) {
@@ -603,7 +611,7 @@ public class Sample implements
                 aliquotFractionFiles = aliquotFolder.listFiles((File file) -> {
                     // want .xml files and only freshones in live-update, but all of them in auto-update
                     boolean isXML = file.getName().toLowerCase().endsWith(".xml");
-                    
+
                     if (getSampleType().equalsIgnoreCase(SampleTypesEnum.LIVEWORKFLOW.getName())) {
                         return ((file.lastModified() >= (aliquotFolder.lastModified() - 20000l))
                                 && isXML);
@@ -1601,5 +1609,24 @@ public class Sample implements
             isotopeStyle = "UPb";
         }
         return isotopeStyle;
+    }
+
+    /**
+     * @return the filteredFractionIDs
+     */
+    @Override
+    public SortedSet<String> getFilteredFractionIDs() {
+        if (filteredFractionIDs == null) {
+            this.filteredFractionIDs = Collections.synchronizedSortedSet(new TreeSet<>());
+        }
+        return filteredFractionIDs;
+    }
+
+    /**
+     * @param filteredFractionIDs the filteredFractionIDs to set
+     */
+    @Override
+    public void setFilteredFractionIDs(SortedSet<String> filteredFractionIDs) {
+        this.filteredFractionIDs = filteredFractionIDs;
     }
 }

--- a/src/main/java/org/earthtime/UTh_Redux/samples/SampleUTh.java
+++ b/src/main/java/org/earthtime/UTh_Redux/samples/SampleUTh.java
@@ -17,6 +17,7 @@ package org.earthtime.UTh_Redux.samples;
 
 import java.io.File;
 import java.io.Serializable;
+import java.util.SortedSet;
 import java.util.Vector;
 import org.earthtime.UPb_Redux.ReduxConstants;
 import org.earthtime.UPb_Redux.dateInterpretation.graphPersistence.GraphAxesSetup;
@@ -582,6 +583,16 @@ public class SampleUTh extends ETSample implements
             isotopeStyle = "UTh";
         }
         return isotopeStyle;
+    }
+
+    @Override
+    public SortedSet<String> getFilteredFractionIDs() {
+        throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+    }
+
+    @Override
+    public void setFilteredFractionIDs(SortedSet<String> filteredFractionIDs) {
+        throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
     }
 
 }

--- a/src/main/java/org/earthtime/dialogs/ReportSettingsManager.form
+++ b/src/main/java/org/earthtime/dialogs/ReportSettingsManager.form
@@ -85,11 +85,11 @@
               <EmptySpace max="-2" attributes="0"/>
               <Group type="103" groupAlignment="1" attributes="0">
                   <Group type="102" alignment="0" attributes="1">
-                      <Component id="categoryMoveUp_button" min="-2" max="-2" attributes="0"/>
+                      <Component id="categoryMoveUp_button" min="-2" pref="25" max="-2" attributes="0"/>
                       <EmptySpace max="-2" attributes="0"/>
-                      <Component id="categoryMoveDown_button" min="-2" max="-2" attributes="0"/>
+                      <Component id="categoryMoveDown_button" min="-2" pref="25" max="-2" attributes="0"/>
                       <EmptySpace max="-2" attributes="0"/>
-                      <Component id="categoryHideShow_button" min="-2" max="-2" attributes="0"/>
+                      <Component id="categoryHideShow_button" min="-2" pref="25" max="-2" attributes="0"/>
                   </Group>
                   <Group type="102" alignment="1" attributes="0">
                       <Component id="categories_scrollPane" min="-2" pref="120" max="-2" attributes="0"/>
@@ -104,15 +104,15 @@
                       <EmptySpace max="-2" attributes="0"/>
                   </Group>
                   <Group type="102" alignment="0" attributes="1">
-                      <Component id="columnMoveUp_button" min="-2" max="-2" attributes="0"/>
+                      <Component id="columnMoveUp_button" min="-2" pref="25" max="-2" attributes="0"/>
                       <EmptySpace type="unrelated" max="-2" attributes="0"/>
-                      <Component id="columnMoveDown_button" min="-2" max="-2" attributes="0"/>
+                      <Component id="columnMoveDown_button" min="-2" pref="25" max="-2" attributes="0"/>
                       <EmptySpace max="32767" attributes="0"/>
-                      <Component id="columnHideShow_button" min="-2" max="-2" attributes="0"/>
+                      <Component id="columnHideShow_button" min="-2" pref="25" max="-2" attributes="0"/>
                       <EmptySpace min="-2" pref="63" max="-2" attributes="0"/>
-                      <Component id="categoryShowAllColumns_button" min="-2" max="-2" attributes="0"/>
+                      <Component id="categoryShowAllColumns_button" min="-2" pref="25" max="-2" attributes="0"/>
                       <EmptySpace type="unrelated" max="-2" attributes="0"/>
-                      <Component id="categoryHideAllColumns_button" min="-2" max="-2" attributes="0"/>
+                      <Component id="categoryHideAllColumns_button" min="-2" pref="25" max="-2" attributes="0"/>
                       <EmptySpace min="-2" pref="12" max="-2" attributes="0"/>
                   </Group>
               </Group>
@@ -177,8 +177,8 @@
         <DimensionLayout dim="1">
           <Group type="103" groupAlignment="0" attributes="0">
               <Group type="103" alignment="0" groupAlignment="3" attributes="0">
-                  <Component id="apply_button" alignment="3" min="-2" pref="28" max="-2" attributes="0"/>
-                  <Component id="close_button" alignment="3" min="-2" pref="28" max="-2" attributes="0"/>
+                  <Component id="apply_button" alignment="3" min="-2" pref="25" max="-2" attributes="0"/>
+                  <Component id="close_button" alignment="3" min="-2" pref="25" max="-2" attributes="0"/>
               </Group>
           </Group>
         </DimensionLayout>
@@ -200,6 +200,9 @@
           <Events>
             <EventHandler event="actionPerformed" listener="java.awt.event.ActionListener" parameters="java.awt.event.ActionEvent" handler="close_buttonActionPerformed"/>
           </Events>
+          <AuxValues>
+            <AuxValue name="JavaCodeGenerator_CreateCodeCustom" type="java.lang.String" value="new ET_JButton()"/>
+          </AuxValues>
         </Component>
         <Component class="javax.swing.JButton" name="apply_button">
           <Properties>
@@ -217,6 +220,9 @@
           <Events>
             <EventHandler event="actionPerformed" listener="java.awt.event.ActionListener" parameters="java.awt.event.ActionEvent" handler="apply_buttonActionPerformed"/>
           </Events>
+          <AuxValues>
+            <AuxValue name="JavaCodeGenerator_CreateCodeCustom" type="java.lang.String" value="new ET_JButton()"/>
+          </AuxValues>
         </Component>
       </SubComponents>
     </Container>
@@ -240,6 +246,9 @@
       <Events>
         <EventHandler event="actionPerformed" listener="java.awt.event.ActionListener" parameters="java.awt.event.ActionEvent" handler="categoryMoveUp_buttonActionPerformed"/>
       </Events>
+      <AuxValues>
+        <AuxValue name="JavaCodeGenerator_CreateCodeCustom" type="java.lang.String" value="new ET_JButton()"/>
+      </AuxValues>
     </Component>
     <Component class="javax.swing.JButton" name="categoryMoveDown_button">
       <Properties>
@@ -253,6 +262,9 @@
       <Events>
         <EventHandler event="actionPerformed" listener="java.awt.event.ActionListener" parameters="java.awt.event.ActionEvent" handler="categoryMoveDown_buttonActionPerformed"/>
       </Events>
+      <AuxValues>
+        <AuxValue name="JavaCodeGenerator_CreateCodeCustom" type="java.lang.String" value="new ET_JButton()"/>
+      </AuxValues>
     </Component>
     <Component class="javax.swing.JButton" name="categoryHideShow_button">
       <Properties>
@@ -266,6 +278,9 @@
       <Events>
         <EventHandler event="actionPerformed" listener="java.awt.event.ActionListener" parameters="java.awt.event.ActionEvent" handler="categoryHideShow_buttonActionPerformed"/>
       </Events>
+      <AuxValues>
+        <AuxValue name="JavaCodeGenerator_CreateCodeCustom" type="java.lang.String" value="new ET_JButton()"/>
+      </AuxValues>
     </Component>
     <Container class="javax.swing.JScrollPane" name="columns_scrollPane">
       <AuxValues>
@@ -311,6 +326,9 @@
       <Events>
         <EventHandler event="actionPerformed" listener="java.awt.event.ActionListener" parameters="java.awt.event.ActionEvent" handler="columnHideShow_buttonActionPerformed"/>
       </Events>
+      <AuxValues>
+        <AuxValue name="JavaCodeGenerator_CreateCodeCustom" type="java.lang.String" value="new ET_JButton()"/>
+      </AuxValues>
     </Component>
     <Component class="javax.swing.JButton" name="columnMoveDown_button">
       <Properties>
@@ -324,6 +342,9 @@
       <Events>
         <EventHandler event="actionPerformed" listener="java.awt.event.ActionListener" parameters="java.awt.event.ActionEvent" handler="columnMoveDown_buttonActionPerformed"/>
       </Events>
+      <AuxValues>
+        <AuxValue name="JavaCodeGenerator_CreateCodeCustom" type="java.lang.String" value="new ET_JButton()"/>
+      </AuxValues>
     </Component>
     <Component class="javax.swing.JButton" name="columnMoveUp_button">
       <Properties>
@@ -337,6 +358,9 @@
       <Events>
         <EventHandler event="actionPerformed" listener="java.awt.event.ActionListener" parameters="java.awt.event.ActionEvent" handler="columnMoveUp_buttonActionPerformed"/>
       </Events>
+      <AuxValues>
+        <AuxValue name="JavaCodeGenerator_CreateCodeCustom" type="java.lang.String" value="new ET_JButton()"/>
+      </AuxValues>
     </Component>
     <Component class="javax.swing.JLabel" name="jLabel3">
       <Properties>
@@ -550,6 +574,9 @@
       <Events>
         <EventHandler event="actionPerformed" listener="java.awt.event.ActionListener" parameters="java.awt.event.ActionEvent" handler="categoryShowAllColumns_buttonActionPerformed"/>
       </Events>
+      <AuxValues>
+        <AuxValue name="JavaCodeGenerator_CreateCodeCustom" type="java.lang.String" value="new ET_JButton()"/>
+      </AuxValues>
     </Component>
     <Component class="javax.swing.JButton" name="categoryHideAllColumns_button">
       <Properties>
@@ -563,6 +590,9 @@
       <Events>
         <EventHandler event="actionPerformed" listener="java.awt.event.ActionListener" parameters="java.awt.event.ActionEvent" handler="categoryHideAllColumns_buttonActionPerformed"/>
       </Events>
+      <AuxValues>
+        <AuxValue name="JavaCodeGenerator_CreateCodeCustom" type="java.lang.String" value="new ET_JButton()"/>
+      </AuxValues>
     </Component>
   </SubComponents>
 </Form>

--- a/src/main/java/org/earthtime/dialogs/ReportSettingsManager.java
+++ b/src/main/java/org/earthtime/dialogs/ReportSettingsManager.java
@@ -18,7 +18,6 @@
  */
 package org.earthtime.dialogs;
 
-import org.earthtime.dialogs.DialogEditor;
 import java.awt.Component;
 import java.awt.Frame;
 import java.awt.event.ActionEvent;
@@ -37,9 +36,10 @@ import javax.swing.event.ListSelectionEvent;
 import javax.swing.event.ListSelectionListener;
 import org.earthtime.UPb_Redux.reports.ReportCategory;
 import org.earthtime.UPb_Redux.reports.ReportColumn;
+import org.earthtime.beans.ET_JButton;
+import org.earthtime.dataDictionaries.ReportSpecifications;
 import org.earthtime.reportViews.ReportListItemI;
 import org.earthtime.reportViews.ReportPainterI;
-import org.earthtime.dataDictionaries.ReportSpecifications;
 import org.earthtime.reports.ReportCategoryInterface;
 import org.earthtime.reports.ReportColumnInterface;
 import org.earthtime.reports.ReportSettingsInterface;
@@ -351,20 +351,20 @@ public class ReportSettingsManager extends DialogEditor {
         uncertaintyMode = new javax.swing.ButtonGroup();
         valueMode = new javax.swing.ButtonGroup();
         categories_scrollPane = new javax.swing.JScrollPane();
-        categories_list = new javax.swing.JList<ReportListItemI>();
+        categories_list = new javax.swing.JList<>();
         buttonsPanel = new javax.swing.JPanel();
-        close_button = new javax.swing.JButton();
-        apply_button = new javax.swing.JButton();
+        close_button = new ET_JButton();
+        apply_button = new ET_JButton();
         jLabel1 = new javax.swing.JLabel();
-        categoryMoveUp_button = new javax.swing.JButton();
-        categoryMoveDown_button = new javax.swing.JButton();
-        categoryHideShow_button = new javax.swing.JButton();
+        categoryMoveUp_button = new ET_JButton();
+        categoryMoveDown_button = new ET_JButton();
+        categoryHideShow_button = new ET_JButton();
         columns_scrollPane = new javax.swing.JScrollPane();
-        columns_list = new javax.swing.JList<ReportListItemI>();
+        columns_list = new javax.swing.JList<>();
         jLabel2 = new javax.swing.JLabel();
-        columnHideShow_button = new javax.swing.JButton();
-        columnMoveDown_button = new javax.swing.JButton();
-        columnMoveUp_button = new javax.swing.JButton();
+        columnHideShow_button = new ET_JButton();
+        columnMoveDown_button = new ET_JButton();
+        columnMoveUp_button = new ET_JButton();
         jLabel3 = new javax.swing.JLabel();
         jScrollPane2 = new javax.swing.JScrollPane();
         jPanel1 = new javax.swing.JPanel();
@@ -379,9 +379,9 @@ public class ReportSettingsManager extends DialogEditor {
         unctModeArbitrary_rButton = new javax.swing.JRadioButton();
         valueModeSigFig_rButton = new javax.swing.JRadioButton();
         valueModeArbitrary_rButton = new javax.swing.JRadioButton();
-        unitsChooser_ComboBox = new javax.swing.JComboBox<String>();
-        categoryShowAllColumns_button = new javax.swing.JButton();
-        categoryHideAllColumns_button = new javax.swing.JButton();
+        unitsChooser_ComboBox = new javax.swing.JComboBox<>();
+        categoryShowAllColumns_button = new ET_JButton();
+        categoryHideAllColumns_button = new ET_JButton();
 
         setDefaultCloseOperation(javax.swing.WindowConstants.DISPOSE_ON_CLOSE);
         setTitle("Report Settings Manager");
@@ -439,8 +439,8 @@ public class ReportSettingsManager extends DialogEditor {
         buttonsPanelLayout.setVerticalGroup(
             buttonsPanelLayout.createParallelGroup(org.jdesktop.layout.GroupLayout.LEADING)
             .add(buttonsPanelLayout.createParallelGroup(org.jdesktop.layout.GroupLayout.BASELINE)
-                .add(apply_button, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE, 28, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE)
-                .add(close_button, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE, 28, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE))
+                .add(apply_button, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE, 25, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE)
+                .add(close_button, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE, 25, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE))
         );
 
         jLabel1.setFont(new java.awt.Font("Arial", 1, 14)); // NOI18N
@@ -712,11 +712,11 @@ public class ReportSettingsManager extends DialogEditor {
                 .addPreferredGap(org.jdesktop.layout.LayoutStyle.RELATED)
                 .add(layout.createParallelGroup(org.jdesktop.layout.GroupLayout.TRAILING)
                     .add(org.jdesktop.layout.GroupLayout.LEADING, layout.createSequentialGroup()
-                        .add(categoryMoveUp_button)
+                        .add(categoryMoveUp_button, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE, 25, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE)
                         .addPreferredGap(org.jdesktop.layout.LayoutStyle.RELATED)
-                        .add(categoryMoveDown_button)
+                        .add(categoryMoveDown_button, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE, 25, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE)
                         .addPreferredGap(org.jdesktop.layout.LayoutStyle.RELATED)
-                        .add(categoryHideShow_button))
+                        .add(categoryHideShow_button, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE, 25, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE))
                     .add(layout.createSequentialGroup()
                         .add(categories_scrollPane, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE, 120, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE)
                         .addPreferredGap(org.jdesktop.layout.LayoutStyle.RELATED)
@@ -727,15 +727,15 @@ public class ReportSettingsManager extends DialogEditor {
                         .add(columns_scrollPane, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE, 277, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE)
                         .addPreferredGap(org.jdesktop.layout.LayoutStyle.RELATED))
                     .add(layout.createSequentialGroup()
-                        .add(columnMoveUp_button)
+                        .add(columnMoveUp_button, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE, 25, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE)
                         .addPreferredGap(org.jdesktop.layout.LayoutStyle.UNRELATED)
-                        .add(columnMoveDown_button)
+                        .add(columnMoveDown_button, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE, 25, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE)
                         .addPreferredGap(org.jdesktop.layout.LayoutStyle.RELATED, org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
-                        .add(columnHideShow_button)
+                        .add(columnHideShow_button, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE, 25, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE)
                         .add(63, 63, 63)
-                        .add(categoryShowAllColumns_button)
+                        .add(categoryShowAllColumns_button, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE, 25, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE)
                         .addPreferredGap(org.jdesktop.layout.LayoutStyle.UNRELATED)
-                        .add(categoryHideAllColumns_button)
+                        .add(categoryHideAllColumns_button, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE, 25, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE)
                         .add(12, 12, 12)))
                 .add(jLabel3)
                 .addPreferredGap(org.jdesktop.layout.LayoutStyle.RELATED)

--- a/src/main/java/org/earthtime/projects/ProjectSample.java
+++ b/src/main/java/org/earthtime/projects/ProjectSample.java
@@ -21,6 +21,7 @@ package org.earthtime.projects;
 
 import java.io.File;
 import java.io.Serializable;
+import java.util.SortedSet;
 import java.util.Vector;
 import org.earthtime.UPb_Redux.ReduxConstants;
 import org.earthtime.UPb_Redux.ReduxConstants.ANALYSIS_PURPOSE;
@@ -472,6 +473,16 @@ public class ProjectSample implements//
             isotopeStyle = "UPb";
         }
         return isotopeStyle;
+    }
+
+    @Override
+    public SortedSet<String> getFilteredFractionIDs() {
+        throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+    }
+
+    @Override
+    public void setFilteredFractionIDs(SortedSet<String> filteredFractionIDs) {
+        throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
     }
 
 }

--- a/src/main/java/org/earthtime/reportViews/ReportAliquotFractionsView.java
+++ b/src/main/java/org/earthtime/reportViews/ReportAliquotFractionsView.java
@@ -198,12 +198,7 @@ public class ReportAliquotFractionsView extends JLayeredPane implements ReportUp
 
         if (lastAquiredTableRowObject != null) {
             int bottomPixelCount = lastAquiredTableRowObject.getBottomPixelCount();
-
-            System.out.println("BOTTOM = " + bottomPixelCount);
         }
-//        reportFractionIDsScrollPane.getVerticalScrollBar().setValue(reportFractionIDsScrollPane.getVerticalScrollBar().getMaximum());
-//        reportFractionIDsScrollPane.validate();
-//        repaint();
     }
 
     /**
@@ -303,7 +298,6 @@ public class ReportAliquotFractionsView extends JLayeredPane implements ReportUp
     }
 
     private void reSizeScrollPanes() {
-//        reportBodyScrollPane.setSize(getWidth() - fractionColumnWidth, getHeight() - DATATABLE_TOP_HEIGHT);
         //July 2016 adapted to handle narrow tables per LiveData 
         reportBodyScrollPane.setSize(Math.min(reportWidth - fractionColumnWidth + fractionButtonMargin + 2 * (int) dividerWidth, getWidth() - fractionColumnWidth), getHeight() - DATATABLE_TOP_HEIGHT);
         reportBodyScrollPane.revalidate();
@@ -1095,6 +1089,7 @@ public class ReportAliquotFractionsView extends JLayeredPane implements ReportUp
                     }
 
                     // list out footnotes
+                    g2D.setColor(Color.BLACK);
                     if (!paintType.equalsIgnoreCase("FRACTION")) {
                         drawnHeight += lineHeight * 3;
                         drawnWidth = leftMargin;

--- a/src/main/java/org/earthtime/reportViews/ReportAliquotFractionsView.java
+++ b/src/main/java/org/earthtime/reportViews/ReportAliquotFractionsView.java
@@ -193,12 +193,12 @@ public class ReportAliquotFractionsView extends JLayeredPane implements ReportUp
     }
 
     public void forceVerticalScrollToShowSpecificRow(String lastAcquiredFractionID) {
-        ((ReportPainter)reportBody).setLastAcquiredFractionID(lastAcquiredFractionID);
+        ((ReportPainter) reportBody).setLastAcquiredFractionID(lastAcquiredFractionID);
         repaint();
-        
-        if (lastAquiredTableRowObject != null){
+
+        if (lastAquiredTableRowObject != null) {
             int bottomPixelCount = lastAquiredTableRowObject.getBottomPixelCount();
-            
+
             System.out.println("BOTTOM = " + bottomPixelCount);
         }
 //        reportFractionIDsScrollPane.getVerticalScrollBar().setValue(reportFractionIDsScrollPane.getVerticalScrollBar().getMaximum());
@@ -322,7 +322,8 @@ public class ReportAliquotFractionsView extends JLayeredPane implements ReportUp
         toggleMeasButton.setBounds(1, 2, fractionColumnWidth - 3, lineHeight - 3);
 
         int drawnWidth = 3;
-        for (int c = 3; c < reportFractions[0].length; c++) {
+        // oct 2016 added -1 for filtering cell added
+        for (int c = 3; c < reportFractions[0].length - 1; c++) {
             float colWidth = calculateColumnWidth(c) * COLUMN_WIDTH_ADJUST_FACTOR;
             sortButtons.get(c - 3).setBounds( //
                     drawnWidth + 2, DATATABLE_TOP_HEIGHT - lineHeight - 1, (int) colWidth + 4, lineHeight - 3);
@@ -395,11 +396,12 @@ public class ReportAliquotFractionsView extends JLayeredPane implements ReportUp
 
         // then pre-process to determine sizes of panels             
         float width = 0;
-        for (int i = 2; i < reportFractions[0].length; i++) {
+        // oct 2016 added -1 for filtering cell added
+        for (int i = 2; i < reportFractions[0].length - 1; i++) {
             width += calculateColumnWidth(i) * COLUMN_WIDTH_ADJUST_FACTOR + dividerWidth;
         }
 
-        reportWidth = (int) width + (int) dividerWidth;// + reportFractions[0].length + (int) dividerWidth;
+        reportWidth = (int) width + (int) dividerWidth;
 
         // column #2 is the fractionID column
         fractionColumnWidth
@@ -431,7 +433,8 @@ public class ReportAliquotFractionsView extends JLayeredPane implements ReportUp
 
         // build sort buttons
         sortButtons = new ArrayList<>();
-        for (int c = 3; c < reportFractions[0].length; c++) {
+        // oct 2016 added -1 for filtering cell added
+        for (int c = 3; c < reportFractions[0].length - 1; c++) {
 
             JButton sortButton = new ET_JButton("\u25B2 \u25BC");
             sortButton.setFont(ReduxConstants.sansSerif_10_Bold);
@@ -820,7 +823,8 @@ public class ReportAliquotFractionsView extends JLayeredPane implements ReportUp
                     if (paintType.equalsIgnoreCase("HEADER")) {
                         colStart = 3;
                     }
-                    for (int c = colStart; c < getReportFractions()[0].length; c++) {
+                    // oct 2016 added -1 for filtering cell added
+                    for (int c = colStart; c < reportFractions[0].length - 1; c++) {
                         float colWidth = calculateColumnWidth(c) * COLUMN_WIDTH_ADJUST_FACTOR;
 
                         catName = getReportFractions()[0][c].trim();
@@ -847,19 +851,20 @@ public class ReportAliquotFractionsView extends JLayeredPane implements ReportUp
                     drawnHeight += lineHeight;
                     int accumulateDrawnHeight = 0;
 
-                    for (int c = colStart; c < getReportFractions()[0].length; c++) {
+                    // oct 2016 added -1 for filtering cell added
+                    for (int c = colStart; c < reportFractions[0].length - 1; c++) {
                         float colWidth = calculateColumnWidth(c) * COLUMN_WIDTH_ADJUST_FACTOR;
 
                         accumulateDrawnHeight = 0;
 
-                        g2D.drawString(getReportFractions()[1][c],
+                        g2D.drawString(reportFractions[1][c],
                                 drawnWidth,
                                 drawnHeight + topMargin + lineHeight + accumulateDrawnHeight);
-                        g2D.drawString(getReportFractions()[2][c],
+                        g2D.drawString(reportFractions[2][c],
                                 drawnWidth,
                                 drawnHeight + topMargin + lineHeight + accumulateDrawnHeight + 11);
                         accumulateDrawnHeight += 11;
-                        g2D.drawString(getReportFractions()[3][c],
+                        g2D.drawString(reportFractions[3][c],
                                 drawnWidth,
                                 drawnHeight + topMargin + lineHeight + accumulateDrawnHeight + 11);
                         accumulateDrawnHeight += 11;
@@ -867,8 +872,8 @@ public class ReportAliquotFractionsView extends JLayeredPane implements ReportUp
                         // handle footnote letters, which are stored in reportFractions[5]
                         if (!reportFractions[5][c].equalsIgnoreCase("")) {
                             g2D.setFont(footnoteFont);
-                            g2D.drawString(getReportFractions()[5][c],//superScript for footnote
-                                    drawnWidth + getReportFractions()[3][c].trim().length() * COLUMN_WIDTH_ADJUST_FACTOR,//6.8f,
+                            g2D.drawString(reportFractions[5][c],//superScript for footnote
+                                    drawnWidth + reportFractions[3][c].trim().length() * COLUMN_WIDTH_ADJUST_FACTOR,//6.8f,
                                     drawnHeight + topMargin + lineHeight + accumulateDrawnHeight - 4);//7);
                             g2D.setFont(numberFont);
                         }
@@ -892,7 +897,6 @@ public class ReportAliquotFractionsView extends JLayeredPane implements ReportUp
                     accumulateDrawnHeight = 0;
 
                     overallWidth = drawnWidth - 3;
-//                    reportWidth = (int) overallWidth + (int) dividerWidth;// + 200;
 
                     // draw horizontal line under column titles
                     g2D.setColor(Color.black);
@@ -909,7 +913,7 @@ public class ReportAliquotFractionsView extends JLayeredPane implements ReportUp
                 // paint fractions and set up interactivity
                 if (paintType.equalsIgnoreCase("BOTH") || paintType.equalsIgnoreCase("BODY") || paintType.equalsIgnoreCase("FRACTION")) {
 
-                    if ((getReportFractions().length < fractionDataStartRow + 1)//
+                    if ((reportFractions.length < fractionDataStartRow + 1)//
                             &&//
                             !paintType.equalsIgnoreCase("FRACTION")) {
                         g2D.drawString(
@@ -921,7 +925,7 @@ public class ReportAliquotFractionsView extends JLayeredPane implements ReportUp
 
                         int grayRow = 0;
 
-                        for (int row = fractionDataStartRow; row < getReportFractions().length; row++) {
+                        for (int row = fractionDataStartRow; row < reportFractions.length; row++) {
                             drawnWidth = leftMargin;
 
                             // april 2012 reportFractions will contain only accepted OR rejected, thus here check for printing fractions
@@ -929,7 +933,7 @@ public class ReportAliquotFractionsView extends JLayeredPane implements ReportUp
                                 grayRow++;
                                 // for each aliquot                                
                                 if (!reportFractions[row][1].equalsIgnoreCase(saveAliquotName)) {
-                                    saveAliquotName = getReportFractions()[row][1];
+                                    saveAliquotName = reportFractions[row][1];
 
                                     g2D.setColor(ReduxConstants.myAliquotGrayColor);
 
@@ -939,14 +943,14 @@ public class ReportAliquotFractionsView extends JLayeredPane implements ReportUp
 
                                     if (!paintType.equalsIgnoreCase("FRACTION")) {
                                         // aliquot  name
-                                        g2D.drawString(getReportFractions()[row][1],
+                                        g2D.drawString(reportFractions[row][1],
                                                 leftMargin,
                                                 drawnHeight + topMargin + lineHeight);
                                     }
 
                                     // build map of row to fraction objects and aliquot objects
                                     if ((sample != null) && paintType.equalsIgnoreCase("FRACTION")) {
-                                        aliquot = sample.getAliquotByName(getReportFractions()[row][1].trim());
+                                        aliquot = sample.getAliquotByName(reportFractions[row][1].trim());
                                         verticalPixelFractionMap.add( //
                                                 new TableRowObject( //
                                                         drawnHeight + topMargin + lineHeight + 1,//
@@ -978,7 +982,9 @@ public class ReportAliquotFractionsView extends JLayeredPane implements ReportUp
                                 }
 
                                 // fraction data
-                                int columnCount = getReportFractions()[0].length;
+                                // oct 2016 -1 added in to compensate for additional cell that records true/false filtering
+                                int columnCount = reportFractions[0].length - 1;
+                                boolean showAsFilteredOut = (reportFractions[row][columnCount].compareToIgnoreCase("false") == 0);
                                 int columnStart = 2;
                                 if (paintType.equalsIgnoreCase("FRACTION")) {
                                     columnCount = 3;
@@ -995,7 +1001,7 @@ public class ReportAliquotFractionsView extends JLayeredPane implements ReportUp
 
                                     ETFractionInterface fraction = null;
                                     try {
-                                        fraction = sample.getFractionByIDAndAliquotNumber(getReportFractions()[row][2].trim(), ((ReduxAliquotInterface) aliquot).getAliquotNumber());
+                                        fraction = sample.getFractionByIDAndAliquotNumber(reportFractions[row][2].trim(), ((ReduxAliquotInterface) aliquot).getAliquotNumber());
                                         TableRowObject currentFractionTableRowObject
                                                 = new TableRowObject( //
                                                         drawnHeight + topMargin + lineHeight + 1,//
@@ -1048,10 +1054,18 @@ public class ReportAliquotFractionsView extends JLayeredPane implements ReportUp
                                 }
 
                                 g2D.setFont(numberFont);
-                                g2D.setColor(Color.BLACK);
+//                                g2D.setColor(Color.BLACK);
+
                                 for (int c = columnStart; c < columnCount; c++) {
+                                    // oct 2016 filtering
+                                    if (showAsFilteredOut) {
+                                        g2D.setColor(Color.LIGHT_GRAY);
+                                    } else {
+                                        g2D.setColor(Color.BLACK);
+                                    }
+
                                     try {
-                                        g2D.drawString(getReportFractions()[row][c],
+                                        g2D.drawString(reportFractions[row][c],
                                                 leftMargin + drawnWidth,
                                                 drawnHeight + topMargin + lineHeight);
 
@@ -1061,10 +1075,9 @@ public class ReportAliquotFractionsView extends JLayeredPane implements ReportUp
                                                 drawnHeight + topMargin + lineHeight);
                                     }
 
-                                    drawnWidth += getReportFractions()[fractionDataStartRow][c].length() * COLUMN_WIDTH_ADJUST_FACTOR;
+                                    drawnWidth += (reportFractions[fractionDataStartRow][c].length()) * COLUMN_WIDTH_ADJUST_FACTOR;
 
                                     // vertical line
-                                    //if (  ! paintType.equalsIgnoreCase( "FRACTION" ) ) {
                                     g2D.setColor(Color.gray);
 
                                     g2D.drawLine(//
@@ -1072,8 +1085,6 @@ public class ReportAliquotFractionsView extends JLayeredPane implements ReportUp
                                             drawnHeight + topMargin,// + lineHeight, //
                                             (int) (leftMargin + drawnWidth + 4), //
                                             drawnHeight + topMargin + lineHeight + 10);
-                                    //}
-                                    g2D.setColor(Color.black);
 
                                     drawnWidth += dividerWidth;
                                 }
@@ -1081,7 +1092,6 @@ public class ReportAliquotFractionsView extends JLayeredPane implements ReportUp
                                 drawnHeight += lineHeight;
                             }
                         }
-
                     }
 
                     // list out footnotes
@@ -1089,7 +1099,7 @@ public class ReportAliquotFractionsView extends JLayeredPane implements ReportUp
                         drawnHeight += lineHeight * 3;
                         drawnWidth = leftMargin;
 
-                        for (String item : getReportFractions()[6]) {
+                        for (String item : reportFractions[6]) {
                             if (!item.equals("")) {
                                 // strip out footnote letter
                                 String[] footNote = item.split("&");
@@ -1275,7 +1285,7 @@ public class ReportAliquotFractionsView extends JLayeredPane implements ReportUp
 
             Map<TranscodingHints.Key, Float> hints = new HashMap<>();
             hints.put(PDFTranscoder.KEY_WIDTH, new Float(reportWidth));
-            hints.put(PDFTranscoder.KEY_HEIGHT, getReportFractions().length * 20f + 150f);
+            hints.put(PDFTranscoder.KEY_HEIGHT, reportFractions.length * 20f + 150f);
             t.setTranscodingHints(hints);
 
             TranscoderInput input = null;

--- a/src/main/java/org/earthtime/reportViews/ReportPainterI.java
+++ b/src/main/java/org/earthtime/reportViews/ReportPainterI.java
@@ -34,7 +34,7 @@ public interface ReportPainterI {
     public void loadAndShowReportTableData (String fractionIdToFocus);
     
     /**
-     * 
+     *
      * @param performReduction
      * @param inLiveMode the value of inLiveMode
      */

--- a/src/main/java/org/earthtime/reportViews/TabbedReportViews.java
+++ b/src/main/java/org/earthtime/reportViews/TabbedReportViews.java
@@ -95,7 +95,6 @@ public class TabbedReportViews extends JTabbedPane {
     public void prepareTabs() {
 
         // default is active fractions
-
         if (sample != null) {
             ((ReportAliquotFractionsView) viewTabulatedAliquotActiveFractions).setSample(sample);
 
@@ -117,6 +116,13 @@ public class TabbedReportViews extends JTabbedPane {
 
             ((ReportAliquotFractionsView) viewTabulatedAliquotRejectedFractions).refreshPanel();
             this.setTitleAt(1, "Rejected Fractions (" + Integer.toString(((ReportAliquotFractionsView) viewTabulatedAliquotRejectedFractions).getReportFractions().length - ReportSettingsInterface.FRACTION_DATA_START_ROW) + ")");
+        }
+    }
+
+    public void repaintTabs() {
+        if (sample != null) {
+            viewTabulatedAliquotActiveFractions.repaint();
+            viewTabulatedAliquotRejectedFractions.repaint();
         }
     }
 

--- a/src/main/java/org/earthtime/reports/ReportSettingsInterface.java
+++ b/src/main/java/org/earthtime/reports/ReportSettingsInterface.java
@@ -546,7 +546,8 @@ public interface ReportSettingsInterface extends Comparable<ReportSettingsInterf
         }
 
         // end of special case for units of date
-        int countOfAllColumns = getCountOfAllColumns() + 2;
+        // oct 2016 added another cell to flag whether fraction is filtered = true or false
+        int countOfAllColumns = getCountOfAllColumns() + 2 + 1;
 
         for (int i = 0; i < retVal.length; i++) {
             retVal[i] = new String[countOfAllColumns];
@@ -649,6 +650,13 @@ public interface ReportSettingsInterface extends Comparable<ReportSettingsInterf
 
                                     retVal[fractionRowCount][1]
                                             = sample.getAliquotByNumber(f.getAliquotNumber()).getAliquotName();
+                                    
+                                    // oct 2016 filtering true = not filtered out
+                                    if (sample.getFilteredFractionIDs().contains(f.getFractionID())){
+                                        retVal[fractionRowCount][countOfAllColumns - 1] = "true";
+                                    } else  {
+                                        retVal[fractionRowCount][countOfAllColumns - 1] = "false";
+                                    }
                                 }
 
                                 // field contains the Value in field[0]

--- a/src/main/java/org/earthtime/samples/SampleInterface.java
+++ b/src/main/java/org/earthtime/samples/SampleInterface.java
@@ -25,6 +25,7 @@ import java.util.Collections;
 import java.util.Comparator;
 import java.util.Iterator;
 import java.util.Map;
+import java.util.SortedSet;
 import java.util.Vector;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -347,7 +348,7 @@ public interface SampleInterface {
 //
 //        return retVal;
 //        
-                
+
         // sept 2016
         return getSampleAnalysisType().startsWith("LAICPMS");
     }
@@ -474,8 +475,8 @@ public interface SampleInterface {
      * @return the calculateTWrhoForLegacyData
      */
     public abstract boolean isCalculateTWrhoForLegacyData();
-    
-    public default boolean isReferenceMaterial(){
+
+    public default boolean isReferenceMaterial() {
         boolean retVal = false;
         retVal = (getFractions().get(0).isStandard() || getFractions().get(0).isSecondaryStandard());
         return retVal;
@@ -1315,6 +1316,20 @@ public interface SampleInterface {
 
         return retval;
     }
+    
+        /**
+     *
+     * @return
+     */
+    public default Vector<ETFractionInterface> getUpbFractionsReferenceMaterial() {
+        Vector<ETFractionInterface> retval = new Vector<>();
+
+        getFractions().stream().filter((f) -> (f.isStandard())).forEach((f) -> {
+            retval.add(f);
+        });
+
+        return retval;
+    }
 
     /**
      *
@@ -2076,4 +2091,14 @@ public interface SampleInterface {
 
         return retVal;
     }
+
+    /**
+     * @return the filteredFractionIDs
+     */
+    public SortedSet<String> getFilteredFractionIDs();
+
+    /**
+     * @param filteredFractionIDs the filteredFractionIDs to set
+     */
+    public void setFilteredFractionIDs(SortedSet<String> filteredFractionIDs);
 }


### PR DESCRIPTION
Per @AZlaserchron , added greying-out of fractions that are filtered on the sample dates interpretation manager at the probability density tab. Added clear filter button for both normal and live filtering dialogs. Improved look and feel for various manager dialogs.