### PR TITLE
Various tweaks requested.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
     <groupId>org.cirdles</groupId>
     <artifactId>ET_Redux</artifactId>
     <name>ET_Redux</name>
-    <version>3.6.12</version>
+    <version>3.6.13</version>
     <description>Successor to U-Pb_Redux</description>
     <url>https://cirdles.org</url>
     <inceptionYear>2006</inceptionYear>

--- a/src/main/java/org/earthtime/ETReduxFrame.form
+++ b/src/main/java/org/earthtime/ETReduxFrame.form
@@ -838,7 +838,7 @@
     </Property>
     <Property name="locationByPlatform" type="boolean" value="true"/>
     <Property name="preferredSize" type="java.awt.Dimension" editor="org.netbeans.beaninfo.editors.DimensionEditor">
-      <Dimension value="[1160, 750]"/>
+      <Dimension value="[1175, 750]"/>
     </Property>
   </Properties>
   <SyntheticProperties>

--- a/src/main/java/org/earthtime/ETReduxFrame.java
+++ b/src/main/java/org/earthtime/ETReduxFrame.java
@@ -155,7 +155,7 @@ import org.earthtime.utilities.FileHelper;
 public class ETReduxFrame extends javax.swing.JFrame implements ReportPainterI, ReportUpdaterInterface, SampleDateInterpretationSubscribeInterface {
 
     // user-specific configurations
-    public final static int FRAME_WIDTH = 1180;
+    public final static int FRAME_WIDTH = 1175;
     private ReduxPersistentState myState;
     private final ClassLoader cldr;
     private final java.net.URL imageURL;
@@ -219,6 +219,24 @@ public class ETReduxFrame extends javax.swing.JFrame implements ReportPainterI, 
             throws BadLabDataException {
 
         this.myState = myState;
+
+        /* Set the Metal look and feel */
+        //<editor-fold defaultstate="collapsed" desc=" Look and feel setting code (optional) ">
+        /* If Metal is not available, stay with the default look and feel.
+         * For details see http://download.oracle.com/javase/tutorial/uiswing/lookandfeel/plaf.html 
+         */
+        try {
+            for (javax.swing.UIManager.LookAndFeelInfo info : javax.swing.UIManager.getInstalledLookAndFeels()) {
+                if ("Metal".equals(info.getName())) { //Nimbus (original), Motif, Metal
+                    javax.swing.UIManager.setLookAndFeel(info.getClassName());
+                    break;
+                }
+            }
+        } catch (ClassNotFoundException | InstantiationException | IllegalAccessException | javax.swing.UnsupportedLookAndFeelException ex) {
+            java.util.logging.Logger.getLogger(org.cirdles.calamari.userInterface.CalamariUI.class.getName()).log(java.util.logging.Level.SEVERE, null, ex);
+        }
+        //</editor-fold>
+
         initComponents();
 
         announcementPane = new AnnouncementPane();
@@ -316,7 +334,7 @@ public class ETReduxFrame extends javax.swing.JFrame implements ReportPainterI, 
         // July 2012 upograde
         reportTableTabbedPane = new TabbedReportViews(this);
         ((TabbedReportViews) reportTableTabbedPane).initializeTabs();
-        reportTableTabbedPane.setSize(fractionsTabulatedResultsLayeredPane.getSize());
+        reportTableTabbedPane.setSize(calculateTabulatedResultsSize());
         fractionsTabulatedResultsLayeredPane.add(reportTableTabbedPane, JLayeredPane.DEFAULT_LAYER);
 
         // reduxfile may exist if supplied to command line
@@ -345,6 +363,11 @@ public class ETReduxFrame extends javax.swing.JFrame implements ReportPainterI, 
         reduceAll_button.setBackground(Color.WHITE);
         interpretSampleDates_button.setBackground(Color.WHITE);
 
+    }
+    
+    private Dimension calculateTabulatedResultsSize(){
+        Dimension mySize = fractionsTabulatedResultsLayeredPane.getSize();
+        return new Dimension((int)mySize.getWidth() - 3, (int)mySize.getHeight());
     }
 
     private void changeContentOfTopPanel(ReduxConstants.TOP_PANEL_CONTENTS contents) {
@@ -2017,7 +2040,7 @@ public class ETReduxFrame extends javax.swing.JFrame implements ReportPainterI, 
         setTitle("EARTHTIME Redux");
         setBackground(new java.awt.Color(237, 242, 250));
         setLocationByPlatform(true);
-        setPreferredSize(new java.awt.Dimension(1160, 750));
+        setPreferredSize(new java.awt.Dimension(1175, 750));
         addComponentListener(new java.awt.event.ComponentAdapter() {
             public void componentResized(java.awt.event.ComponentEvent evt) {
                 formComponentResized(evt);
@@ -2030,7 +2053,7 @@ public class ETReduxFrame extends javax.swing.JFrame implements ReportPainterI, 
         });
 
         buttonBar_panel.setBackground(new java.awt.Color(235, 255, 255));
-        buttonBar_panel.setBorder(javax.swing.BorderFactory.createBevelBorder(javax.swing.border.BevelBorder.LOWERED));
+        buttonBar_panel.setBorder(javax.swing.BorderFactory.createBevelBorder(1));
         buttonBar_panel.setLayout(new org.netbeans.lib.awtextra.AbsoluteLayout());
 
         saveAndQuit_button.setBackground(new java.awt.Color(204, 204, 204));
@@ -3948,8 +3971,8 @@ private void formComponentResized (java.awt.event.ComponentEvent evt) {//GEN-FIR
 
 private void fractionsTabulatedResultsLayeredPaneComponentResized (java.awt.event.ComponentEvent evt) {//GEN-FIRST:event_fractionsTabulatedResultsLayeredPaneComponentResized
     try {
-        getReportTableTabbedPane().//
-                setSize(fractionsTabulatedResultsLayeredPane.getSize());
+        reportTableTabbedPane.//
+                setSize(calculateTabulatedResultsSize());
     } catch (Exception e) {
     }
 }//GEN-LAST:event_fractionsTabulatedResultsLayeredPaneComponentResized

--- a/src/main/java/org/earthtime/Tripoli/fractions/TripoliFraction.java
+++ b/src/main/java/org/earthtime/Tripoli/fractions/TripoliFraction.java
@@ -1639,8 +1639,10 @@ public class TripoliFraction implements //
     }
 
     public String dateSummary() {
-        return fractionID
-                + ">  206/238: "
+        String retVal = fractionID;
+        
+        if (uPbFraction != null){
+        retVal += ">  206/238: "
                 + uPbFraction.getRadiogenicIsotopeDateByName(RadDates.age206_238r)
                 .formatValueAndTwoSigmaForPublicationSigDigMode("ABS", -6, 2)
                 + ">  207/235: "
@@ -1649,5 +1651,10 @@ public class TripoliFraction implements //
                 + ">  207/206: "
                 + uPbFraction.getRadiogenicIsotopeDateByName(RadDates.age207_206r)
                 .formatValueAndTwoSigmaForPublicationSigDigMode("ABS", -6, 2);
+        } else {
+            retVal += "  could not be processed at this time.";
+        }
+        
+        return retVal;
     }
 }

--- a/src/main/java/org/earthtime/Tripoli/rawDataFiles/handlers/Thermo/LaserchronElementIIFileHandler.java
+++ b/src/main/java/org/earthtime/Tripoli/rawDataFiles/handlers/Thermo/LaserchronElementIIFileHandler.java
@@ -118,11 +118,9 @@ public class LaserchronElementIIFileHandler extends AbstractRawDataFileHandler {
     @Override
     public void getAndLoadRawIntensityDataFile(SwingWorker loadDataTask, boolean usingFullPropagation, int leftShadeCount, int ignoreFirstFractions, boolean inLiveMode) {
 
-        if (referenceMaterialIncrementerMap == null) {
-            referenceMaterialIncrementerMap = new ConcurrentHashMap<>();
-            for (int i = 0; i < rawDataFileTemplate.getStandardIDs().length; i++) {
-                referenceMaterialIncrementerMap.put(rawDataFileTemplate.getStandardIDs()[i], 1);
-            }
+        referenceMaterialIncrementerMap = new ConcurrentHashMap<>();
+        for (int i = 0; i < rawDataFileTemplate.getStandardIDs().length; i++) {
+            referenceMaterialIncrementerMap.put(rawDataFileTemplate.getStandardIDs()[i], 1);
         }
 
         // Laserchron ElementII has folder of .dat files 

--- a/src/main/java/org/earthtime/Tripoli/rawDataFiles/handlers/Thermo/LaserchronElementIIFileHandler.java
+++ b/src/main/java/org/earthtime/Tripoli/rawDataFiles/handlers/Thermo/LaserchronElementIIFileHandler.java
@@ -118,9 +118,11 @@ public class LaserchronElementIIFileHandler extends AbstractRawDataFileHandler {
     @Override
     public void getAndLoadRawIntensityDataFile(SwingWorker loadDataTask, boolean usingFullPropagation, int leftShadeCount, int ignoreFirstFractions, boolean inLiveMode) {
 
-        referenceMaterialIncrementerMap = new ConcurrentHashMap<>();
-        for (int i = 0; i < rawDataFileTemplate.getStandardIDs().length; i++) {
-            referenceMaterialIncrementerMap.put(rawDataFileTemplate.getStandardIDs()[i], 1);
+        if ((referenceMaterialIncrementerMap == null) || !inLiveMode) {
+            referenceMaterialIncrementerMap = new ConcurrentHashMap<>();
+            for (String standardID : rawDataFileTemplate.getStandardIDs()) {
+                referenceMaterialIncrementerMap.put(standardID, 1);
+            }
         }
 
         // Laserchron ElementII has folder of .dat files 

--- a/src/main/java/org/earthtime/Tripoli/rawDataFiles/templates/AbstractRawDataFileTemplate.java
+++ b/src/main/java/org/earthtime/Tripoli/rawDataFiles/templates/AbstractRawDataFileTemplate.java
@@ -219,6 +219,10 @@ public abstract class AbstractRawDataFileTemplate implements //
         return NAME;
     }
 
+    public String getNAME() {
+        return NAME;
+    }
+
     /**
      * @return the aboutInfo
      */

--- a/src/main/java/org/earthtime/UPb_Redux/dateInterpretation/DateProbabilityDensityPanel.java
+++ b/src/main/java/org/earthtime/UPb_Redux/dateInterpretation/DateProbabilityDensityPanel.java
@@ -167,7 +167,7 @@ public class DateProbabilityDensityPanel extends JLayeredPane
         this.sample = sample;
 
         setOpaque(true);
-
+       
         setBackground(Color.white);
 
         selectedAliquotNumber = 0;
@@ -741,7 +741,6 @@ public class DateProbabilityDensityPanel extends JLayeredPane
     @Override
     public void preparePanel(boolean doReScale, boolean inLiveMode) {
 
-//        System.out.println("========Probability Prep=======");
         this.removeAll();
 
         //nov 2011

--- a/src/main/java/org/earthtime/UPb_Redux/dateInterpretation/kwiki/KwikiPDFToolBar.java
+++ b/src/main/java/org/earthtime/UPb_Redux/dateInterpretation/kwiki/KwikiPDFToolBar.java
@@ -48,6 +48,7 @@ import org.earthtime.UPb_Redux.dateInterpretation.graphPersistence.GraphAxesSetu
 import org.earthtime.UPb_Redux.dialogs.sampleManagers.sampleDateInterpretationManagers.SampleDateInterpretationsUtilities;
 import org.earthtime.beans.ET_JButton;
 import org.earthtime.fractions.ETFractionInterface;
+import org.earthtime.reduxLabData.ReduxLabData;
 import org.earthtime.reportViews.TabbedReportViews;
 import org.earthtime.samples.SampleInterface;
 
@@ -80,6 +81,7 @@ public class KwikiPDFToolBar extends JLayeredPane implements GraphPanelModeChang
     private final SampleTreeI dateTreeByAliquot;
     private JTabbedPane reportTableTabbedPane;
     private final JButton clearFilters;
+    private final JButton defaultFilters;
 
     /**
      * Creates a new instance of KwikiConcordiaToolBar
@@ -97,12 +99,6 @@ public class KwikiPDFToolBar extends JLayeredPane implements GraphPanelModeChang
 
         super();
 
-        setOpaque(true);
-
-        setBackground(Color.white);
-
-        setBounds(x, y, 700, 56);
-
         this.probabilityPanel = aPDFGraphPanel;
         this.concordiaGraphPanel = aConcordiaGraphPanel;
 
@@ -116,6 +112,12 @@ public class KwikiPDFToolBar extends JLayeredPane implements GraphPanelModeChang
 
         doLinkDiscordances = true;
 
+        setOpaque(true);
+
+        setBackground(Color.white);
+
+        setBounds(x, y, 720, 56);
+
         SetupZoomToggleButtons();
         SetupDateChooserButtons();
 
@@ -124,7 +126,7 @@ public class KwikiPDFToolBar extends JLayeredPane implements GraphPanelModeChang
         negativePctDiscordance_slider.setMaximum(0);
         negativePctDiscordance_slider.setMinimum(-100);
         negativePctDiscordance_slider.setMajorTickSpacing(10);
-        negativePctDiscordance_slider.setMinorTickSpacing(2);
+        negativePctDiscordance_slider.setMinorTickSpacing(1);
         negativePctDiscordance_slider.setPaintLabels(true);
         negativePctDiscordance_slider.setPaintTicks(true);
         negativePctDiscordance_slider.setSnapToTicks(true);
@@ -142,7 +144,7 @@ public class KwikiPDFToolBar extends JLayeredPane implements GraphPanelModeChang
         negativePctDiscordance_text.setOpaque(false);
         negativePctDiscordance_text.setFont(new java.awt.Font("Arial", 1, 10));
         negativePctDiscordance_text.setHorizontalAlignment(javax.swing.JTextField.CENTER);
-        negativePctDiscordance_text.setText("Negative % discordance");
+        negativePctDiscordance_text.setText("Neg % discordance");
         negativePctDiscordance_text.setAlignmentX(0.0F);
         negativePctDiscordance_text.setAlignmentY(0.0F);
         negativePctDiscordance_text.setBorder(null);
@@ -164,7 +166,7 @@ public class KwikiPDFToolBar extends JLayeredPane implements GraphPanelModeChang
         linkedUnlinkedDiscordance.setOpaque(true);
         linkedUnlinkedDiscordance.setPressedIcon(new javax.swing.ImageIcon(getClass().getResource("/org/earthtime/images/linked.png")));
         linkedUnlinkedDiscordance.setVerticalTextPosition(javax.swing.SwingConstants.BOTTOM);
-        linkedUnlinkedDiscordance.setBounds(285, 5, 20, 20);
+        linkedUnlinkedDiscordance.setBounds(300, 5, 20, 20);
         linkedUnlinkedDiscordance.setOpaque(true);
         linkedUnlinkedDiscordance.setBackground(Color.white);
 
@@ -178,14 +180,14 @@ public class KwikiPDFToolBar extends JLayeredPane implements GraphPanelModeChang
         positivePctDiscordance_slider.setMaximum(100);
         positivePctDiscordance_slider.setMinimum(0);
         positivePctDiscordance_slider.setMajorTickSpacing(10);
-        positivePctDiscordance_slider.setMinorTickSpacing(2);
+        positivePctDiscordance_slider.setMinorTickSpacing(1);
         positivePctDiscordance_slider.setPaintLabels(true);
         positivePctDiscordance_slider.setPaintTicks(true);
         positivePctDiscordance_slider.setSnapToTicks(true);
         positivePctDiscordance_slider.setAutoscrolls(true);
         positivePctDiscordance_slider.setValue(Integer.parseInt(probabilityChartOptions.get("positivePerCentDiscordanceSliderValue")));
         positivePctDiscordance_slider.setName("positivePerCentDiscordanceSliderValue");
-        positivePctDiscordance_slider.setBounds(310, 1, 175, 38);
+        positivePctDiscordance_slider.setBounds(335, 1, 175, 38);
         positivePctDiscordance_slider.setOpaque(true);
         positivePctDiscordance_slider.setBackground(Color.white);
 
@@ -196,11 +198,11 @@ public class KwikiPDFToolBar extends JLayeredPane implements GraphPanelModeChang
         positivePctDiscordance_text.setOpaque(false);
         positivePctDiscordance_text.setFont(new java.awt.Font("Arial", 1, 10));
         positivePctDiscordance_text.setHorizontalAlignment(javax.swing.JTextField.CENTER);
-        positivePctDiscordance_text.setText("Positive % discordance");
+        positivePctDiscordance_text.setText("Pos % discordance");
         positivePctDiscordance_text.setAlignmentX(0.0F);
         positivePctDiscordance_text.setAlignmentY(0.0F);
         positivePctDiscordance_text.setBorder(null);
-        positivePctDiscordance_text.setBounds(310, 38, 175, 17);
+        positivePctDiscordance_text.setBounds(335, 38, 175, 17);
         add(positivePctDiscordance_text);
 
         percentUncertainty_slider = new javax.swing.JSlider();
@@ -208,13 +210,13 @@ public class KwikiPDFToolBar extends JLayeredPane implements GraphPanelModeChang
         percentUncertainty_slider.setMaximum(100);
         percentUncertainty_slider.setMinimum(0);
         percentUncertainty_slider.setMajorTickSpacing(10);
-        percentUncertainty_slider.setMinorTickSpacing(2);
+        percentUncertainty_slider.setMinorTickSpacing(1);
         percentUncertainty_slider.setPaintLabels(true);
         percentUncertainty_slider.setPaintTicks(true);
         percentUncertainty_slider.setSnapToTicks(true);
         percentUncertainty_slider.setAutoscrolls(true);
         percentUncertainty_slider.setName("uncertaintyPerCentSliderValue");
-        percentUncertainty_slider.setBounds(490, 1, 175, 38);
+        percentUncertainty_slider.setBounds(515, 1, 175, 38);
         percentUncertainty_slider.setOpaque(true);
         percentUncertainty_slider.setBackground(Color.white);
 
@@ -229,16 +231,23 @@ public class KwikiPDFToolBar extends JLayeredPane implements GraphPanelModeChang
         pctUncertainty_text.setAlignmentX(0.0F);
         pctUncertainty_text.setAlignmentY(0.0F);
         pctUncertainty_text.setBorder(null);
-        pctUncertainty_text.setBounds(490, 38, 175, 17);
+        pctUncertainty_text.setBounds(515, 38, 175, 17);
         add(pctUncertainty_text);
 
         clearFilters = new ET_JButton("Clear");
-        clearFilters.setBounds(278, 37, 39, 16);
+        clearFilters.setBounds(310, 38, 39, 16);
+        clearFilters.setFont(new java.awt.Font("Arial", 1, 10));
 
         clearFilters.addActionListener((ActionEvent arg0) -> {
+            if (!doLinkDiscordances) {
+                toggleLinkLockDiscordanceSliders();
+            }
+
             negativePctDiscordance_slider.setValue(-100);
-            positivePctDiscordance_slider.setValue(100);
+            updateSlidersStatus(negativePctDiscordance_slider);
+
             percentUncertainty_slider.setValue(100);
+            updateSlidersStatus(percentUncertainty_slider);
 
             performFilteringPerSliders(true);
 
@@ -250,6 +259,43 @@ public class KwikiPDFToolBar extends JLayeredPane implements GraphPanelModeChang
 
         add(clearFilters, javax.swing.JLayeredPane.DEFAULT_LAYER);
         this.setComponentZOrder(clearFilters, 0);
+
+        defaultFilters = new ET_JButton("Default");
+        defaultFilters.setBounds(270, 38, 40, 16);
+        defaultFilters.setFont(new java.awt.Font("Arial", 1, 10));
+
+        defaultFilters.addActionListener((ActionEvent arg0) -> {
+            int negPctDis = ReduxLabData.getInstance().getDefaultNegPctDiscordanceFilter();
+            int posPctDis = ReduxLabData.getInstance().getDefaultPosPctDiscordanceFilter();
+            boolean testDoLinkDiscordances = (Math.abs(negPctDis) == posPctDis);
+            if (doLinkDiscordances != testDoLinkDiscordances) {
+                toggleLinkLockDiscordanceSliders();
+            }
+            
+            if (doLinkDiscordances) {
+                negativePctDiscordance_slider.setValue(ReduxLabData.getInstance().getDefaultNegPctDiscordanceFilter());
+                updateSlidersStatus(negativePctDiscordance_slider);
+
+            } else {
+                negativePctDiscordance_slider.setValue(ReduxLabData.getInstance().getDefaultNegPctDiscordanceFilter());
+                positivePctDiscordance_slider.setValue(ReduxLabData.getInstance().getDefaultPosPctDiscordanceFilter());
+                updateSlidersStatus(negativePctDiscordance_slider);
+                updateSlidersStatus(positivePctDiscordance_slider);
+            }
+
+            percentUncertainty_slider.setValue(ReduxLabData.getInstance().getDefaultPctUncertaintyFilter());
+            updateSlidersStatus(percentUncertainty_slider);
+
+            performFilteringPerSliders(false);
+
+            try {
+                ((TabbedReportViews) reportTableTabbedPane).refreshTabs();
+            } catch (Exception noTabs) {
+            }
+        });
+
+        add(defaultFilters, javax.swing.JLayeredPane.DEFAULT_LAYER);
+        this.setComponentZOrder(defaultFilters, 0);
 
         try {
             int uncertaintyPerCentSliderValue = Integer.parseInt(probabilityChartOptions.get("uncertaintyPerCentSliderValue"));
@@ -298,6 +344,13 @@ public class KwikiPDFToolBar extends JLayeredPane implements GraphPanelModeChang
     }
 
     private void linkedUnlinkedDiscordanceActionPerformed(java.awt.event.ActionEvent evt) {
+        toggleLinkLockDiscordanceSliders();
+        // test for linkage
+        updateSlidersStatus(positivePctDiscordance_slider);
+        performFilteringPerSliders(false);
+    }
+
+    private void toggleLinkLockDiscordanceSliders() {
         Icon oldPressed = linkedUnlinkedDiscordance.getPressedIcon();
         linkedUnlinkedDiscordance.setPressedIcon(linkedUnlinkedDiscordance.getIcon());
         linkedUnlinkedDiscordance.setIcon(oldPressed);
@@ -307,8 +360,6 @@ public class KwikiPDFToolBar extends JLayeredPane implements GraphPanelModeChang
         } else {
             linkedUnlinkedDiscordance.setToolTipText("Click to Lock sliders.");
         }
-        // test for linkage
-        updateSlidersStatus(positivePctDiscordance_slider);
     }
 
     private class SliderChangeListener implements ChangeListener {
@@ -360,16 +411,16 @@ public class KwikiPDFToolBar extends JLayeredPane implements GraphPanelModeChang
         }
 
         if (slider.equals(negativePctDiscordance_slider)) {
-            negativePctDiscordance_text.setText("Negative % discordance = " + negativePctDiscordance_slider.getValue());
+            negativePctDiscordance_text.setText("Neg % discordance = " + negativePctDiscordance_slider.getValue());
             if (doLinkDiscordances) {
-                positivePctDiscordance_text.setText("Positive % discordance = " + positivePctDiscordance_slider.getValue());
+                positivePctDiscordance_text.setText("Pos % discordance = " + positivePctDiscordance_slider.getValue());
             }
         }
 
         if (slider.equals(positivePctDiscordance_slider)) {
-            positivePctDiscordance_text.setText("Positive % discordance = " + positivePctDiscordance_slider.getValue());
+            positivePctDiscordance_text.setText("Pos % discordance = " + positivePctDiscordance_slider.getValue());
             if (doLinkDiscordances) {
-                negativePctDiscordance_text.setText("Negative % discordance = " + negativePctDiscordance_slider.getValue());
+                negativePctDiscordance_text.setText("Neg % discordance = " + negativePctDiscordance_slider.getValue());
             }
         }
 

--- a/src/main/java/org/earthtime/UPb_Redux/dialogs/parameterManagers/AbstractProjectParametersManager.java
+++ b/src/main/java/org/earthtime/UPb_Redux/dialogs/parameterManagers/AbstractProjectParametersManager.java
@@ -642,6 +642,8 @@ public abstract class AbstractProjectParametersManager extends JLayeredPane {
 
         mineralStandardsComboBox.setBounds(500, 475, 275, 25);
         mineralStandardsComboBox.setFont(ReduxConstants.sansSerif_10_Bold);
+        mineralStandardsComboBox.setOpaque(true);
+        mineralStandardsComboBox.setBackground(Color.white);
         this.add(mineralStandardsComboBox);
 
         // view standard model

--- a/src/main/java/org/earthtime/UPb_Redux/dialogs/parameterManagers/LAICPMSProjectParametersManager.java
+++ b/src/main/java/org/earthtime/UPb_Redux/dialogs/parameterManagers/LAICPMSProjectParametersManager.java
@@ -694,26 +694,28 @@ public class LAICPMSProjectParametersManager extends JLayeredPane {
         defaultPrimaryReferenceMaterialLabel.setBounds(500, 450, 400, 25);
         this.add(defaultPrimaryReferenceMaterialLabel);
 
-        JComboBox referenceMagerialsComboBox = new JComboBox();
+        JComboBox referenceMaterialsComboBox = new JComboBox();
         ArrayList<AbstractRatiosDataModel> mineralStandardModels = ReduxLabData.getInstance().getMineralStandardModels();
         for (int i = (mineralStandardModels.size() > 1 ? 1 : 0); i < mineralStandardModels.size(); i++) {
-            referenceMagerialsComboBox.addItem(mineralStandardModels.get(i));
+            referenceMaterialsComboBox.addItem(mineralStandardModels.get(i));
         }
 
-        referenceMagerialsComboBox.setSelectedItem(rawDataFileHandler.getAcquisitionModel().getPrimaryMineralStandardModel());
-        referenceMagerialsComboBox.addActionListener((ActionEvent e) -> {
+        referenceMaterialsComboBox.setSelectedItem(rawDataFileHandler.getAcquisitionModel().getPrimaryMineralStandardModel());
+        referenceMaterialsComboBox.addActionListener((ActionEvent e) -> {
             rawDataFileHandler.getAcquisitionModel().setPrimaryMineralStandardModel((AbstractRatiosDataModel) ((JComboBox) e.getSource()).getSelectedItem());
         });
 
-        referenceMagerialsComboBox.setBounds(500, 475, 275, 25);
-        referenceMagerialsComboBox.setFont(ReduxConstants.sansSerif_10_Bold);
-        this.add(referenceMagerialsComboBox);
+        referenceMaterialsComboBox.setBounds(500, 475, 275, 25);
+        referenceMaterialsComboBox.setFont(ReduxConstants.sansSerif_10_Bold);
+        referenceMaterialsComboBox.setOpaque(true);
+        referenceMaterialsComboBox.setBackground(Color.white);
+        this.add(referenceMaterialsComboBox);
 
         // view reference material model
         JButton viewReferenceMaterialModelButton = new ET_JButton("View");
         viewReferenceMaterialModelButton.addActionListener((ActionEvent e) -> {
             AbstractRatiosDataModel selectedModel
-                    = ((AbstractRatiosDataModel) referenceMagerialsComboBox.getSelectedItem());
+                    = ((AbstractRatiosDataModel) referenceMaterialsComboBox.getSelectedItem());
             AbstractRatiosDataView modelView
                     = new ReferenceMaterialUPbRatiosDataViewNotEditable(selectedModel, null, false);
             modelView.displayModelInFrame();

--- a/src/main/java/org/earthtime/UPb_Redux/dialogs/projectManagers/ProjectManagerFor_SHRIMP_FromRawData.java
+++ b/src/main/java/org/earthtime/UPb_Redux/dialogs/projectManagers/ProjectManagerFor_SHRIMP_FromRawData.java
@@ -52,7 +52,7 @@ public class ProjectManagerFor_SHRIMP_FromRawData extends AbstractProjectManager
         // eventually move to xml external files
         knownRawDataFileHandlers = new ArrayList<>();
 
-        // LaserChron Element 2 
+        //SHRIMP
         AbstractRawDataFileHandler theSHRIMPFileHandler
                 = ShrimpFileHandler.getInstance();
         theSHRIMPFileHandler.getAvailableRawDataFileTemplates()//

--- a/src/main/java/org/earthtime/UPb_Redux/dialogs/sampleManagers/sampleDateInterpretationManagers/SampleDateInterpretationsManager.form
+++ b/src/main/java/org/earthtime/UPb_Redux/dialogs/sampleManagers/sampleDateInterpretationManagers/SampleDateInterpretationsManager.form
@@ -1368,7 +1368,7 @@
                           <Font name="Arial" size="10" style="1"/>
                         </Property>
                         <Property name="majorTickSpacing" type="int" value="10"/>
-                        <Property name="minorTickSpacing" type="int" value="2"/>
+                        <Property name="minorTickSpacing" type="int" value="1"/>
                         <Property name="paintLabels" type="boolean" value="true"/>
                         <Property name="paintTicks" type="boolean" value="true"/>
                         <Property name="snapToTicks" type="boolean" value="true"/>
@@ -1390,7 +1390,7 @@
                           <Font name="Arial" size="10" style="1"/>
                         </Property>
                         <Property name="majorTickSpacing" type="int" value="10"/>
-                        <Property name="minorTickSpacing" type="int" value="2"/>
+                        <Property name="minorTickSpacing" type="int" value="1"/>
                         <Property name="paintLabels" type="boolean" value="true"/>
                         <Property name="paintTicks" type="boolean" value="true"/>
                         <Property name="snapToTicks" type="boolean" value="true"/>
@@ -1414,7 +1414,7 @@
                         <Property name="majorTickSpacing" type="int" value="10"/>
                         <Property name="maximum" type="int" value="0"/>
                         <Property name="minimum" type="int" value="-100"/>
-                        <Property name="minorTickSpacing" type="int" value="2"/>
+                        <Property name="minorTickSpacing" type="int" value="1"/>
                         <Property name="paintLabels" type="boolean" value="true"/>
                         <Property name="paintTicks" type="boolean" value="true"/>
                         <Property name="snapToTicks" type="boolean" value="true"/>
@@ -1445,7 +1445,7 @@
                       </Properties>
                       <Constraints>
                         <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.DesignAbsoluteLayout" value="org.netbeans.modules.form.compat2.layouts.DesignAbsoluteLayout$AbsoluteConstraintsDescription">
-                          <AbsoluteConstraints x="586" y="45" width="130" height="15"/>
+                          <AbsoluteConstraints x="586" y="45" width="150" height="15"/>
                         </Constraint>
                       </Constraints>
                     </Component>
@@ -1467,7 +1467,7 @@
                       </Properties>
                       <Constraints>
                         <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.DesignAbsoluteLayout" value="org.netbeans.modules.form.compat2.layouts.DesignAbsoluteLayout$AbsoluteConstraintsDescription">
-                          <AbsoluteConstraints x="365" y="45" width="130" height="15"/>
+                          <AbsoluteConstraints x="345" y="45" width="150" height="15"/>
                         </Constraint>
                       </Constraints>
                     </Component>
@@ -1761,7 +1761,7 @@
                         <Property name="font" type="java.awt.Font" editor="org.netbeans.beaninfo.editors.FontEditor">
                           <Font name="Helvetica" size="10" style="1"/>
                         </Property>
-                        <Property name="text" type="java.lang.String" value="Clear Filters"/>
+                        <Property name="text" type="java.lang.String" value="Clear"/>
                         <Property name="border" type="javax.swing.border.Border" editor="org.netbeans.modules.form.editors2.BorderEditor">
                           <Border info="org.netbeans.modules.form.compat2.border.LineBorderInfo">
                             <LineBorder/>
@@ -1781,7 +1781,39 @@
                       </AuxValues>
                       <Constraints>
                         <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.DesignAbsoluteLayout" value="org.netbeans.modules.form.compat2.layouts.DesignAbsoluteLayout$AbsoluteConstraintsDescription">
-                          <AbsoluteConstraints x="505" y="45" width="75" height="20"/>
+                          <AbsoluteConstraints x="540" y="50" width="40" height="18"/>
+                        </Constraint>
+                      </Constraints>
+                    </Component>
+                    <Component class="javax.swing.JButton" name="defaultFilters_button">
+                      <Properties>
+                        <Property name="background" type="java.awt.Color" editor="org.netbeans.beaninfo.editors.ColorEditor">
+                          <Color blue="ff" green="ff" red="ff" type="rgb"/>
+                        </Property>
+                        <Property name="font" type="java.awt.Font" editor="org.netbeans.beaninfo.editors.FontEditor">
+                          <Font name="Helvetica" size="10" style="1"/>
+                        </Property>
+                        <Property name="text" type="java.lang.String" value="Default"/>
+                        <Property name="border" type="javax.swing.border.Border" editor="org.netbeans.modules.form.editors2.BorderEditor">
+                          <Border info="org.netbeans.modules.form.compat2.border.LineBorderInfo">
+                            <LineBorder/>
+                          </Border>
+                        </Property>
+                        <Property name="contentAreaFilled" type="boolean" value="false"/>
+                        <Property name="margin" type="java.awt.Insets" editor="org.netbeans.beaninfo.editors.InsetsEditor">
+                          <Insets value="[0, 0, 0, 0]"/>
+                        </Property>
+                        <Property name="opaque" type="boolean" value="true"/>
+                      </Properties>
+                      <Events>
+                        <EventHandler event="actionPerformed" listener="java.awt.event.ActionListener" parameters="java.awt.event.ActionEvent" handler="defaultFilters_buttonActionPerformed"/>
+                      </Events>
+                      <AuxValues>
+                        <AuxValue name="JavaCodeGenerator_CreateCodeCustom" type="java.lang.String" value=" new ET_JButton();"/>
+                      </AuxValues>
+                      <Constraints>
+                        <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.DesignAbsoluteLayout" value="org.netbeans.modules.form.compat2.layouts.DesignAbsoluteLayout$AbsoluteConstraintsDescription">
+                          <AbsoluteConstraints x="500" y="50" width="40" height="18"/>
                         </Constraint>
                       </Constraints>
                     </Component>

--- a/src/main/java/org/earthtime/UPb_Redux/dialogs/sampleManagers/sampleDateInterpretationManagers/SampleDateInterpretationsManager.java
+++ b/src/main/java/org/earthtime/UPb_Redux/dialogs/sampleManagers/sampleDateInterpretationManagers/SampleDateInterpretationsManager.java
@@ -1027,6 +1027,7 @@ public class SampleDateInterpretationsManager extends DialogEditor
         commonLeadCorrectionSelectorPDF_checkbox = new javax.swing.JCheckBox();
         DatePbCorrSchemeA_radio = new javax.swing.JRadioButton();
         clearFilters_button =  new ET_JButton();
+        defaultFilters_button =  new ET_JButton();
         jPanel1 = new javax.swing.JPanel();
         writeConcordiaPDF_button =  new ET_JButton();
         close_button =  new ET_JButton();
@@ -1611,7 +1612,7 @@ public class SampleDateInterpretationsManager extends DialogEditor
         positivePctDiscordance_slider.setBackground(new java.awt.Color(241, 230, 255));
         positivePctDiscordance_slider.setFont(new java.awt.Font("Arial", 1, 10)); // NOI18N
         positivePctDiscordance_slider.setMajorTickSpacing(10);
-        positivePctDiscordance_slider.setMinorTickSpacing(2);
+        positivePctDiscordance_slider.setMinorTickSpacing(1);
         positivePctDiscordance_slider.setPaintLabels(true);
         positivePctDiscordance_slider.setPaintTicks(true);
         positivePctDiscordance_slider.setSnapToTicks(true);
@@ -1622,7 +1623,7 @@ public class SampleDateInterpretationsManager extends DialogEditor
         percentUncertainty_slider.setBackground(new java.awt.Color(241, 230, 255));
         percentUncertainty_slider.setFont(new java.awt.Font("Arial", 1, 10)); // NOI18N
         percentUncertainty_slider.setMajorTickSpacing(10);
-        percentUncertainty_slider.setMinorTickSpacing(2);
+        percentUncertainty_slider.setMinorTickSpacing(1);
         percentUncertainty_slider.setPaintLabels(true);
         percentUncertainty_slider.setPaintTicks(true);
         percentUncertainty_slider.setSnapToTicks(true);
@@ -1635,7 +1636,7 @@ public class SampleDateInterpretationsManager extends DialogEditor
         negativePctDiscordance_slider.setMajorTickSpacing(10);
         negativePctDiscordance_slider.setMaximum(0);
         negativePctDiscordance_slider.setMinimum(-100);
-        negativePctDiscordance_slider.setMinorTickSpacing(2);
+        negativePctDiscordance_slider.setMinorTickSpacing(1);
         negativePctDiscordance_slider.setPaintLabels(true);
         negativePctDiscordance_slider.setPaintTicks(true);
         negativePctDiscordance_slider.setSnapToTicks(true);
@@ -1650,7 +1651,7 @@ public class SampleDateInterpretationsManager extends DialogEditor
         positivePctDiscordance_text.setAlignmentX(0.0F);
         positivePctDiscordance_text.setAlignmentY(0.0F);
         positivePctDiscordance_text.setBorder(null);
-        probabilityToolPanel.add(positivePctDiscordance_text, new org.netbeans.lib.awtextra.AbsoluteConstraints(586, 45, 130, 15));
+        probabilityToolPanel.add(positivePctDiscordance_text, new org.netbeans.lib.awtextra.AbsoluteConstraints(586, 45, 150, 15));
 
         negativePctDiscordance_text.setBackground(new java.awt.Color(241, 230, 255));
         negativePctDiscordance_text.setFont(new java.awt.Font("Arial", 1, 10)); // NOI18N
@@ -1659,7 +1660,7 @@ public class SampleDateInterpretationsManager extends DialogEditor
         negativePctDiscordance_text.setAlignmentX(0.0F);
         negativePctDiscordance_text.setAlignmentY(0.0F);
         negativePctDiscordance_text.setBorder(null);
-        probabilityToolPanel.add(negativePctDiscordance_text, new org.netbeans.lib.awtextra.AbsoluteConstraints(365, 45, 130, 15));
+        probabilityToolPanel.add(negativePctDiscordance_text, new org.netbeans.lib.awtextra.AbsoluteConstraints(345, 45, 150, 15));
 
         pctUncertainty_text.setBackground(new java.awt.Color(241, 230, 255));
         pctUncertainty_text.setFont(new java.awt.Font("Arial", 1, 10)); // NOI18N
@@ -1789,7 +1790,7 @@ public class SampleDateInterpretationsManager extends DialogEditor
 
         clearFilters_button.setBackground(new java.awt.Color(255, 255, 255));
         clearFilters_button.setFont(new java.awt.Font("Helvetica", 1, 10)); // NOI18N
-        clearFilters_button.setText("Clear Filters");
+        clearFilters_button.setText("Clear");
         clearFilters_button.setBorder(javax.swing.BorderFactory.createLineBorder(new java.awt.Color(0, 0, 0)));
         clearFilters_button.setContentAreaFilled(false);
         clearFilters_button.setMargin(new java.awt.Insets(0, 0, 0, 0));
@@ -1799,7 +1800,21 @@ public class SampleDateInterpretationsManager extends DialogEditor
                 clearFilters_buttonActionPerformed(evt);
             }
         });
-        probabilityToolPanel.add(clearFilters_button, new org.netbeans.lib.awtextra.AbsoluteConstraints(505, 45, 75, 20));
+        probabilityToolPanel.add(clearFilters_button, new org.netbeans.lib.awtextra.AbsoluteConstraints(540, 50, 40, 18));
+
+        defaultFilters_button.setBackground(new java.awt.Color(255, 255, 255));
+        defaultFilters_button.setFont(new java.awt.Font("Helvetica", 1, 10)); // NOI18N
+        defaultFilters_button.setText("Default");
+        defaultFilters_button.setBorder(javax.swing.BorderFactory.createLineBorder(new java.awt.Color(0, 0, 0)));
+        defaultFilters_button.setContentAreaFilled(false);
+        defaultFilters_button.setMargin(new java.awt.Insets(0, 0, 0, 0));
+        defaultFilters_button.setOpaque(true);
+        defaultFilters_button.addActionListener(new java.awt.event.ActionListener() {
+            public void actionPerformed(java.awt.event.ActionEvent evt) {
+                defaultFilters_buttonActionPerformed(evt);
+            }
+        });
+        probabilityToolPanel.add(defaultFilters_button, new org.netbeans.lib.awtextra.AbsoluteConstraints(500, 50, 40, 18));
 
         normedProbabilityLayeredPane.add(probabilityToolPanel);
         probabilityToolPanel.setBounds(0, 560, 920, 70);
@@ -2383,11 +2398,30 @@ private void lockUnlockHistogramBinsMouseEntered (java.awt.event.MouseEvent evt)
         negativePctDiscordance_slider.setValue(-100);
         positivePctDiscordance_slider.setValue(100);
         percentUncertainty_slider.setValue(100);
+        
+        updateSlidersStatus(negativePctDiscordance_slider);
+        updateSlidersStatus(positivePctDiscordance_slider);
+        updateSlidersStatus(percentUncertainty_slider);
 
         performFilteringPerSliders(true);
 
         parentFrame.refreshReportTableData();
     }//GEN-LAST:event_clearFilters_buttonActionPerformed
+
+    private void defaultFilters_buttonActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_defaultFilters_buttonActionPerformed
+        negativePctDiscordance_slider.setValue(ReduxLabData.getInstance().getDefaultNegPctDiscordanceFilter());
+        positivePctDiscordance_slider.setValue(ReduxLabData.getInstance().getDefaultPosPctDiscordanceFilter());
+        percentUncertainty_slider.setValue(ReduxLabData.getInstance().getDefaultPctUncertaintyFilter());
+        
+        updateSlidersStatus(negativePctDiscordance_slider);
+        updateSlidersStatus(positivePctDiscordance_slider);
+        updateSlidersStatus(percentUncertainty_slider);
+
+        performFilteringPerSliders(false);
+        
+        parentFrame.refreshReportTableData(); 
+        
+    }//GEN-LAST:event_defaultFilters_buttonActionPerformed
 
     // Variables declaration - do not modify//GEN-BEGIN:variables
     private javax.swing.JRadioButton DatePbCorrSchemeA_radio;
@@ -2415,6 +2449,7 @@ private void lockUnlockHistogramBinsMouseEntered (java.awt.event.MouseEvent evt)
     private javax.swing.JScrollPane dateTreeByAliquot_ScrollPane;
     private javax.swing.JScrollPane dateTreeBySample_ScrollPane;
     private javax.swing.JTabbedPane dateTrees_tabs;
+    private javax.swing.JButton defaultFilters_button;
     private javax.swing.JCheckBox ellipseCentersAny2OnToggle_checkbox;
     private javax.swing.JCheckBox ellipseCenters_checkbox;
     private javax.swing.JCheckBox ellipseLabelsAny2OnToggle_checkbox;

--- a/src/main/java/org/earthtime/UPb_Redux/dialogs/sampleManagers/sampleDateInterpretationManagers/SampleDateInterpretationsManager.java
+++ b/src/main/java/org/earthtime/UPb_Redux/dialogs/sampleManagers/sampleDateInterpretationManagers/SampleDateInterpretationsManager.java
@@ -2224,14 +2224,12 @@ private void zoomInProbability_buttonActionPerformed (java.awt.event.ActionEvent
 private void resetGraphProbability_buttonActionPerformed (java.awt.event.ActionEvent evt) {//GEN-FIRST:event_resetGraphProbability_buttonActionPerformed
 
 // oct 2016 removed this behavior and moved it to new button "clear filters"
-
 //    positivePctDiscordance_slider.setValue(100);
 //    negativePctDiscordance_slider.setValue(-100);
 //    percentUncertainty_slider.setValue(100);
 //
 //    ((DateProbabilityDensityPanel) probabilityPanel).//
 //            setSelectedFractions(filterActiveUPbFractions(sample.getUpbFractionsUnknown()));
-
     ((PlottingDetailsDisplayInterface) probabilityPanel).refreshPanel(true, false);
 }//GEN-LAST:event_resetGraphProbability_buttonActionPerformed
 
@@ -2250,19 +2248,23 @@ private void protactiniumCorrectionSelector_checkboxActionPerformed (java.awt.ev
 }//GEN-LAST:event_protactiniumCorrectionSelector_checkboxActionPerformed
 
 private void linkedUnlinkedDiscordanceActionPerformed (java.awt.event.ActionEvent evt) {//GEN-FIRST:event_linkedUnlinkedDiscordanceActionPerformed
-    Icon oldPressed = linkedUnlinkedDiscordance.getPressedIcon();
-    linkedUnlinkedDiscordance.setPressedIcon(linkedUnlinkedDiscordance.getIcon());
-    linkedUnlinkedDiscordance.setIcon(oldPressed);
-    doLinkDiscordances = !doLinkDiscordances;
-    if (doLinkDiscordances) {
-        linkedUnlinkedDiscordance.setToolTipText("Click to Unlock sliders.");
-    } else {
-        linkedUnlinkedDiscordance.setToolTipText("Click to Lock sliders.");
-    }
+    toggleLinkLockDiscordanceSliders();
     // test for linkage
     updateSlidersStatus(positivePctDiscordance_slider);
+    performFilteringPerSliders(false);
 }//GEN-LAST:event_linkedUnlinkedDiscordanceActionPerformed
 
+    private void toggleLinkLockDiscordanceSliders() {
+        Icon oldPressed = linkedUnlinkedDiscordance.getPressedIcon();
+        linkedUnlinkedDiscordance.setPressedIcon(linkedUnlinkedDiscordance.getIcon());
+        linkedUnlinkedDiscordance.setIcon(oldPressed);
+        doLinkDiscordances = !doLinkDiscordances;
+        if (doLinkDiscordances) {
+            linkedUnlinkedDiscordance.setToolTipText("Click to Unlock sliders.");
+        } else {
+            linkedUnlinkedDiscordance.setToolTipText("Click to Lock sliders.");
+        }
+    }
 private void showHistogram_buttonActionPerformed (java.awt.event.ActionEvent evt) {//GEN-FIRST:event_showHistogram_buttonActionPerformed
     toggleShowHistogramButton();
 }//GEN-LAST:event_showHistogram_buttonActionPerformed
@@ -2308,7 +2310,7 @@ private void lockUnlockHistogramBinsMouseEntered (java.awt.event.MouseEvent evt)
 
     String currentBinWidth
             = (new DecimalFormat("###0").//
-            format(((DateProbabilityDensityPanel) probabilityPanel).getAdjustedScottsBinWidth()))//
+                    format(((DateProbabilityDensityPanel) probabilityPanel).getAdjustedScottsBinWidth()))//
             + " Ma";
     if (((DateProbabilityDensityPanel) probabilityPanel).isFreezeHistogramBinWidth()) {
         lockUnlockHistogramBins.setToolTipText("Click to Thaw Histogram bin width from current " //
@@ -2395,12 +2397,15 @@ private void lockUnlockHistogramBinsMouseEntered (java.awt.event.MouseEvent evt)
     }//GEN-LAST:event_sortFractionsDateAsc_menuItemCheckBoxActionPerformed
 
     private void clearFilters_buttonActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_clearFilters_buttonActionPerformed
+
+        if (!doLinkDiscordances) {
+            toggleLinkLockDiscordanceSliders();
+        }
+
         negativePctDiscordance_slider.setValue(-100);
-        positivePctDiscordance_slider.setValue(100);
-        percentUncertainty_slider.setValue(100);
-        
         updateSlidersStatus(negativePctDiscordance_slider);
-        updateSlidersStatus(positivePctDiscordance_slider);
+
+        percentUncertainty_slider.setValue(100);
         updateSlidersStatus(percentUncertainty_slider);
 
         performFilteringPerSliders(true);
@@ -2409,18 +2414,32 @@ private void lockUnlockHistogramBinsMouseEntered (java.awt.event.MouseEvent evt)
     }//GEN-LAST:event_clearFilters_buttonActionPerformed
 
     private void defaultFilters_buttonActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_defaultFilters_buttonActionPerformed
-        negativePctDiscordance_slider.setValue(ReduxLabData.getInstance().getDefaultNegPctDiscordanceFilter());
-        positivePctDiscordance_slider.setValue(ReduxLabData.getInstance().getDefaultPosPctDiscordanceFilter());
+
+        int negPctDis = ReduxLabData.getInstance().getDefaultNegPctDiscordanceFilter();
+        int posPctDis = ReduxLabData.getInstance().getDefaultPosPctDiscordanceFilter();
+        boolean testDoLinkDiscordances = (Math.abs(negPctDis) == posPctDis);
+        if (doLinkDiscordances != testDoLinkDiscordances) {
+            toggleLinkLockDiscordanceSliders();
+        }
+
+        if (doLinkDiscordances) {
+            negativePctDiscordance_slider.setValue(ReduxLabData.getInstance().getDefaultNegPctDiscordanceFilter());
+            updateSlidersStatus(negativePctDiscordance_slider);
+
+        } else {
+            negativePctDiscordance_slider.setValue(ReduxLabData.getInstance().getDefaultNegPctDiscordanceFilter());
+            positivePctDiscordance_slider.setValue(ReduxLabData.getInstance().getDefaultPosPctDiscordanceFilter());
+            updateSlidersStatus(negativePctDiscordance_slider);
+            updateSlidersStatus(positivePctDiscordance_slider);
+        }
+
         percentUncertainty_slider.setValue(ReduxLabData.getInstance().getDefaultPctUncertaintyFilter());
-        
-        updateSlidersStatus(negativePctDiscordance_slider);
-        updateSlidersStatus(positivePctDiscordance_slider);
         updateSlidersStatus(percentUncertainty_slider);
 
         performFilteringPerSliders(false);
-        
-        parentFrame.refreshReportTableData(); 
-        
+
+        parentFrame.refreshReportTableData();
+
     }//GEN-LAST:event_defaultFilters_buttonActionPerformed
 
     // Variables declaration - do not modify//GEN-BEGIN:variables
@@ -2672,8 +2691,8 @@ private void lockUnlockHistogramBinsMouseEntered (java.awt.event.MouseEvent evt)
                 Vector<ETFractionInterface> tempDeselected
                         = //
                         ((ReduxAliquotInterface) aliquotNodeInfo).//
-                        getAliquotSampleDateModelDeSelectedFractions(((SampleDateModel) nodeInfo).//
-                                getIncludedFractionIDsVector());
+                                getAliquotSampleDateModelDeSelectedFractions(((SampleDateModel) nodeInfo).//
+                                        getIncludedFractionIDsVector());
                 ((DateProbabilityDensityPanel) probabilityPanel).//
                         setDeSelectedFractions(filterActiveUPbFractions(tempDeselected));
 
@@ -2690,12 +2709,12 @@ private void lockUnlockHistogramBinsMouseEntered (java.awt.event.MouseEvent evt)
                 Object aliquotNodeInfo
                         = //
                         ((DefaultMutableTreeNode) //
-                        ((TreeNode) node).getParent().getParent()).getUserObject();
+                                ((TreeNode) node).getParent().getParent()).getUserObject();
 
                 Object sampleDateNodeInfo
                         = //
                         ((DefaultMutableTreeNode) //
-                        ((TreeNode) node).getParent()).getUserObject();
+                                ((TreeNode) node).getParent()).getUserObject();
 
                 if (graphPanels_TabbedPane.getSelectedIndex() == graphPanels_TabbedPane.indexOfTab("Concordia")) {
 
@@ -2744,8 +2763,8 @@ private void lockUnlockHistogramBinsMouseEntered (java.awt.event.MouseEvent evt)
                     Vector<ETFractionInterface> tempDeselected
                             = //
                             ((ReduxAliquotInterface) aliquotNodeInfo).//
-                            getAliquotSampleDateModelDeSelectedFractions(((SampleDateModel) sampleDateNodeInfo).//
-                                    getIncludedFractionIDsVector());
+                                    getAliquotSampleDateModelDeSelectedFractions(((SampleDateModel) sampleDateNodeInfo).//
+                                            getIncludedFractionIDsVector());
                     ((DateProbabilityDensityPanel) probabilityPanel).//
                             setDeSelectedFractions(filterActiveUPbFractions(tempDeselected));
                     probabilityPanel.repaint();
@@ -2776,8 +2795,8 @@ private void lockUnlockHistogramBinsMouseEntered (java.awt.event.MouseEvent evt)
             // oct 2014 modified to be sure to work no matter where text is clicked
             ((CheckBoxNode) nodeInfo).setSelected(//
                     ((SampleDateModel) sampleDateNodeInfo).//
-                    ToggleAliquotFractionByName(//
-                            temp[0].trim()));//,
+                            ToggleAliquotFractionByName(//
+                                    temp[0].trim()));//,
 
             SampleInterface.updateAndSaveSampleDateModelsByAliquot(sample);
 
@@ -2827,8 +2846,8 @@ private void lockUnlockHistogramBinsMouseEntered (java.awt.event.MouseEvent evt)
                 Vector<ETFractionInterface> tempDeselected
                         = //
                         ((ReduxAliquotInterface) aliquotNodeInfo).//
-                        getAliquotSampleDateModelDeSelectedFractions(((SampleDateModel) sampleDateNodeInfo).//
-                                getIncludedFractionIDsVector());
+                                getAliquotSampleDateModelDeSelectedFractions(((SampleDateModel) sampleDateNodeInfo).//
+                                        getIncludedFractionIDsVector());
                 ((DateProbabilityDensityPanel) probabilityPanel).//
                         setDeSelectedFractions(filterActiveUPbFractions(tempDeselected));
                 probabilityPanel.repaint();
@@ -2905,12 +2924,12 @@ private void lockUnlockHistogramBinsMouseEntered (java.awt.event.MouseEvent evt)
                 Object sampleNodeInfo
                         = //
                         ((DefaultMutableTreeNode) //
-                        ((TreeNode) node).getParent().getParent()).getUserObject();
+                                ((TreeNode) node).getParent().getParent()).getUserObject();
 
                 Object sampleDateNodeInfo
                         = //
                         ((DefaultMutableTreeNode) //
-                        ((TreeNode) node).getParent()).getUserObject();
+                                ((TreeNode) node).getParent()).getUserObject();
 
                 // check for special case interpretations: lower and upper intercepts
                 ((ConcordiaGraphPanel) concordiaGraphPanel).//
@@ -2963,8 +2982,8 @@ private void lockUnlockHistogramBinsMouseEntered (java.awt.event.MouseEvent evt)
             // oct 2014 modified to be sure to work no matter where text is clicked
             ((CheckBoxNode) nodeInfo).setSelected(//
                     ((SampleDateModel) sampleDateNodeInfo).//
-                    ToggleSampleFractionByName(//
-                            temp[0].trim()));//,
+                            ToggleSampleFractionByName(//
+                                    temp[0].trim()));//,
 
             sample.updateSampleDateModels();
 

--- a/src/main/java/org/earthtime/UPb_Redux/dialogs/sessionManagers/SessionAnalysisWorkflowManagerLAICPMS.form
+++ b/src/main/java/org/earthtime/UPb_Redux/dialogs/sessionManagers/SessionAnalysisWorkflowManagerLAICPMS.form
@@ -182,7 +182,11 @@
     </Container>
     <Container class="javax.swing.JTabbedPane" name="tripoliDataProcessing_tabbedPane">
       <Properties>
+        <Property name="background" type="java.awt.Color" editor="org.netbeans.beaninfo.editors.ColorEditor">
+          <Color blue="e6" green="f0" red="fa" type="rgb"/>
+        </Property>
         <Property name="tabPlacement" type="int" value="3"/>
+        <Property name="opaque" type="boolean" value="true"/>
       </Properties>
       <Events>
         <EventHandler event="componentResized" listener="java.awt.event.ComponentListener" parameters="java.awt.event.ComponentEvent" handler="tripoliDataProcessing_tabbedPaneComponentResized"/>
@@ -531,10 +535,14 @@
                 </Component>
                 <Component class="javax.swing.JSlider" name="yAxisZoomSlider">
                   <Properties>
+                    <Property name="background" type="java.awt.Color" editor="org.netbeans.beaninfo.editors.ColorEditor">
+                      <Color blue="e6" green="f0" red="fa" type="rgb"/>
+                    </Property>
                     <Property name="maximum" type="int" value="320"/>
                     <Property name="minimum" type="int" value="64"/>
                     <Property name="orientation" type="int" value="1"/>
                     <Property name="value" type="int" value="128"/>
+                    <Property name="opaque" type="boolean" value="true"/>
                   </Properties>
                   <Constraints>
                     <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.DesignAbsoluteLayout" value="org.netbeans.modules.form.compat2.layouts.DesignAbsoluteLayout$AbsoluteConstraintsDescription">
@@ -1239,11 +1247,12 @@
             <Component class="javax.swing.JSlider" name="xAxisZoomSlider">
               <Properties>
                 <Property name="background" type="java.awt.Color" editor="org.netbeans.beaninfo.editors.ColorEditor">
-                  <Color blue="e4" green="e4" red="e6" type="rgb"/>
+                  <Color blue="e6" green="f0" red="fa" type="rgb"/>
                 </Property>
                 <Property name="maximum" type="int" value="640"/>
                 <Property name="minimum" type="int" value="4"/>
                 <Property name="value" type="int" value="128"/>
+                <Property name="opaque" type="boolean" value="true"/>
               </Properties>
               <AuxValues>
                 <AuxValue name="JLayeredPane.layer" type="java.lang.Integer" value="100"/>

--- a/src/main/java/org/earthtime/UPb_Redux/dialogs/sessionManagers/SessionAnalysisWorkflowManagerLAICPMS.java
+++ b/src/main/java/org/earthtime/UPb_Redux/dialogs/sessionManagers/SessionAnalysisWorkflowManagerLAICPMS.java
@@ -891,7 +891,9 @@ public class SessionAnalysisWorkflowManagerLAICPMS extends DialogEditor //
         });
         toolBar_panel.add(switchToReductionManager_button, new org.netbeans.lib.awtextra.AbsoluteConstraints(115, 3, 180, 20));
 
+        tripoliDataProcessing_tabbedPane.setBackground(new java.awt.Color(250, 240, 230));
         tripoliDataProcessing_tabbedPane.setTabPlacement(javax.swing.JTabbedPane.BOTTOM);
+        tripoliDataProcessing_tabbedPane.setOpaque(true);
         tripoliDataProcessing_tabbedPane.addComponentListener(new java.awt.event.ComponentAdapter() {
             public void componentResized(java.awt.event.ComponentEvent evt) {
                 tripoliDataProcessing_tabbedPaneComponentResized(evt);
@@ -1070,10 +1072,12 @@ public class SessionAnalysisWorkflowManagerLAICPMS extends DialogEditor //
         controlPanel_panel.add(jLabel4);
         jLabel4.setBounds(10, 145, 170, 13);
 
+        yAxisZoomSlider.setBackground(new java.awt.Color(250, 240, 230));
         yAxisZoomSlider.setMaximum(320);
         yAxisZoomSlider.setMinimum(64);
         yAxisZoomSlider.setOrientation(javax.swing.JSlider.VERTICAL);
         yAxisZoomSlider.setValue(128);
+        yAxisZoomSlider.setOpaque(true);
         controlPanel_panel.add(yAxisZoomSlider);
         yAxisZoomSlider.setBounds(1, 420, 20, 190);
 
@@ -1413,10 +1417,11 @@ public class SessionAnalysisWorkflowManagerLAICPMS extends DialogEditor //
         tripoliTab_layeredPane.add(controlPanel_panel);
         controlPanel_panel.setBounds(0, 0, 191, 620);
 
-        xAxisZoomSlider.setBackground(new java.awt.Color(230, 228, 228));
+        xAxisZoomSlider.setBackground(new java.awt.Color(250, 240, 230));
         xAxisZoomSlider.setMaximum(640);
         xAxisZoomSlider.setMinimum(4);
         xAxisZoomSlider.setValue(128);
+        xAxisZoomSlider.setOpaque(true);
         tripoliTab_layeredPane.setLayer(xAxisZoomSlider, javax.swing.JLayeredPane.PALETTE_LAYER);
         tripoliTab_layeredPane.add(xAxisZoomSlider);
         xAxisZoomSlider.setBounds(110, 600, 400, 20);

--- a/src/main/java/org/earthtime/UPb_Redux/user/ReduxPersistentState.java
+++ b/src/main/java/org/earthtime/UPb_Redux/user/ReduxPersistentState.java
@@ -65,8 +65,10 @@ public class ReduxPersistentState implements Serializable {
     private File MRUProjectFile;
     private ArrayList<String> MRUProjectList;
     private String MRUProjectFolderPath;
-    // oct 2016 manage mru for LAICPMS file handling protocols - save name of last used
-    private String mruFileHandlingProtocolForLAICPMS;
+    // oct 2016 manage mru for file handling protocols - save name of last used
+    private String mruFileHandlingProtocol;
+    private String mruRawDataTemplate;
+    private String mruPurpose;
 
     /**
      *
@@ -106,8 +108,10 @@ public class ReduxPersistentState implements Serializable {
         }
 
         MRUProjectFile = null;
-        
-        mruFileHandlingProtocolForLAICPMS = "";
+
+        mruFileHandlingProtocol = "";
+        mruRawDataTemplate = "";
+        mruPurpose = "";
 
         serializeSelf();
     }
@@ -468,19 +472,53 @@ public class ReduxPersistentState implements Serializable {
     }
 
     /**
-     * @return the mruFileHandlingProtocolForLAICPMS
+     * @return the mruFileHandlingProtocol
      */
-    public String getMruFileHandlingProtocolForLAICPMS() {
-        if (mruFileHandlingProtocolForLAICPMS == null){
-            mruFileHandlingProtocolForLAICPMS = "";
+    public String getMruFileHandlingProtocol() {
+        if (mruFileHandlingProtocol == null) {
+            mruFileHandlingProtocol = "";
         }
-        return mruFileHandlingProtocolForLAICPMS;
+        return mruFileHandlingProtocol;
     }
 
     /**
-     * @param mruFileHandlingProtocolForLAICPMS the mruFileHandlingProtocolForLAICPMS to set
+     * @param mruFileHandlingProtocol the mruFileHandlingProtocol to set
      */
-    public void setMruFileHandlingProtocolForLAICPMS(String mruFileHandlingProtocolForLAICPMS) {
-        this.mruFileHandlingProtocolForLAICPMS = mruFileHandlingProtocolForLAICPMS;
+    public void setMruFileHandlingProtocol(String mruFileHandlingProtocol) {
+        this.mruFileHandlingProtocol = mruFileHandlingProtocol;
+    }
+
+    /**
+     * @return the mruRawDataTemplate
+     */
+    public String getMruRawDataTemplate() {
+        if (mruRawDataTemplate == null) {
+            mruRawDataTemplate = "";
+        }
+        return mruRawDataTemplate;
+    }
+
+    /**
+     * @param mruRawDataTemplate the mruRawDataTemplate to set
+     */
+    public void setMruRawDataTemplate(String mruRawDataTemplate) {
+        this.mruRawDataTemplate = mruRawDataTemplate;
+    }
+
+    /**
+     * @return the mruPurpose
+     */
+    public String getMruPurpose() {
+        if (mruPurpose == null) {
+            mruPurpose = "";
+        }
+        return mruPurpose;
+    }
+
+    /**
+     * @param mruPurpose the mruPurpose to set
+     */
+    public void setMruPurpose(String mruPurpose) {
+        this.mruPurpose = mruPurpose;
     }
 }

--- a/src/main/java/org/earthtime/dialogs/LabDataEditorDialog.form
+++ b/src/main/java/org/earthtime/dialogs/LabDataEditorDialog.form
@@ -597,6 +597,9 @@
   <Properties>
     <Property name="defaultCloseOperation" type="int" value="2"/>
     <Property name="alwaysOnTop" type="boolean" value="true"/>
+    <Property name="preferredSize" type="java.awt.Dimension" editor="org.netbeans.beaninfo.editors.DimensionEditor">
+      <Dimension value="[1113, 770]"/>
+    </Property>
     <Property name="resizable" type="boolean" value="false"/>
   </Properties>
   <SyntheticProperties>
@@ -644,13 +647,15 @@
         <DimensionLayout dim="1">
           <Group type="103" groupAlignment="0" attributes="0">
               <Group type="102" attributes="0">
-                  <Component id="header_Panel" min="-2" max="-2" attributes="0"/>
-                  <EmptySpace min="649" pref="649" max="-2" attributes="0"/>
-                  <Component id="buttonsPanel" min="-2" max="-2" attributes="0"/>
-              </Group>
-              <Group type="102" attributes="0">
-                  <EmptySpace min="24" pref="24" max="-2" attributes="0"/>
-                  <Component id="details_pane" min="-2" pref="660" max="-2" attributes="0"/>
+                  <Group type="103" groupAlignment="0" attributes="0">
+                      <Component id="header_Panel" min="-2" max="-2" attributes="0"/>
+                      <Group type="102" attributes="0">
+                          <EmptySpace min="24" pref="24" max="-2" attributes="0"/>
+                          <Component id="details_pane" min="-2" pref="660" max="-2" attributes="0"/>
+                      </Group>
+                  </Group>
+                  <EmptySpace max="32767" attributes="0"/>
+                  <Component id="buttonsPanel" min="-2" pref="35" max="-2" attributes="0"/>
               </Group>
           </Group>
         </DimensionLayout>
@@ -2696,21 +2701,8 @@
             </Property>
           </Properties>
 
-          <Layout>
-            <DimensionLayout dim="0">
-              <Group type="103" groupAlignment="0" attributes="0">
-                  <Group type="102" alignment="0" attributes="0">
-                      <EmptySpace max="-2" attributes="0"/>
-                      <Component id="save_button" max="32767" attributes="0"/>
-                      <EmptySpace max="-2" attributes="0"/>
-                  </Group>
-              </Group>
-            </DimensionLayout>
-            <DimensionLayout dim="1">
-              <Group type="103" groupAlignment="0" attributes="0">
-                  <Component id="save_button" alignment="0" pref="36" max="32767" attributes="0"/>
-              </Group>
-            </DimensionLayout>
+          <Layout class="org.netbeans.modules.form.compat2.layouts.DesignAbsoluteLayout">
+            <Property name="useNullLayout" type="boolean" value="false"/>
           </Layout>
           <SubComponents>
             <Component class="javax.swing.JButton" name="save_button">
@@ -2735,6 +2727,11 @@
               <AuxValues>
                 <AuxValue name="JavaCodeGenerator_CreateCodeCustom" type="java.lang.String" value=" new ET_JButton(&quot;OK&quot;);"/>
               </AuxValues>
+              <Constraints>
+                <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.DesignAbsoluteLayout" value="org.netbeans.modules.form.compat2.layouts.DesignAbsoluteLayout$AbsoluteConstraintsDescription">
+                  <AbsoluteConstraints x="8" y="6" width="1097" height="25"/>
+                </Constraint>
+              </Constraints>
             </Component>
           </SubComponents>
         </Container>

--- a/src/main/java/org/earthtime/dialogs/LabDataEditorDialog.form
+++ b/src/main/java/org/earthtime/dialogs/LabDataEditorDialog.form
@@ -2613,12 +2613,21 @@
               </Layout>
               <SubComponents>
                 <Component class="javax.swing.JComboBox" name="defaultLAICPMSPrimaryMineralStandardModel_Chooser">
+                  <Properties>
+                    <Property name="background" type="java.awt.Color" editor="org.netbeans.beaninfo.editors.ColorEditor">
+                      <Color blue="ff" green="ff" red="ff" type="rgb"/>
+                    </Property>
+                    <Property name="font" type="java.awt.Font" editor="org.netbeans.beaninfo.editors.FontEditor">
+                      <Font name="Lucida Sans" size="12" style="0"/>
+                    </Property>
+                    <Property name="opaque" type="boolean" value="true"/>
+                  </Properties>
                   <AuxValues>
                     <AuxValue name="JavaCodeGenerator_TypeParameters" type="java.lang.String" value="&lt;String&gt;"/>
                   </AuxValues>
                   <Constraints>
                     <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.DesignAbsoluteLayout" value="org.netbeans.modules.form.compat2.layouts.DesignAbsoluteLayout$AbsoluteConstraintsDescription">
-                      <AbsoluteConstraints x="475" y="60" width="350" height="-1"/>
+                      <AbsoluteConstraints x="475" y="60" width="360" height="-1"/>
                     </Constraint>
                   </Constraints>
                 </Component>

--- a/src/main/java/org/earthtime/dialogs/LabDataEditorDialog.java
+++ b/src/main/java/org/earthtime/dialogs/LabDataEditorDialog.java
@@ -297,12 +297,10 @@ public class LabDataEditorDialog extends DialogEditor {
                 tracersTab_panel.getWidth(), tracersTab_panel.getHeight() - VERTICAL_OFFSET_MODEL_VIEW);
         if (editable) {
             tracerModelView
-                    = //
-                    new TracerUPbRatiosDataViewEditable(tracerModel, tracerViewDimension, false);
+                    = new TracerUPbRatiosDataViewEditable(tracerModel, tracerViewDimension, false);
         } else {
             tracerModelView
-                    = //
-                    new TracerUPbRatiosDataViewNotEditable(tracerModel, tracerViewDimension, false);
+                    = new TracerUPbRatiosDataViewNotEditable(tracerModel, tracerViewDimension, false);
         }
 
         tracerModelView.setBackground(tracersTab_panel.getBackground());
@@ -1533,12 +1531,10 @@ public class LabDataEditorDialog extends DialogEditor {
 
         if (editable) {
             initialPbModelView
-                    = //
-                    new RatiosDataViewEditable(initialPbModel, initialPbModelsTab_panel.getSize(), false);
+                    = new RatiosDataViewEditable(initialPbModel, initialPbModelsTab_panel.getSize(), false);
         } else {
             initialPbModelView
-                    = //
-                    new RatiosDataViewNotEditable(initialPbModel, initialPbModelsTab_panel.getSize(), false);
+                    = new RatiosDataViewNotEditable(initialPbModel, initialPbModelsTab_panel.getSize(), false);
         }
 
         initialPbModelView.setBackground(initialPbModelsTab_panel.getBackground());
@@ -2134,12 +2130,10 @@ public class LabDataEditorDialog extends DialogEditor {
 
         if (editable) {
             mineralStandardModelView
-                    = //
-                    new ReferenceMaterialUPbRatiosDataViewEditable(mineralStandardModel, mineralStandard_panel.getSize(), false);
+                    = new ReferenceMaterialUPbRatiosDataViewEditable(mineralStandardModel, mineralStandard_panel.getSize(), false);
         } else {
             mineralStandardModelView
-                    = //
-                    new ReferenceMaterialUPbRatiosDataViewNotEditable(mineralStandardModel, mineralStandard_panel.getSize(), false);
+                    = new ReferenceMaterialUPbRatiosDataViewNotEditable(mineralStandardModel, mineralStandard_panel.getSize(), false);
         }
 
         mineralStandardModelView.setBounds(mineralStandard_panel.getBounds());
@@ -2901,7 +2895,7 @@ public class LabDataEditorDialog extends DialogEditor {
      *
      */
     public void setSize() {
-        setSize(1113, 765);
+        setSize(1113, 770);
     }
 
     private void exitLabData()
@@ -3219,6 +3213,7 @@ public class LabDataEditorDialog extends DialogEditor {
 
         setDefaultCloseOperation(javax.swing.WindowConstants.DISPOSE_ON_CLOSE);
         setAlwaysOnTop(true);
+        setPreferredSize(new java.awt.Dimension(1113, 770));
         setResizable(false);
         addWindowListener(new java.awt.event.WindowAdapter() {
             public void windowClosing(java.awt.event.WindowEvent evt) {
@@ -4336,6 +4331,7 @@ public class LabDataEditorDialog extends DialogEditor {
 
         buttonsPanel.setBackground(new java.awt.Color(252, 236, 235));
         buttonsPanel.setBorder(javax.swing.BorderFactory.createBevelBorder(javax.swing.border.BevelBorder.LOWERED));
+        buttonsPanel.setLayout(new org.netbeans.lib.awtextra.AbsoluteLayout());
 
         save_button.setFont(new java.awt.Font("Arial", 1, 14)); // NOI18N
         save_button.setForeground(new java.awt.Color(255, 51, 0));
@@ -4347,20 +4343,7 @@ public class LabDataEditorDialog extends DialogEditor {
                 save_buttonActionPerformed(evt);
             }
         });
-
-        org.jdesktop.layout.GroupLayout buttonsPanelLayout = new org.jdesktop.layout.GroupLayout(buttonsPanel);
-        buttonsPanel.setLayout(buttonsPanelLayout);
-        buttonsPanelLayout.setHorizontalGroup(
-            buttonsPanelLayout.createParallelGroup(org.jdesktop.layout.GroupLayout.LEADING)
-            .add(buttonsPanelLayout.createSequentialGroup()
-                .addContainerGap()
-                .add(save_button, org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
-                .addContainerGap())
-        );
-        buttonsPanelLayout.setVerticalGroup(
-            buttonsPanelLayout.createParallelGroup(org.jdesktop.layout.GroupLayout.LEADING)
-            .add(save_button, org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, 36, Short.MAX_VALUE)
-        );
+        buttonsPanel.add(save_button, new org.netbeans.lib.awtextra.AbsoluteConstraints(8, 6, 1097, 25));
 
         labPane_layered.setLayer(details_pane, javax.swing.JLayeredPane.DEFAULT_LAYER);
         labPane_layered.setLayer(header_Panel, javax.swing.JLayeredPane.DEFAULT_LAYER);
@@ -4377,12 +4360,13 @@ public class LabDataEditorDialog extends DialogEditor {
         labPane_layeredLayout.setVerticalGroup(
             labPane_layeredLayout.createParallelGroup(org.jdesktop.layout.GroupLayout.LEADING)
             .add(labPane_layeredLayout.createSequentialGroup()
-                .add(header_Panel, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE, org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE)
-                .add(649, 649, 649)
-                .add(buttonsPanel, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE, org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE))
-            .add(labPane_layeredLayout.createSequentialGroup()
-                .add(24, 24, 24)
-                .add(details_pane, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE, 660, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE))
+                .add(labPane_layeredLayout.createParallelGroup(org.jdesktop.layout.GroupLayout.LEADING)
+                    .add(header_Panel, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE, org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE)
+                    .add(labPane_layeredLayout.createSequentialGroup()
+                        .add(24, 24, 24)
+                        .add(details_pane, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE, 660, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE)))
+                .addPreferredGap(org.jdesktop.layout.LayoutStyle.RELATED, org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
+                .add(buttonsPanel, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE, 35, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE))
         );
 
         fileMenu_menu.setText("File");

--- a/src/main/java/org/earthtime/dialogs/LabDataEditorDialog.java
+++ b/src/main/java/org/earthtime/dialogs/LabDataEditorDialog.java
@@ -119,6 +119,10 @@ public class LabDataEditorDialog extends DialogEditor {
     private JTextField default206_207irmrText;
     private JTextField default208_232irmrText;
 
+    private JTextField defaultNegPctDiscordanceText;
+    private JTextField defaultPosPctDiscordanceText;
+    private JTextField defaultPctUncertaintyText;
+
     /**
      * Creates new form LabDataEditorDialog
      *
@@ -649,7 +653,7 @@ public class LabDataEditorDialog extends DialogEditor {
         alphaUName_label.setForeground(
                 (alphaU.getName().equalsIgnoreCase(
                         myLabData.getDefaultLabAlphaUModel().getName()))
-                        ? Color.RED : Color.BLACK);
+                ? Color.RED : Color.BLACK);
 
         alphaUName_text.setText(alphaU.getName());
 
@@ -937,7 +941,7 @@ public class LabDataEditorDialog extends DialogEditor {
         alphaPbName_label.setForeground(
                 (alphaPb.getName().equalsIgnoreCase(
                         myLabData.getDefaultLabAlphaPbModel().getName()))
-                        ? Color.RED : Color.BLACK);
+                ? Color.RED : Color.BLACK);
 
         alphaPbName_text.setText(alphaPb.getName());
 
@@ -2493,75 +2497,75 @@ public class LabDataEditorDialog extends DialogEditor {
         // default Pb Blank mass
         defaultPbBlankMass_text.setText(
                 myLabData.getDefaultPbBlankMassInGrams().getValue().//
-                multiply(ReduxConstants.PicoGramsPerGram).//
-                setScale(ReduxConstants.DEFAULT_MASS_DISPLAY_SCALE, RoundingMode.HALF_UP).toPlainString());
+                        multiply(ReduxConstants.PicoGramsPerGram).//
+                        setScale(ReduxConstants.DEFAULT_MASS_DISPLAY_SCALE, RoundingMode.HALF_UP).toPlainString());
         defaultPbBlankMassOneSigma_text.setText(
                 myLabData.getDefaultPbBlankMassInGrams().getOneSigma().//
-                multiply(ReduxConstants.PicoGramsPerGram).//
-                setScale(ReduxConstants.DEFAULT_MASS_DISPLAY_SCALE, RoundingMode.HALF_UP).toPlainString());
+                        multiply(ReduxConstants.PicoGramsPerGram).//
+                        setScale(ReduxConstants.DEFAULT_MASS_DISPLAY_SCALE, RoundingMode.HALF_UP).toPlainString());
 
         // assumed U Blank mass
         defaultUBlankMass_text.setText(
                 myLabData.getDefaultAssumedUBlankMassInGrams().getValue().//
-                multiply(ReduxConstants.PicoGramsPerGram).//
-                setScale(ReduxConstants.DEFAULT_MASS_DISPLAY_SCALE, RoundingMode.HALF_UP).toPlainString());
+                        multiply(ReduxConstants.PicoGramsPerGram).//
+                        setScale(ReduxConstants.DEFAULT_MASS_DISPLAY_SCALE, RoundingMode.HALF_UP).toPlainString());
         defaultUBlankMassOneSigma_text.setText(
                 myLabData.getDefaultAssumedUBlankMassInGrams().getOneSigma().
-                multiply(ReduxConstants.PicoGramsPerGram).//
-                setScale(ReduxConstants.DEFAULT_MASS_DISPLAY_SCALE, RoundingMode.HALF_UP).toPlainString());
+                        multiply(ReduxConstants.PicoGramsPerGram).//
+                        setScale(ReduxConstants.DEFAULT_MASS_DISPLAY_SCALE, RoundingMode.HALF_UP).toPlainString());
 
         // default r18O_16O
         default18O_16O_text.setText(
                 myLabData.getDefaultR18O_16O().getValue()//
-                .setScale(ReduxConstants.DEFAULT_DEFAULTS_SCALE, RoundingMode.HALF_UP).toPlainString());
+                        .setScale(ReduxConstants.DEFAULT_DEFAULTS_SCALE, RoundingMode.HALF_UP).toPlainString());
         default18O_16OOneSigma_text.setText(
                 myLabData.getDefaultR18O_16O().getOneSigma()//
-                .setScale(ReduxConstants.DEFAULT_DEFAULTS_SCALE, RoundingMode.HALF_UP).toPlainString());
+                        .setScale(ReduxConstants.DEFAULT_DEFAULTS_SCALE, RoundingMode.HALF_UP).toPlainString());
 
         // default r238_235b
         defaultR238_235b_text.setText(
                 myLabData.getDefaultR238_235b().getValue()//
-                .setScale(ReduxConstants.DEFAULT_PARAMETERS_SCALE, RoundingMode.HALF_UP).toPlainString());
+                        .setScale(ReduxConstants.DEFAULT_PARAMETERS_SCALE, RoundingMode.HALF_UP).toPlainString());
         defaultR238_235bOneSigma_text.setText(
                 myLabData.getDefaultR238_235b().getOneSigma()//
-                .setScale(ReduxConstants.DEFAULT_PARAMETERS_SCALE, RoundingMode.HALF_UP).toPlainString());
+                        .setScale(ReduxConstants.DEFAULT_PARAMETERS_SCALE, RoundingMode.HALF_UP).toPlainString());
 
         // default r238_235s
         defaultR238_235s_text.setText(
                 myLabData.getDefaultR238_235s().getValue()//
-                .setScale(ReduxConstants.DEFAULT_PARAMETERS_SCALE, RoundingMode.HALF_UP).toPlainString());
+                        .setScale(ReduxConstants.DEFAULT_PARAMETERS_SCALE, RoundingMode.HALF_UP).toPlainString());
         defaultR238_235sOneSigma_text.setText(
                 myLabData.getDefaultR238_235s().getOneSigma()//
-                .setScale(ReduxConstants.DEFAULT_PARAMETERS_SCALE, RoundingMode.HALF_UP).toPlainString());
+                        .setScale(ReduxConstants.DEFAULT_PARAMETERS_SCALE, RoundingMode.HALF_UP).toPlainString());
 
         // default tracerModel mass uncertainty
         defaultTracerMassOneSigma_text.setText(
                 myLabData.getDefaultTracerMass().getOneSigma()//
-                .setScale(ReduxConstants.DEFAULT_MASS_DISPLAY_SCALE, RoundingMode.HALF_UP).toPlainString());
+                        .setScale(ReduxConstants.DEFAULT_MASS_DISPLAY_SCALE, RoundingMode.HALF_UP).toPlainString());
 
         // default rTh_Umagma
         defaultRTh_Umagma_text.setText(
                 myLabData.getDefaultRTh_Umagma().getValue()//
-                .setScale(ReduxConstants.DEFAULT_PARAMETERS_SCALE, RoundingMode.HALF_UP).toPlainString());
+                        .setScale(ReduxConstants.DEFAULT_PARAMETERS_SCALE, RoundingMode.HALF_UP).toPlainString());
         defaultRTh_UmagmaOneSigma_text.setText(
                 myLabData.getDefaultRTh_Umagma().getOneSigma()//
-                .setScale(ReduxConstants.DEFAULT_PARAMETERS_SCALE, RoundingMode.HALF_UP).toPlainString());
+                        .setScale(ReduxConstants.DEFAULT_PARAMETERS_SCALE, RoundingMode.HALF_UP).toPlainString());
 
         // default ar231_235sample
         defaultAr231_235sample_text.setText(
                 myLabData.getDefaultAr231_235sample().getValue()//
-                .setScale(ReduxConstants.DEFAULT_PARAMETERS_SCALE, RoundingMode.HALF_UP).toPlainString());
+                        .setScale(ReduxConstants.DEFAULT_PARAMETERS_SCALE, RoundingMode.HALF_UP).toPlainString());
         defaultAr231_235sampleOneSigma_text.setText(
                 myLabData.getDefaultAr231_235sample().getOneSigma()//
-                .setScale(ReduxConstants.DEFAULT_PARAMETERS_SCALE, RoundingMode.HALF_UP).toPlainString());
+                        .setScale(ReduxConstants.DEFAULT_PARAMETERS_SCALE, RoundingMode.HALF_UP).toPlainString());
 
         // default stacey kramers settings
         defaultStaceyKramersRelativeUnct_text.setText(
                 myLabData.getDefaultStaceyKramersOnePctUnct().//
-                setScale(ReduxConstants.DEFAULT_PARAMETERS_SCALE, RoundingMode.HALF_UP).toPlainString());
+                        setScale(ReduxConstants.DEFAULT_PARAMETERS_SCALE, RoundingMode.HALF_UP).toPlainString());
         defaultStaceyKramersCorrelationCoeff_text.setText(
                 myLabData.getDefaultStaceyKramersCorrelationCoeffs().//
-                setScale(ReduxConstants.DEFAULT_PARAMETERS_SCALE, RoundingMode.HALF_UP).toPlainString());
+                        setScale(ReduxConstants.DEFAULT_PARAMETERS_SCALE, RoundingMode.HALF_UP).toPlainString());
 
         // set up Mineral chooser
         mineralNameChooser.removeAllItems();
@@ -2649,6 +2653,8 @@ public class LabDataEditorDialog extends DialogEditor {
         viewStandardModelButton.setFont(ReduxConstants.sansSerif_10_Bold);
         viewStandardModelButton.setBounds(850, 60, 30, 23);
 
+        LAICPMSLabDefaultsPane.add(viewStandardModelButton);
+
         // feb 2016
         // add defaultInterReferenceMaterialReproducibility
         JLabel defaultInterReferenceMaterialReproducibilityLabel = new JLabel("Set default Inter-Reference Material Reproducibility: ");
@@ -2723,8 +2729,76 @@ public class LabDataEditorDialog extends DialogEditor {
         default208_232irmrNote.setBounds(700, 150, 75, 25);
         LAICPMSLabDefaultsPane.add(default208_232irmrNote);
 
-        LAICPMSLabDefaultsPane.add(viewStandardModelButton);
+        // Nov 2016
+        // add default filter values for discordance and uncertainty
+        JLabel defaultFilterSettingsForSlidersLabel = new JLabel("Set default Filter Settings for Sliders: ");
+        defaultFilterSettingsForSlidersLabel.setHorizontalAlignment(SwingConstants.LEFT);
+        defaultFilterSettingsForSlidersLabel.setFont(ReduxConstants.sansSerif_12_Bold);
+        defaultFilterSettingsForSlidersLabel.setBounds(25, 185, 450, 25);
+        LAICPMSLabDefaultsPane.add(defaultFilterSettingsForSlidersLabel);
 
+        JLabel defaultNegativeDiscordanceLabel = new JLabel("neg % discordance :");
+        defaultNegativeDiscordanceLabel.setHorizontalAlignment(SwingConstants.RIGHT);
+        defaultNegativeDiscordanceLabel.setFont(ReduxConstants.sansSerif_12_Bold);
+        defaultNegativeDiscordanceLabel.setBounds(475, 185, 125, 25);
+        LAICPMSLabDefaultsPane.add(defaultNegativeDiscordanceLabel);
+
+        defaultNegPctDiscordanceText = new JTextField();
+        defaultNegPctDiscordanceText.setDocument(new IntegerDocument(defaultNegPctDiscordanceText, true));
+        defaultNegPctDiscordanceText.setHorizontalAlignment(SwingConstants.CENTER);
+        defaultNegPctDiscordanceText.setFont(ReduxConstants.sansSerif_12_Bold);
+        defaultNegPctDiscordanceText.setBounds(610, 185, 65, 25);
+        text = String.valueOf(Math.abs(myLabData.getDefaultNegPctDiscordanceFilter()));
+        defaultNegPctDiscordanceText.setText(text);
+        LAICPMSLabDefaultsPane.add(defaultNegPctDiscordanceText);
+
+        JLabel defaultNegPctDiscordanceNote = new JLabel("pos integer");
+        defaultNegPctDiscordanceNote.setHorizontalAlignment(SwingConstants.LEFT);
+        defaultNegPctDiscordanceNote.setFont(ReduxConstants.sansSerif_12_Bold);
+        defaultNegPctDiscordanceNote.setBounds(700, 185, 75, 25);
+        LAICPMSLabDefaultsPane.add(defaultNegPctDiscordanceNote);
+
+        JLabel defaultPositiveDiscordanceLabel = new JLabel("pos % discordance :");
+        defaultPositiveDiscordanceLabel.setHorizontalAlignment(SwingConstants.RIGHT);
+        defaultPositiveDiscordanceLabel.setFont(ReduxConstants.sansSerif_12_Bold);
+        defaultPositiveDiscordanceLabel.setBounds(475, 215, 125, 25);
+        LAICPMSLabDefaultsPane.add(defaultPositiveDiscordanceLabel);
+
+        defaultPosPctDiscordanceText = new JTextField();
+        defaultPosPctDiscordanceText.setDocument(new IntegerDocument(defaultPosPctDiscordanceText, true));
+        defaultPosPctDiscordanceText.setHorizontalAlignment(SwingConstants.CENTER);
+        defaultPosPctDiscordanceText.setFont(ReduxConstants.sansSerif_12_Bold);
+        defaultPosPctDiscordanceText.setBounds(610, 215, 65, 25);
+        text = String.valueOf(Math.abs(myLabData.getDefaultPosPctDiscordanceFilter()));
+        defaultPosPctDiscordanceText.setText(text);
+        LAICPMSLabDefaultsPane.add(defaultPosPctDiscordanceText);
+
+        JLabel defaultPosPctDiscordanceNote = new JLabel("pos integer");
+        defaultPosPctDiscordanceNote.setHorizontalAlignment(SwingConstants.LEFT);
+        defaultPosPctDiscordanceNote.setFont(ReduxConstants.sansSerif_12_Bold);
+        defaultPosPctDiscordanceNote.setBounds(700, 215, 75, 25);
+        LAICPMSLabDefaultsPane.add(defaultPosPctDiscordanceNote);
+
+        JLabel defaultPctUncertaintyLabel = new JLabel("% uncertainty :");
+        defaultPctUncertaintyLabel.setHorizontalAlignment(SwingConstants.RIGHT);
+        defaultPctUncertaintyLabel.setFont(ReduxConstants.sansSerif_12_Bold);
+        defaultPctUncertaintyLabel.setBounds(475, 245, 125, 25);
+        LAICPMSLabDefaultsPane.add(defaultPctUncertaintyLabel);
+
+        defaultPctUncertaintyText = new JTextField();
+        defaultPctUncertaintyText.setDocument(new IntegerDocument(defaultPctUncertaintyText, true));
+        defaultPctUncertaintyText.setHorizontalAlignment(SwingConstants.CENTER);
+        defaultPctUncertaintyText.setFont(ReduxConstants.sansSerif_12_Bold);
+        defaultPctUncertaintyText.setBounds(610, 245, 65, 25);
+        text = String.valueOf(Math.abs(myLabData.getDefaultPctUncertaintyFilter()));
+        defaultPctUncertaintyText.setText(text);
+        LAICPMSLabDefaultsPane.add(defaultPctUncertaintyText);
+
+        JLabel defaultPctUncertaintyNote = new JLabel("pos integer");
+        defaultPctUncertaintyNote.setHorizontalAlignment(SwingConstants.LEFT);
+        defaultPctUncertaintyNote.setFont(ReduxConstants.sansSerif_12_Bold);
+        defaultPctUncertaintyNote.setBounds(700, 245, 75, 25);
+        LAICPMSLabDefaultsPane.add(defaultPctUncertaintyNote);
     }
 
     private synchronized boolean CheckIsSavedStatusOfDefaultsEdit()
@@ -2888,6 +2962,18 @@ public class LabDataEditorDialog extends DialogEditor {
                 .setValue(new BigDecimal(default206_207irmrText.getText()).movePointLeft(2));
         myLabData.getDefaultInterReferenceMaterialReproducibilityMap().get(RadRatios.r208_232r)//
                 .setValue(new BigDecimal(default208_232irmrText.getText()).movePointLeft(2));
+
+        // force to value between -100 and 0;
+        int value = -1 * Math.min(Math.abs(Integer.parseInt(defaultNegPctDiscordanceText.getText())), 100);
+        myLabData.setDefaultNegPctDiscordanceFilter(value);
+
+        // force to value between 100 and 0;
+        value = Math.min(Math.abs(Integer.parseInt(defaultPosPctDiscordanceText.getText())), 100);
+        myLabData.setDefaultPosPctDiscordanceFilter(value);
+
+        // force to value between 100 and 0;
+        value = Math.min(Math.abs(Integer.parseInt(defaultPctUncertaintyText.getText())), 100);
+        myLabData.setDefaultPctUncertaintyFilter(value);
 
     }
 
@@ -4292,8 +4378,12 @@ public class LabDataEditorDialog extends DialogEditor {
         details_pane.addTab("Lab Defaults II", labDefaultsCont_panel);
 
         LAICPMSLabDefaultsPane.setLayout(null);
+
+        defaultLAICPMSPrimaryMineralStandardModel_Chooser.setBackground(new java.awt.Color(255, 255, 255));
+        defaultLAICPMSPrimaryMineralStandardModel_Chooser.setFont(new java.awt.Font("Lucida Sans", 0, 12)); // NOI18N
+        defaultLAICPMSPrimaryMineralStandardModel_Chooser.setOpaque(true);
         LAICPMSLabDefaultsPane.add(defaultLAICPMSPrimaryMineralStandardModel_Chooser);
-        defaultLAICPMSPrimaryMineralStandardModel_Chooser.setBounds(475, 60, 350, 27);
+        defaultLAICPMSPrimaryMineralStandardModel_Chooser.setBounds(475, 60, 360, 27);
 
         developerNote.setText("Note: elements are programmatically generated here.");
         LAICPMSLabDefaultsPane.add(developerNote);

--- a/src/main/java/org/earthtime/projects/ProjectSample.java
+++ b/src/main/java/org/earthtime/projects/ProjectSample.java
@@ -21,7 +21,9 @@ package org.earthtime.projects;
 
 import java.io.File;
 import java.io.Serializable;
+import java.util.Collections;
 import java.util.SortedSet;
+import java.util.TreeSet;
 import java.util.Vector;
 import org.earthtime.UPb_Redux.ReduxConstants;
 import org.earthtime.UPb_Redux.ReduxConstants.ANALYSIS_PURPOSE;
@@ -70,6 +72,8 @@ public class ProjectSample implements//
 
     private transient ReduxLabData reduxLabData;
 
+    private SortedSet<String> filteredFractionIDs;
+
     /**
      *
      * @param sampleName the value of sampleName
@@ -108,6 +112,8 @@ public class ProjectSample implements//
         this.concordiaGraphAxesSetup = new GraphAxesSetup("C", 2);
         this.terraWasserburgGraphAxesSetup = new GraphAxesSetup("T-W", 2);
         this.sampleDateModels = new Vector<>();
+        
+        initFilteredFractionsToAll();
 
     }
 
@@ -185,7 +191,7 @@ public class ProjectSample implements//
     @Override
     public void setAnalysisPurpose(ReduxConstants.ANALYSIS_PURPOSE analysisPurpose) {
         this.analysisPurpose = analysisPurpose;
-        for (int i = 0; i < aliquots.size(); i ++){
+        for (int i = 0; i < aliquots.size(); i++) {
             aliquots.get(i).setAnalysisPurpose(analysisPurpose);
         }
     }
@@ -475,14 +481,30 @@ public class ProjectSample implements//
         return isotopeStyle;
     }
 
+    /**
+     * @return the filteredFractionIDs
+     */
     @Override
     public SortedSet<String> getFilteredFractionIDs() {
-        throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+        if (filteredFractionIDs == null) {
+            initFilteredFractionsToAll();
+        }
+        return filteredFractionIDs;
     }
 
+    /**
+     * @param filteredFractionIDs the filteredFractionIDs to set
+     */
     @Override
     public void setFilteredFractionIDs(SortedSet<String> filteredFractionIDs) {
-        throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+        this.filteredFractionIDs = filteredFractionIDs;
+    }
+
+    private void initFilteredFractionsToAll() {
+        this.filteredFractionIDs = Collections.synchronizedSortedSet(new TreeSet<>());
+        for (int i = 0; i < fractions.size(); i++) {
+            filteredFractionIDs.add(fractions.get(i).getFractionID());
+        }
     }
 
 }

--- a/src/main/java/org/earthtime/reduxLabData/ReduxLabData.java
+++ b/src/main/java/org/earthtime/reduxLabData/ReduxLabData.java
@@ -116,6 +116,10 @@ public final class ReduxLabData implements Serializable {
     private AbstractRatiosDataModel defaultDetritalUraniumAndThoriumModel;
     // feb 2016
     private Map<RadRatios, ValueModel> defaultInterReferenceMaterialReproducibilityMap;
+    // oct 2016
+    private int defaultNegPctDiscordanceFilter;
+    private int defaultPosPctDiscordanceFilter;
+    private int defaultPctUncertaintyFilter;
 
     /**
      * Creates a new instance of ReduxLabData
@@ -222,6 +226,10 @@ public final class ReduxLabData implements Serializable {
         this.defaultLeftShadeCountForSHRIMPAquisitions = 0;
 
         initDefaultInterReferenceMaterialReproducibilityMap();
+
+        defaultNegPctDiscordanceFilter = -100;
+        defaultPosPctDiscordanceFilter = 100;
+        defaultPctUncertaintyFilter = 100;
 
     }
 
@@ -432,9 +440,9 @@ public final class ReduxLabData implements Serializable {
             addTracer(TracerUPbModel.getNoneInstance());
             defaultLabTracer = getFirstTracer();
         } else // detect if legacy default is none and change if possible
-         if (defaultLabTracer.equals(getNoneTracer())) {
-                defaultLabTracer = getFirstTracer();
-            }
+        if (defaultLabTracer.equals(getNoneTracer())) {
+            defaultLabTracer = getFirstTracer();
+        }
         return defaultLabTracer;
     }
 
@@ -550,9 +558,9 @@ public final class ReduxLabData implements Serializable {
             addAlphaUModel(new ValueModel(ReduxConstants.NONE));
             setDefaultLabAlphaUModel(getFirstAlphaUModel());
         } else // detect if legacy default is none and change if possible
-         if (defaultLabAlphaUModel.equals(getNoneAlphaUModel())) {
-                setDefaultLabAlphaUModel(getFirstAlphaUModel());
-            }
+        if (defaultLabAlphaUModel.equals(getNoneAlphaUModel())) {
+            setDefaultLabAlphaUModel(getFirstAlphaUModel());
+        }
         return defaultLabAlphaUModel;
     }
 
@@ -657,9 +665,9 @@ public final class ReduxLabData implements Serializable {
             addAlphaPbModel(new ValueModel(ReduxConstants.NONE));
             setDefaultLabAlphaPbModel(getFirstAlphaPbModel());
         } else // detect if legacy default is none and change if possible
-         if (defaultLabAlphaPbModel.equals(getNoneAlphaPbModel())) {
-                setDefaultLabAlphaPbModel(getFirstAlphaPbModel());
-            }
+        if (defaultLabAlphaPbModel.equals(getNoneAlphaPbModel())) {
+            setDefaultLabAlphaPbModel(getFirstAlphaPbModel());
+        }
         return defaultLabAlphaPbModel;
     }
 
@@ -766,9 +774,9 @@ public final class ReduxLabData implements Serializable {
             addBlank(PbBlankICModel.getNoneInstance());
             setDefaultLabPbBlank(getFirstPbBlank());
         } else // detect if legacy default is none and change if possible
-         if (defaultLabPbBlank.equals(getNonePbBlankModel())) {
-                setDefaultLabPbBlank(getFirstPbBlank());
-            }
+        if (defaultLabPbBlank.equals(getNonePbBlankModel())) {
+            setDefaultLabPbBlank(getFirstPbBlank());
+        }
         return defaultLabPbBlank;
     }
 
@@ -888,9 +896,9 @@ public final class ReduxLabData implements Serializable {
 
             defaultLabInitialPbModel = getFirstInitialPbModel();
         } else // detect if legacy default is none and change if possible
-         if (defaultLabInitialPbModel.equals(getNoneInitialPbModel())) {
-                defaultLabInitialPbModel = getFirstInitialPbModel();
-            }
+        if (defaultLabInitialPbModel.equals(getNoneInitialPbModel())) {
+            defaultLabInitialPbModel = getFirstInitialPbModel();
+        }
         return defaultLabInitialPbModel;
     }
 
@@ -1259,9 +1267,9 @@ public final class ReduxLabData implements Serializable {
             addRareEarthElementModel(RareEarthElementsModel.getNoneInstance());
             defaultRareEarthElementModel = getFirstRareEarthElementModel();
         } else // detect if legacy default is none and change if possible
-         if (defaultRareEarthElementModel.equals(getNoneRareEarthElementModel())) {
-                defaultRareEarthElementModel = getFirstRareEarthElementModel();
-            }
+        if (defaultRareEarthElementModel.equals(getNoneRareEarthElementModel())) {
+            defaultRareEarthElementModel = getFirstRareEarthElementModel();
+        }
         return defaultRareEarthElementModel;
     }
 
@@ -1366,9 +1374,9 @@ public final class ReduxLabData implements Serializable {
             addDetritalUraniumAndThoriumModel(DetritalUraniumAndThoriumModel.getNoneInstance());
             defaultDetritalUraniumAndThoriumModel = getFirstDetritalUraniumAndThoriumModel();
         } else // detect if legacy default is none and change if possible
-         if (defaultDetritalUraniumAndThoriumModel.equals(getNoneDetritalUraniumAndThoriumModel())) {
-                defaultDetritalUraniumAndThoriumModel = getFirstDetritalUraniumAndThoriumModel();
-            }
+        if (defaultDetritalUraniumAndThoriumModel.equals(getNoneDetritalUraniumAndThoriumModel())) {
+            defaultDetritalUraniumAndThoriumModel = getFirstDetritalUraniumAndThoriumModel();
+        }
         return defaultDetritalUraniumAndThoriumModel;
     }
 
@@ -1466,8 +1474,7 @@ public final class ReduxLabData implements Serializable {
      * @return the org.earthtime.reports.ReportSettingsInterface
      * @throws org.earthtime.UPb_Redux.exceptions.BadLabDataException
      */
-    public ReportSettingsInterface getDefaultReportSettingsModelByIsotopeStyle(String isotopeStyle)
-             {
+    public ReportSettingsInterface getDefaultReportSettingsModelByIsotopeStyle(String isotopeStyle) {
         if (defaultReportSettingsModel == null) {
             defaultReportSettingsModel = ReportSettings.EARTHTIMEReportSettingsUPb();
             addReportSettingsModel(defaultReportSettingsModel);
@@ -1767,11 +1774,11 @@ public final class ReduxLabData implements Serializable {
         String retVal = "<html>" + alphaModel.getName() + "<br>";
         retVal += "&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;" + alphaType + " = " //
                 + alphaModel.getValue().movePointRight(2)//
-                .setScale(ReduxConstants.DEFAULT_PARAMETERS_SCALE, RoundingMode.HALF_UP).toPlainString()//
+                        .setScale(ReduxConstants.DEFAULT_PARAMETERS_SCALE, RoundingMode.HALF_UP).toPlainString()//
                 + " % / amu" + "<br>"//
                 + "&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;1-sigma abs = " //
                 + alphaModel.getOneSigma().movePointRight(2)//
-                .setScale(ReduxConstants.DEFAULT_PARAMETERS_SCALE, RoundingMode.HALF_UP).toPlainString()//
+                        .setScale(ReduxConstants.DEFAULT_PARAMETERS_SCALE, RoundingMode.HALF_UP).toPlainString()//
                 + " % / amu" + "</html>";
 
         return retVal;
@@ -1877,8 +1884,8 @@ public final class ReduxLabData implements Serializable {
      */
     public String getAnalystName() {
         //if (analystName == null) {
-            analystName = System.getProperty("user.name");
-       // }
+        analystName = System.getProperty("user.name");
+        // }
         return analystName;
     }
 
@@ -2036,10 +2043,64 @@ public final class ReduxLabData implements Serializable {
     }
 
     /**
-     * @param defaultLeftShadeCountForSHRIMPAquisitions the defaultLeftShadeCountForSHRIMPAquisitions to set
+     * @param defaultLeftShadeCountForSHRIMPAquisitions the
+     * defaultLeftShadeCountForSHRIMPAquisitions to set
      */
     public void setDefaultLeftShadeCountForSHRIMPAquisitions(int defaultLeftShadeCountForSHRIMPAquisitions) {
         this.defaultLeftShadeCountForSHRIMPAquisitions = defaultLeftShadeCountForSHRIMPAquisitions;
+    }
+
+    /**
+     * @return the defaultNegPctDiscordanceFilter
+     */
+    public int getDefaultNegPctDiscordanceFilter() {
+        if (defaultNegPctDiscordanceFilter == 0) {
+            defaultNegPctDiscordanceFilter = -100;
+        }
+        return defaultNegPctDiscordanceFilter;
+    }
+
+    /**
+     * @param defaultNegPctDiscordanceFilter the defaultNegPctDiscordanceFilter
+     * to set
+     */
+    public void setDefaultNegPctDiscordanceFilter(int defaultNegPctDiscordanceFilter) {
+        this.defaultNegPctDiscordanceFilter = defaultNegPctDiscordanceFilter;
+    }
+
+    /**
+     * @return the defaultPosPctDiscordanceFilter
+     */
+    public int getDefaultPosPctDiscordanceFilter() {
+        if (defaultPosPctDiscordanceFilter == 0) {
+            defaultPosPctDiscordanceFilter = 100;
+        }
+        return defaultPosPctDiscordanceFilter;
+    }
+
+    /**
+     * @param defaultPosPctDiscordanceFilter the defaultPosPctDiscordanceFilter
+     * to set
+     */
+    public void setDefaultPosPctDiscordanceFilter(int defaultPosPctDiscordanceFilter) {
+        this.defaultPosPctDiscordanceFilter = defaultPosPctDiscordanceFilter;
+    }
+
+    /**
+     * @return the defaultPctUncertaintyFilter
+     */
+    public int getDefaultPctUncertaintyFilter() {
+        if (defaultPctUncertaintyFilter == 0) {
+            defaultPctUncertaintyFilter = 100;
+        }
+        return defaultPctUncertaintyFilter;
+    }
+
+    /**
+     * @param defaultPctUncertaintyFilter the defaultPctUncertaintyFilter to set
+     */
+    public void setDefaultPctUncertaintyFilter(int defaultPctUncertaintyFilter) {
+        this.defaultPctUncertaintyFilter = defaultPctUncertaintyFilter;
     }
 
 }

--- a/src/main/java/org/earthtime/reports/ReportSettingsInterface.java
+++ b/src/main/java/org/earthtime/reports/ReportSettingsInterface.java
@@ -572,6 +572,8 @@ public interface ReportSettingsInterface extends Comparable<ReportSettingsInterf
         // FRACTION_DATA_START_ROW is stored in 0,0
         retVal[0][0] = Integer.toString(FRACTION_DATA_START_ROW);
 
+        SortedSet<String> filteredFractions = sample.getFilteredFractionIDs();
+
         int columnCount = 2;
 
         int footNoteCounter = 0;
@@ -639,7 +641,7 @@ public interface ReportSettingsInterface extends Comparable<ReportSettingsInterf
 
                             // walk all the fractions for each column
                             int fractionRowCount = FRACTION_DATA_START_ROW;
-                            SortedSet<String> filteredFractions = sample.getFilteredFractionIDs();
+//                            SortedSet<String> filteredFractions = sample.getFilteredFractionIDs();
                             for (ETFractionInterface f : fractions) {
 
                                 // test for included fraction on first data pass col=2==>fractionID
@@ -652,11 +654,11 @@ public interface ReportSettingsInterface extends Comparable<ReportSettingsInterf
 
                                     retVal[fractionRowCount][1]
                                             = sample.getAliquotByNumber(f.getAliquotNumber()).getAliquotName();
-                                    
+
                                     // oct 2016 filtering true = not filtered out
-                                    if (filteredFractions.contains(f.getFractionID())){
+                                    if (filteredFractions.contains(f.getFractionID())) {
                                         retVal[fractionRowCount][countOfAllColumns - 1] = "true";
-                                    } else  {
+                                    } else {
                                         retVal[fractionRowCount][countOfAllColumns - 1] = "false";
                                     }
                                 }
@@ -717,10 +719,10 @@ public interface ReportSettingsInterface extends Comparable<ReportSettingsInterf
             try {
                 lambda238Ref
                         = " (" + ((ValueModelReferenced) sample.getPhysicalConstantsModel()//
-                        .getDatumByName(Lambdas.lambda238.getName())).getReference() + ")";
+                                .getDatumByName(Lambdas.lambda238.getName())).getReference() + ")";
                 lambda235Ref
                         = " (" + ((ValueModelReferenced) sample.getPhysicalConstantsModel()//
-                        .getDatumByName(Lambdas.lambda235.getName())).getReference() + ")";
+                                .getDatumByName(Lambdas.lambda235.getName())).getReference() + ")";
             } catch (BadLabDataException badLabDataException) {
             }
 
@@ -759,7 +761,7 @@ public interface ReportSettingsInterface extends Comparable<ReportSettingsInterf
                         += //
                         " (" //
                         + ((ValueModelReferenced) sample.getPhysicalConstantsModel().getDatumByName(Lambdas.lambda230.getName()))//
-                        .getReference() //
+                                .getReference() //
                         + ")";
             } catch (BadLabDataException badLabDataException) {
             }
@@ -774,7 +776,7 @@ public interface ReportSettingsInterface extends Comparable<ReportSettingsInterf
                         += //
                         " (" //
                         + ((ValueModelReferenced) sample.getPhysicalConstantsModel().getDatumByName(Lambdas.lambda232.getName()))//
-                        .getReference() //
+                                .getReference() //
                         + ")";
             } catch (BadLabDataException badLabDataException) {
             }
@@ -788,7 +790,7 @@ public interface ReportSettingsInterface extends Comparable<ReportSettingsInterf
                         += //
                         " (" //
                         + ((ValueModelReferenced) sample.getPhysicalConstantsModel().getDatumByName(Lambdas.lambda234.getName()))//
-                        .getReference() //
+                                .getReference() //
                         + ")";
             } catch (BadLabDataException badLabDataException) {
             }


### PR DESCRIPTION
Fixes #129 - can't reproduce effect, but provides defaults for sliders in lab data and a button on live data and sample dates manager to invoke defaults.  If abs value negative and positive discordances are equal, lock is invoked, otherwise lock is broken.  Fixes #130, LA ICP MS project manager remembers last choices for three parameters.  Fixes various minor bugs and refactors.  Move MAC OS menus to window to keep uniform appearance with WIN OS and metal look and feel.