### PR TITLE
Updates Useries visualizations and addresses issues 182, 181, 171, 164.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
     <groupId>org.cirdles</groupId>
     <artifactId>ET_Redux</artifactId>
     <name>ET_Redux</name>
-    <version>3.6.84</version>
+    <version>3.6.85</version>
     <description>Successor to U-Pb_Redux</description>
     <url>https://cirdles.org</url>
     <inceptionYear>2006</inceptionYear>

--- a/src/main/java/org/earthtime/UPb_Redux/ReduxConstants.java
+++ b/src/main/java/org/earthtime/UPb_Redux/ReduxConstants.java
@@ -177,7 +177,8 @@ final public class ReduxConstants {
     /**
      *
      */
-    static public int DEFAULT_MASS_DISPLAY_SCALE = 5;
+    static public int DEFAULT_MASS_IN_GRAMS_DISPLAY_SCALE = 5;
+    static public int DEFAULT_MASS_IN_MICRO_GRAMS_DISPLAY_SCALE = 3;
     /**
      *
      */

--- a/src/main/java/org/earthtime/UPb_Redux/aliquots/UPbReduxAliquot.java
+++ b/src/main/java/org/earthtime/UPb_Redux/aliquots/UPbReduxAliquot.java
@@ -215,7 +215,7 @@ public class UPbReduxAliquot extends Aliquot
 
         setDefaultUBlankMassText(getMyReduxLabData().getDefaultAssumedUBlankMassInGrams().
                 getValue().multiply(ReduxConstants.PicoGramsPerGram).
-                setScale(ReduxConstants.DEFAULT_MASS_DISPLAY_SCALE,
+                setScale(ReduxConstants.DEFAULT_MASS_IN_GRAMS_DISPLAY_SCALE,
                         RoundingMode.HALF_UP).toPlainString());
 
         setDefaultR238_235sText(getMyReduxLabData().getDefaultR238_235s()//
@@ -227,7 +227,7 @@ public class UPbReduxAliquot extends Aliquot
                         RoundingMode.HALF_UP).toPlainString());
 
         setDefaultR18O_16OText(getMyReduxLabData().getDefaultR18O_16O()//
-                .getValue().setScale(ReduxConstants.DEFAULT_MASS_DISPLAY_SCALE,
+                .getValue().setScale(ReduxConstants.DEFAULT_MASS_IN_GRAMS_DISPLAY_SCALE,
                         RoundingMode.HALF_UP).toPlainString());
 
         try {
@@ -244,7 +244,7 @@ public class UPbReduxAliquot extends Aliquot
 
         setDefaultPbBlankMassText(getMyReduxLabData().getDefaultPbBlankMassInGrams().
                 getValue().multiply(ReduxConstants.PicoGramsPerGram).
-                setScale(ReduxConstants.DEFAULT_MASS_DISPLAY_SCALE,
+                setScale(ReduxConstants.DEFAULT_MASS_IN_GRAMS_DISPLAY_SCALE,
                         RoundingMode.HALF_UP).toPlainString());
 
         setDefaultRTh_UmagmaText(getMyReduxLabData().getDefaultRTh_Umagma().
@@ -267,38 +267,38 @@ public class UPbReduxAliquot extends Aliquot
 
         // uncertainties
         setDefaultTracerMassOneSigmaText(getMyReduxLabData().getDefaultTracerMass()//
-                .getOneSigmaAbs().setScale(ReduxConstants.DEFAULT_MASS_DISPLAY_SCALE,
+                .getOneSigmaAbs().setScale(ReduxConstants.DEFAULT_MASS_IN_GRAMS_DISPLAY_SCALE,
                         RoundingMode.HALF_UP).toPlainString());
 
         setDefaultUBlankMassOneSigmaText(getMyReduxLabData().getDefaultAssumedUBlankMassInGrams()//
                 .getOneSigmaAbs().multiply(ReduxConstants.PicoGramsPerGram)//
-                .setScale(ReduxConstants.DEFAULT_MASS_DISPLAY_SCALE,
+                .setScale(ReduxConstants.DEFAULT_MASS_IN_GRAMS_DISPLAY_SCALE,
                         RoundingMode.HALF_UP).toPlainString());
 
         setDefaultR238_235sOneSigmaText(getMyReduxLabData().getDefaultR238_235s()//
-                .getOneSigmaAbs().setScale(ReduxConstants.DEFAULT_MASS_DISPLAY_SCALE,
+                .getOneSigmaAbs().setScale(ReduxConstants.DEFAULT_MASS_IN_GRAMS_DISPLAY_SCALE,
                         RoundingMode.HALF_UP).toPlainString());
 
         this.defaultR238_235bOneSigmaText = getMyReduxLabData().getDefaultR238_235b()//
-                .getOneSigmaAbs().setScale(ReduxConstants.DEFAULT_MASS_DISPLAY_SCALE,
+                .getOneSigmaAbs().setScale(ReduxConstants.DEFAULT_MASS_IN_GRAMS_DISPLAY_SCALE,
                         RoundingMode.HALF_UP).toPlainString();
 
         this.defaultPbBlankMassOneSigmaText = getMyReduxLabData().getDefaultPbBlankMassInGrams()//
                 .getOneSigmaAbs().multiply(ReduxConstants.PicoGramsPerGram).//
-                setScale(ReduxConstants.DEFAULT_MASS_DISPLAY_SCALE,
+                setScale(ReduxConstants.DEFAULT_MASS_IN_GRAMS_DISPLAY_SCALE,
                         RoundingMode.HALF_UP).toPlainString();
 
         // TODO there is some odd duplication with this getters setters
         setDefaultR18O_16OOneSigmaText(getMyReduxLabData().getDefaultR18O_16O()//
-                .getOneSigmaAbs().setScale(ReduxConstants.DEFAULT_MASS_DISPLAY_SCALE,
+                .getOneSigmaAbs().setScale(ReduxConstants.DEFAULT_MASS_IN_GRAMS_DISPLAY_SCALE,
                         RoundingMode.HALF_UP).toPlainString());
 
         this.defaultRTh_UmagmaOneSigmaText = getMyReduxLabData().getDefaultRTh_Umagma()//
-                .getOneSigmaAbs().setScale(ReduxConstants.DEFAULT_MASS_DISPLAY_SCALE,
+                .getOneSigmaAbs().setScale(ReduxConstants.DEFAULT_MASS_IN_GRAMS_DISPLAY_SCALE,
                         RoundingMode.HALF_UP).toPlainString();
 
         this.defaultAr231_235sampleOneSigmaText = getMyReduxLabData().getDefaultAr231_235sample()//
-                .getOneSigmaAbs().setScale(ReduxConstants.DEFAULT_MASS_DISPLAY_SCALE,
+                .getOneSigmaAbs().setScale(ReduxConstants.DEFAULT_MASS_IN_GRAMS_DISPLAY_SCALE,
                         RoundingMode.HALF_UP).toPlainString();
 
         this.automaticDataUpdateMode = false;

--- a/src/main/java/org/earthtime/UPb_Redux/dialogs/aliquotManagers/AliquotEditorDialog.java
+++ b/src/main/java/org/earthtime/UPb_Redux/dialogs/aliquotManagers/AliquotEditorDialog.java
@@ -4079,7 +4079,7 @@ private void publishAliquot_panelMouseClicked(java.awt.event.MouseEvent evt) {//
                         toPlainString());
         fractionStaceyKramersCorrelationCoeffsText.get(row).setEnabled(hasStaceyKramersModel);
 
-        ((JTextComponent) fractionPbBlankMassText.get(row)).setText(tempFrac.getAnalysisMeasure(AnalysisMeasures.pbBlankMassInGrams.getName()).getValue().multiply(ReduxConstants.PicoGramsPerGram).setScale(ReduxConstants.DEFAULT_MASS_DISPLAY_SCALE,
+        ((JTextComponent) fractionPbBlankMassText.get(row)).setText(tempFrac.getAnalysisMeasure(AnalysisMeasures.pbBlankMassInGrams.getName()).getValue().multiply(ReduxConstants.PicoGramsPerGram).setScale(ReduxConstants.DEFAULT_MASS_IN_GRAMS_DISPLAY_SCALE,
                 RoundingMode.HALF_UP).toPlainString());
         ((UnDoAbleDocument) ((JTextComponent) fractionPbBlankMassText.get(row)).getDocument()).undo.discardAllEdits();
         fractionPbBlankMassText.get(row).setEnabled(!isZircon);
@@ -4107,12 +4107,12 @@ private void publishAliquot_panelMouseClicked(java.awt.event.MouseEvent evt) {//
         fractionTracerChoice.get(row).setEnabled(!(fraCorrU || fraCorrPb));
 
         ((JTextComponent) fractionTracerMassText.get(row)).setText(tempFrac.getAnalysisMeasure(AnalysisMeasures.tracerMassInGrams.getName()).getValue().
-                setScale(ReduxConstants.DEFAULT_MASS_DISPLAY_SCALE,
+                setScale(ReduxConstants.DEFAULT_MASS_IN_GRAMS_DISPLAY_SCALE,
                         RoundingMode.HALF_UP).toPlainString());
         fractionTracerMassText.get(row).setEnabled(!(fraCorrU));
 
         ((JTextComponent) fractionMassText.get(row)).setText(tempFrac.getAnalysisMeasure(AnalysisMeasures.fractionMass.getName()).getValue().
-                setScale(ReduxConstants.DEFAULT_MASS_DISPLAY_SCALE, RoundingMode.HALF_UP).//
+                setScale(ReduxConstants.DEFAULT_MASS_IN_GRAMS_DISPLAY_SCALE, RoundingMode.HALF_UP).//
                 toPlainString());
 
         updateAlphaPbModelChooserForRow(tempFrac, ((UPbFraction) tempFrac).needsAlphaPbModel(), row);
@@ -4123,11 +4123,11 @@ private void publishAliquot_panelMouseClicked(java.awt.event.MouseEvent evt) {//
 
         updateInitialPbModelChooserForRow(tempFrac, isZircon, row);
 
-        ((JTextField) fractionPbBlankMassText.get(row)).setText(tempFrac.getAnalysisMeasure(AnalysisMeasures.pbBlankMassInGrams.getName()).getValue().multiply(ReduxConstants.PicoGramsPerGram).setScale(ReduxConstants.DEFAULT_MASS_DISPLAY_SCALE,
+        ((JTextField) fractionPbBlankMassText.get(row)).setText(tempFrac.getAnalysisMeasure(AnalysisMeasures.pbBlankMassInGrams.getName()).getValue().multiply(ReduxConstants.PicoGramsPerGram).setScale(ReduxConstants.DEFAULT_MASS_IN_GRAMS_DISPLAY_SCALE,
                 RoundingMode.HALF_UP).toPlainString());
         fractionPbBlankMassText.get(row).setEnabled(!isZircon);
 
-        ((JTextField) fractionUBlankMassText.get(row)).setText(tempFrac.getAnalysisMeasure(AnalysisMeasures.uBlankMassInGrams.getName()).getValue().multiply(ReduxConstants.PicoGramsPerGram).setScale(ReduxConstants.DEFAULT_MASS_DISPLAY_SCALE,
+        ((JTextField) fractionUBlankMassText.get(row)).setText(tempFrac.getAnalysisMeasure(AnalysisMeasures.uBlankMassInGrams.getName()).getValue().multiply(ReduxConstants.PicoGramsPerGram).setScale(ReduxConstants.DEFAULT_MASS_IN_GRAMS_DISPLAY_SCALE,
                 RoundingMode.HALF_UP).toPlainString());
         fractionUBlankMassText.get(row).setEnabled(!(fraCorrU));
 
@@ -4147,36 +4147,36 @@ private void publishAliquot_panelMouseClicked(java.awt.event.MouseEvent evt) {//
         fractionR18O_16OText.get(row).setEnabled(((UPbFraction) tempFrac).isAnOxide());
 
         ((JTextField) fractionRTh_UmagmaText.get(row)).setText(tempFrac.getAnalysisMeasure(AnalysisMeasures.rTh_Umagma.getName()).getValue().
-                setScale(ReduxConstants.DEFAULT_MASS_DISPLAY_SCALE, RoundingMode.HALF_UP).//
+                setScale(ReduxConstants.DEFAULT_MASS_IN_GRAMS_DISPLAY_SCALE, RoundingMode.HALF_UP).//
                 toPlainString());
         fractionRTh_UmagmaText.get(row).setEnabled(true);
 
         ((JTextField) fractionAR231_235sampleText.get(row)).setText(tempFrac.getAnalysisMeasure(AnalysisMeasures.ar231_235sample.getName()).getValue().
-                setScale(ReduxConstants.DEFAULT_MASS_DISPLAY_SCALE, RoundingMode.HALF_UP).//
+                setScale(ReduxConstants.DEFAULT_MASS_IN_GRAMS_DISPLAY_SCALE, RoundingMode.HALF_UP).//
                 toPlainString());
         fractionAR231_235sampleText.get(row).setEnabled(true);
 
         //  uncertainties
         ((JTextField) fractionTracerMassOneSigmaText.get(row)).setText(tempFrac.getAnalysisMeasure(AnalysisMeasures.tracerMassInGrams.getName()).getOneSigmaAbs().
-                setScale(ReduxConstants.DEFAULT_MASS_DISPLAY_SCALE,
+                setScale(ReduxConstants.DEFAULT_MASS_IN_GRAMS_DISPLAY_SCALE,
                         RoundingMode.HALF_UP).toPlainString());
 
         ((JTextField) fractionUBlankMassOneSigmaText.get(row)).setText(tempFrac.getAnalysisMeasure(AnalysisMeasures.uBlankMassInGrams.getName()).getOneSigmaAbs().//
                 multiply(ReduxConstants.PicoGramsPerGram).
-                setScale(ReduxConstants.DEFAULT_MASS_DISPLAY_SCALE, RoundingMode.HALF_UP).//
+                setScale(ReduxConstants.DEFAULT_MASS_IN_GRAMS_DISPLAY_SCALE, RoundingMode.HALF_UP).//
                 toPlainString());
 
         ((JTextField) fractionR238_235sOneSigmaText.get(row)).setText(tempFrac.getAnalysisMeasure(AnalysisMeasures.r238_235s.getName()).getOneSigmaAbs().
-                setScale(ReduxConstants.DEFAULT_MASS_DISPLAY_SCALE,
+                setScale(ReduxConstants.DEFAULT_MASS_IN_GRAMS_DISPLAY_SCALE,
                         RoundingMode.HALF_UP).toPlainString());
 
         ((JTextField) fractionR238_235bOneSigmaText.get(row)).setText(tempFrac.getAnalysisMeasure(AnalysisMeasures.r238_235b.getName()).getOneSigmaAbs().
-                setScale(ReduxConstants.DEFAULT_MASS_DISPLAY_SCALE,
+                setScale(ReduxConstants.DEFAULT_MASS_IN_GRAMS_DISPLAY_SCALE,
                         RoundingMode.HALF_UP).toPlainString());
 
         ((JTextField) fractionPbBlankMassOneSigmaText.get(row)).setText(tempFrac.getAnalysisMeasure(AnalysisMeasures.pbBlankMassInGrams.getName()).getOneSigmaAbs().
                 multiply(ReduxConstants.PicoGramsPerGram).
-                setScale(ReduxConstants.DEFAULT_MASS_DISPLAY_SCALE,
+                setScale(ReduxConstants.DEFAULT_MASS_IN_GRAMS_DISPLAY_SCALE,
                         RoundingMode.HALF_UP).toPlainString());
         fractionPbBlankMassOneSigmaText.get(row).setEnabled(!isZircon);
 
@@ -4186,11 +4186,11 @@ private void publishAliquot_panelMouseClicked(java.awt.event.MouseEvent evt) {//
         fractionR18O_16OOneSigmaText.get(row).setEnabled(((UPbFraction) tempFrac).isAnOxide());
 
         ((JTextField) fractionRTh_UmagmaOneSigmaText.get(row)).setText(tempFrac.getAnalysisMeasure(AnalysisMeasures.rTh_Umagma.getName()).getOneSigmaAbs().
-                setScale(ReduxConstants.DEFAULT_MASS_DISPLAY_SCALE,
+                setScale(ReduxConstants.DEFAULT_MASS_IN_GRAMS_DISPLAY_SCALE,
                         RoundingMode.HALF_UP).toPlainString());
 
         ((JTextField) fractionAr231_235sampleOneSigmaText.get(row)).setText(tempFrac.getAnalysisMeasure(AnalysisMeasures.ar231_235sample.getName()).getOneSigmaAbs().
-                setScale(ReduxConstants.DEFAULT_MASS_DISPLAY_SCALE,
+                setScale(ReduxConstants.DEFAULT_MASS_IN_GRAMS_DISPLAY_SCALE,
                         RoundingMode.HALF_UP).toPlainString());
 
     }

--- a/src/main/java/org/earthtime/UPb_Redux/dialogs/fractionManagers/UPbFractionEditorDialog.form
+++ b/src/main/java/org/earthtime/UPb_Redux/dialogs/fractionManagers/UPbFractionEditorDialog.form
@@ -3500,8 +3500,10 @@
                   <Font name="Tahoma" size="12" style="1"/>
                 </Property>
                 <Property name="horizontalAlignment" type="int" value="11"/>
-                <Property name="text" type="java.lang.String" value="fraction mass in g:"/>
               </Properties>
+              <AuxValues>
+                <AuxValue name="JavaCodeGenerator_CreateCodePost" type="java.lang.String" value="fractionMassInGrams_label.setText(&quot;fraction mass in \u03BCg:&quot;);&#xa;"/>
+              </AuxValues>
             </Component>
             <Component class="javax.swing.JCheckBox" name="fractionIsZircon_CheckBox">
               <Properties>

--- a/src/main/java/org/earthtime/UPb_Redux/dialogs/fractionManagers/UPbFractionEditorDialog.java
+++ b/src/main/java/org/earthtime/UPb_Redux/dialogs/fractionManagers/UPbFractionEditorDialog.java
@@ -1440,8 +1440,9 @@ public class UPbFractionEditorDialog extends DialogEditor {
 
         fractionIsZircon_CheckBox.setSelected(((FractionI)myFraction).isZircon());
 
+        // july 2019 issue 164 - switching to micrograms       
         fractionMass_text.setText(myFraction.getAnalysisMeasure(AnalysisMeasures.fractionMass.getName()).//
-                getValue().setScale(ReduxConstants.DEFAULT_PARAMETERS_SCALE, RoundingMode.HALF_UP).toPlainString());
+                getValue().movePointRight(6).setScale(ReduxConstants.DEFAULT_MASS_IN_MICRO_GRAMS_DISPLAY_SCALE, RoundingMode.HALF_UP).toPlainString());
 
         // Pb tab **************************************************************
         r206_204_text.setText(myFraction.getMeasuredRatioByName(MeasuredRatios.r206_204m.getName()).//
@@ -1554,14 +1555,14 @@ public class UPbFractionEditorDialog extends DialogEditor {
 
         inputAlphaUOneSigmaAbs_text.setText(((UPbFraction) myFraction).getInputAlphaU().getOneSigmaAbs().//
                 movePointRight(2).//
-                setScale(ReduxConstants.DEFAULT_MASS_DISPLAY_SCALE, RoundingMode.HALF_UP).toPlainString());
+                setScale(ReduxConstants.DEFAULT_MASS_IN_GRAMS_DISPLAY_SCALE, RoundingMode.HALF_UP).toPlainString());
 
         // tracer tab **********************************************************
         tracerMassOneSigmaAbs_label.setText("<html><u>1\u03C3 ABS:</u></html>");
         tracerMass_text.setText(myFraction.getAnalysisMeasure(AnalysisMeasures.tracerMassInGrams.getName()).//
                 getValue().setScale(ReduxConstants.DEFAULT_PARAMETERS_SCALE, RoundingMode.HALF_UP).toPlainString());
         tracerMassOneSigmaAbs_text.setText(myFraction.getAnalysisMeasure(AnalysisMeasures.tracerMassInGrams.getName()).//
-                getOneSigma().setScale(ReduxConstants.DEFAULT_MASS_DISPLAY_SCALE, RoundingMode.HALF_UP).toPlainString());
+                getOneSigma().setScale(ReduxConstants.DEFAULT_MASS_IN_GRAMS_DISPLAY_SCALE, RoundingMode.HALF_UP).toPlainString());
 
         // set up Tracer chooser modified June 2012
         ItemListener[] tracerActionListeners = tracerChooser.getItemListeners();
@@ -2004,8 +2005,9 @@ public class UPbFractionEditorDialog extends DialogEditor {
         }
 
         try {
+            // july 2019 issue 164 switch to micrograms display
             myFraction.getAnalysisMeasure(AnalysisMeasures.fractionMass.getName()).
-                    setValue(new BigDecimal(fractionMass_text.getText()));
+                    setValue(new BigDecimal(fractionMass_text.getText()).movePointLeft(6));
 
             // Pb tab
             myFraction.getMeasuredRatioByName(MeasuredRatios.r206_204m.getName()).setValue(new BigDecimal(r206_204_text.getText()));
@@ -2475,6 +2477,7 @@ public class UPbFractionEditorDialog extends DialogEditor {
         fractionMass_text = new javax.swing.JTextField();
         fractionID_text = new javax.swing.JTextField();
         fractionMassInGrams_label = new javax.swing.JLabel();
+        fractionMassInGrams_label.setText("fraction mass in \u03BCg:");
         fractionIsZircon_CheckBox = new javax.swing.JCheckBox();
         fraction_Chooser = new javax.swing.JComboBox<>();
         fractionID_label1 = new javax.swing.JLabel();
@@ -4142,7 +4145,6 @@ public class UPbFractionEditorDialog extends DialogEditor {
 
         fractionMassInGrams_label.setFont(new java.awt.Font("Tahoma", 1, 12)); // NOI18N
         fractionMassInGrams_label.setHorizontalAlignment(javax.swing.SwingConstants.TRAILING);
-        fractionMassInGrams_label.setText("fraction mass in g:");
 
         fractionIsZircon_CheckBox.setFont(new java.awt.Font("Tahoma", 1, 12)); // NOI18N
         fractionIsZircon_CheckBox.setText("No InitialPb");

--- a/src/main/java/org/earthtime/UPb_Redux/dialogs/sampleManagers/analysisManagers/SampleAnalysisWorkflowManagerIDTIMS.form
+++ b/src/main/java/org/earthtime/UPb_Redux/dialogs/sampleManagers/analysisManagers/SampleAnalysisWorkflowManagerIDTIMS.form
@@ -416,9 +416,6 @@
             </Property>
             <Property name="text" type="java.lang.String" value="Set Physical Constants:"/>
           </Properties>
-          <AccessibilityProperties>
-            <Property name="AccessibleContext.accessibleName" type="java.lang.String" value="Set Physical Constants:"/>
-          </AccessibilityProperties>
           <Constraints>
             <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.DesignAbsoluteLayout" value="org.netbeans.modules.form.compat2.layouts.DesignAbsoluteLayout$AbsoluteConstraintsDescription">
               <AbsoluteConstraints x="670" y="30" width="140" height="30"/>

--- a/src/main/java/org/earthtime/UPb_Redux/dialogs/sampleManagers/analysisManagers/SampleAnalysisWorkflowManagerIDTIMS.java
+++ b/src/main/java/org/earthtime/UPb_Redux/dialogs/sampleManagers/analysisManagers/SampleAnalysisWorkflowManagerIDTIMS.java
@@ -719,7 +719,8 @@ public class SampleAnalysisWorkflowManagerIDTIMS extends DialogEditor implements
         });
 
         // populate rows
-        for (int row = 0; row < ((UPbReduxAliquot) aliquot).getAliquotFractions().size(); row++) {
+        Vector<ETFractionInterface> fractionsFromAliquot = ((UPbReduxAliquot) aliquot).getAliquotFractionsSorted();
+        for (int row = 0; row < fractionsFromAliquot.size(); row++) {
             ETFractionInterface tempFrac = ((UPbReduxAliquot) aliquot).getAliquotFractions().get(row);
             int max = ((UPbReduxAliquot) aliquot).getAliquotFractions().size();
             addFractionRow(aliquot, tempFrac, row, max);
@@ -855,7 +856,7 @@ public class SampleAnalysisWorkflowManagerIDTIMS extends DialogEditor implements
         insertTableTextFieldForDoubles(fractionMassText, max);
 
         // Fraction Mass grams label
-        tempJL = new JLabel(" g");
+        tempJL = new JLabel("\u03BCg");
         tempJL.setForeground(Color.RED);
         tempJL.setFont(new Font("Monospaced", Font.BOLD, 10));
         fractionMassGRAMS.add(tempJL);
@@ -1059,8 +1060,8 @@ public class SampleAnalysisWorkflowManagerIDTIMS extends DialogEditor implements
         // build display *******************************************************
         // master fields
         myHorizFraction.add(jPanel2Layout.createSequentialGroup()//
-                .add(55, 55, 55) // left margin
-                .add(masterNewFractionName, 110, 110, 110)//
+                .add(60, 60, 60) // left margin
+                .add(masterNewFractionName, 100, 100, 100)//
                 .add(0, 0, 0)//
                 .add(masterZirconCaseCheckBox, 75, 75, 75)//
                 .add(5, 5, 5)//
@@ -1126,7 +1127,6 @@ public class SampleAnalysisWorkflowManagerIDTIMS extends DialogEditor implements
                         .add(masterEstimatedDateFiller)//, 22, 22, 22)//
                         .add(masterPbBlankMassFiller)//, 22, 22, 22)//
                 );
-
 
         // stop delete when only one fraction
         fractionDeleteButtons.get(0).setEnabled(fractionDeleteButtons.size() != 1);
@@ -1327,9 +1327,9 @@ public class SampleAnalysisWorkflowManagerIDTIMS extends DialogEditor implements
     }
 
     private void tuneNotesButton(JButton tempJB, String notes) {
-        
+
         Font font = tempJB.getFont();
-        
+
         if (notes.length() == 0) {
             tempJB.setFont(font.deriveFont(font.getStyle() & ~Font.BOLD));
 
@@ -1433,7 +1433,7 @@ public class SampleAnalysisWorkflowManagerIDTIMS extends DialogEditor implements
                 toPlainString());
         fractionEstDateText.get(row).setEnabled(hasStaceyKramersModel);
 
-        ((JTextComponent) fractionPbBlankMassText.get(row)).setText(tempFrac.getAnalysisMeasure(AnalysisMeasures.pbBlankMassInGrams.getName()).getValue().multiply(ReduxConstants.PicoGramsPerGram).setScale(ReduxConstants.DEFAULT_MASS_DISPLAY_SCALE,
+        ((JTextComponent) fractionPbBlankMassText.get(row)).setText(tempFrac.getAnalysisMeasure(AnalysisMeasures.pbBlankMassInGrams.getName()).getValue().multiply(ReduxConstants.PicoGramsPerGram).setScale(ReduxConstants.DEFAULT_MASS_IN_GRAMS_DISPLAY_SCALE,
                 RoundingMode.HALF_UP).toPlainString());
         ((UnDoAbleDocument) ((JTextComponent) fractionPbBlankMassText.get(row)).getDocument()).undo.discardAllEdits();
         fractionPbBlankMassText.get(row).setEnabled(!isZircon);
@@ -1462,13 +1462,15 @@ public class SampleAnalysisWorkflowManagerIDTIMS extends DialogEditor implements
         fractionTracerChoice.get(row).setEnabled(!(fraCorrU || fraCorrPb));
 
         ((JTextComponent) fractionTracerMassText.get(row)).setText(tempFrac.getAnalysisMeasure(AnalysisMeasures.tracerMassInGrams.getName()).getValue().
-                setScale(ReduxConstants.DEFAULT_MASS_DISPLAY_SCALE,
+                setScale(ReduxConstants.DEFAULT_MASS_IN_GRAMS_DISPLAY_SCALE,
                         RoundingMode.HALF_UP).toPlainString());
         ((UnDoAbleDocument) ((JTextComponent) fractionTracerMassText.get(row)).getDocument()).undo.discardAllEdits();
         fractionTracerMassText.get(row).setEnabled(!(fraCorrU));
 
-        ((JTextComponent) fractionMassText.get(row)).setText(tempFrac.getAnalysisMeasure(AnalysisMeasures.fractionMass.getName()).getValue().
-                setScale(ReduxConstants.DEFAULT_MASS_DISPLAY_SCALE, RoundingMode.HALF_UP).//
+        // july 2019 issue 164 switch to micrograms display
+        ((JTextComponent) fractionMassText.get(row)).setText(tempFrac.getAnalysisMeasure(AnalysisMeasures.fractionMass.getName())
+                .getValue().movePointRight(6).
+                setScale(ReduxConstants.DEFAULT_MASS_IN_MICRO_GRAMS_DISPLAY_SCALE, RoundingMode.HALF_UP).//
                 toPlainString());
         ((UnDoAbleDocument) ((JTextComponent) fractionMassText.get(row)).getDocument()).undo.discardAllEdits();
 
@@ -1482,7 +1484,7 @@ public class SampleAnalysisWorkflowManagerIDTIMS extends DialogEditor implements
                 setSelectedItem(((UPbFraction) tempFrac).getInitialPbModel().getReduxLabDataElementName());
         fractionInitialPbChoice.get(row).setEnabled(!isZircon);
 
-        ((JTextComponent) fractionPbBlankMassText.get(row)).setText(tempFrac.getAnalysisMeasure(AnalysisMeasures.pbBlankMassInGrams.getName()).getValue().multiply(ReduxConstants.PicoGramsPerGram).setScale(ReduxConstants.DEFAULT_MASS_DISPLAY_SCALE,
+        ((JTextComponent) fractionPbBlankMassText.get(row)).setText(tempFrac.getAnalysisMeasure(AnalysisMeasures.pbBlankMassInGrams.getName()).getValue().multiply(ReduxConstants.PicoGramsPerGram).setScale(ReduxConstants.DEFAULT_MASS_IN_GRAMS_DISPLAY_SCALE,
                 RoundingMode.HALF_UP).toPlainString());
         ((UnDoAbleDocument) ((JTextField) fractionPbBlankMassText.get(row)).getDocument()).undo.discardAllEdits();
         fractionPbBlankMassText.get(row).setEnabled(!isZircon);
@@ -1680,7 +1682,7 @@ public class SampleAnalysisWorkflowManagerIDTIMS extends DialogEditor implements
             try {
                 getMySample().setPhysicalConstantsModel(
                         ReduxLabData.getInstance().
-                        getAPhysicalConstantsModel(((String) physicalConstantsModelChooser.getSelectedItem())));
+                                getAPhysicalConstantsModel(((String) physicalConstantsModelChooser.getSelectedItem())));
 
             } catch (BadLabDataException ex) {
                 new ETWarningDialog(ex).setVisible(true);
@@ -1779,8 +1781,7 @@ public class SampleAnalysisWorkflowManagerIDTIMS extends DialogEditor implements
             if (((UPbFraction) tempFrac).needsAlphaPbModel()) {
                 if (((UPbFractionI) tempFrac).getAlphaPbModel().equals(noneAlphaPb)) {
                     ValueModel alphaPb
-                            = //
-                            ((UPbFraction) tempFrac).getMyLabData().getAnAlphaPbModel(((UPbReduxAliquot) aliquot).getDefaultAlphaPbModelID());
+                            = ((UPbFraction) tempFrac).getMyLabData().getAnAlphaPbModel(((UPbReduxAliquot) aliquot).getDefaultAlphaPbModelID());
                     ((UPbFractionI) tempFrac).setAlphaPbModel(alphaPb);
                 }
             } else {
@@ -1815,8 +1816,9 @@ public class SampleAnalysisWorkflowManagerIDTIMS extends DialogEditor implements
         tempFrac.getAnalysisMeasure(AnalysisMeasures.tracerMassInGrams.getName())//
                 .setValue(new BigDecimal(((JTextComponent) fractionTracerMassText.get(row)).getText()));
 
+        // July 2019 issue 164 switch to micrograms
         tempFrac.getAnalysisMeasure(AnalysisMeasures.fractionMass.getName())//
-                .setValue(new BigDecimal(((JTextComponent) fractionMassText.get(row)).getText()));
+                .setValue(new BigDecimal(((JTextComponent) fractionMassText.get(row)).getText()).movePointLeft(6));
 
         try {
             AbstractRatiosDataModel pbBlank = ((UPbFraction) tempFrac).getMyLabData().//
@@ -2150,7 +2152,7 @@ public class SampleAnalysisWorkflowManagerIDTIMS extends DialogEditor implements
 
         // dec 2011 update sample date models
         SampleInterface.updateAndSaveSampleDateModelsByAliquot(mySample);
-        
+
         // Sept 2017
         mySample.initFilteredFractionsToAll();
 

--- a/src/main/java/org/earthtime/UPb_Redux/dialogs/sampleManagers/analysisManagers/SampleAnalysisWorkflowManagerLAICPMS.java
+++ b/src/main/java/org/earthtime/UPb_Redux/dialogs/sampleManagers/analysisManagers/SampleAnalysisWorkflowManagerLAICPMS.java
@@ -1292,7 +1292,7 @@ public class SampleAnalysisWorkflowManagerLAICPMS extends DialogEditor implement
 //
 //        ((JTextField) fractionPbBlankMassText.get( row )).setText(
 //                tempFrac.getAnalysisMeasure( AnalysisMeasures.pbBlankMassInGrams.getName() ).getValue().multiply(
-//                ReduxConstants.PicoGramsPerGram ).setScale( ReduxConstants.DEFAULT_MASS_DISPLAY_SCALE,
+//                ReduxConstants.PicoGramsPerGram ).setScale( ReduxConstants.DEFAULT_MASS_IN_GRAMS_DISPLAY_SCALE,
 //                RoundingMode.HALF_UP ).toPlainString() );
 //        ((UnDoAbleDocument) ((JTextField) fractionPbBlankMassText.get( row )).getDocument()).undo.discardAllEdits();
 //        fractionPbBlankMassText.get( row ).setEnabled(  ! isZircon );
@@ -1322,14 +1322,14 @@ public class SampleAnalysisWorkflowManagerLAICPMS extends DialogEditor implement
 //
 //        ((JTextField) fractionTracerMassText.get( row )).setText(
 //                tempFrac.getAnalysisMeasure( AnalysisMeasures.tracerMassInGrams.getName() ).getValue().
-//                setScale( ReduxConstants.DEFAULT_MASS_DISPLAY_SCALE,
+//                setScale( ReduxConstants.DEFAULT_MASS_IN_GRAMS_DISPLAY_SCALE,
 //                RoundingMode.HALF_UP ).toPlainString() );
 //        ((UnDoAbleDocument) ((JTextField) fractionTracerMassText.get( row )).getDocument()).undo.discardAllEdits();
 //        fractionTracerMassText.get( row ).setEnabled(  ! (fraCorrU) );
 //
 //        ((JTextField) fractionMassText.get( row )).setText(
 //                tempFrac.getAnalysisMeasure( AnalysisMeasures.fractionMass.getName() ).getValue().
-//                setScale( ReduxConstants.DEFAULT_MASS_DISPLAY_SCALE, RoundingMode.HALF_UP ).//
+//                setScale( ReduxConstants.DEFAULT_MASS_IN_GRAMS_DISPLAY_SCALE, RoundingMode.HALF_UP ).//
 //                toPlainString() );
 //        ((UnDoAbleDocument) ((JTextField) fractionMassText.get( row )).getDocument()).undo.discardAllEdits();
 //
@@ -1347,7 +1347,7 @@ public class SampleAnalysisWorkflowManagerLAICPMS extends DialogEditor implement
 //
 //        ((JTextField) fractionPbBlankMassText.get( row )).setText(
 //                tempFrac.getAnalysisMeasure( AnalysisMeasures.pbBlankMassInGrams.getName() ).getValue().multiply(
-//                ReduxConstants.PicoGramsPerGram ).setScale( ReduxConstants.DEFAULT_MASS_DISPLAY_SCALE,
+//                ReduxConstants.PicoGramsPerGram ).setScale( ReduxConstants.DEFAULT_MASS_IN_GRAMS_DISPLAY_SCALE,
 //                RoundingMode.HALF_UP ).toPlainString() );
 //        ((UnDoAbleDocument) ((JTextField) fractionPbBlankMassText.get( row )).getDocument()).undo.discardAllEdits();
 //        fractionPbBlankMassText.get( row ).setEnabled(  ! isZircon );

--- a/src/main/java/org/earthtime/UPb_Redux/dialogs/sampleManagers/sampleDateInterpretationManagers/SampleDateInterpretationsManager.java
+++ b/src/main/java/org/earthtime/UPb_Redux/dialogs/sampleManagers/sampleDateInterpretationManagers/SampleDateInterpretationsManager.java
@@ -1068,7 +1068,12 @@ public class SampleDateInterpretationsManager extends DialogEditor
         // this standin aliquot for the whole sample makes weighted means graphs work
         // updated april 2016
         AliquotInterface standInAliquot
-                = sample.generateDefaultAliquot(1, sample.getSampleName(), ReduxLabData.getInstance().getDefaultPhysicalConstantsModel(), sample.isAnalyzed(), sample.getMySESARSampleMetadata());
+                = sample.generateDefaultAliquot(
+                        1, 
+                        sample.getSampleName(), 
+                        ReduxLabData.getInstance().getDefaultPhysicalConstantsModel(), 
+                        sample.isAnalyzed(), sample.getMySESARSampleMetadata(),
+                        sample.getSampleAnalysisType());
 //        standInAliquot.setAliquotName(sample.getSampleName());
 
         ((ReduxAliquotInterface) standInAliquot).setAliquotFractions(sample.getFractions());

--- a/src/main/java/org/earthtime/UPb_Redux/reports/ReportSettings.java
+++ b/src/main/java/org/earthtime/UPb_Redux/reports/ReportSettings.java
@@ -55,7 +55,7 @@ public class ReportSettings implements
      * report models upon opening in ET_Redux.
      */
     private static transient int CURRENT_VERSION_REPORT_SETTINGS_UPB = 405;
-    private static transient int CURRENT_VERSION_REPORT_SETTINGS_UTH_Carb = 6027;
+    private static transient int CURRENT_VERSION_REPORT_SETTINGS_UTH_Carb = 6029;
     private static transient int CURRENT_VERSION_REPORT_SETTINGS_UTH_Ign = 6007;
 
     // Fields

--- a/src/main/java/org/earthtime/UPb_Redux/reports/ReportSettings.java
+++ b/src/main/java/org/earthtime/UPb_Redux/reports/ReportSettings.java
@@ -55,7 +55,7 @@ public class ReportSettings implements
      * report models upon opening in ET_Redux.
      */
     private static transient int CURRENT_VERSION_REPORT_SETTINGS_UPB = 405;
-    private static transient int CURRENT_VERSION_REPORT_SETTINGS_UTH_Carb = 6025;
+    private static transient int CURRENT_VERSION_REPORT_SETTINGS_UTH_Carb = 6027;
     private static transient int CURRENT_VERSION_REPORT_SETTINGS_UTH_Ign = 6007;
 
     // Fields

--- a/src/main/java/org/earthtime/UPb_Redux/samples/Sample.java
+++ b/src/main/java/org/earthtime/UPb_Redux/samples/Sample.java
@@ -278,21 +278,27 @@ public class Sample implements
         this.filteredFractionIDs = null;
     }
 
+    /**
+     *
+     * @param aliquotNumber the value of aliquotNumber
+     * @param aliquotName the value of aliquotName
+     * @param physicalConstants the value of physicalConstants
+     * @param compiled the value of compiled
+     * @param mySESARSampleMetadata the value of mySESARSampleMetadata
+     * @param sampleAnalysisType the value of sampleAnalysisType
+     */
     @Override
     public AliquotInterface generateDefaultAliquot(//
-            int aliquotNumber,
-            String aliquotName,
-            AbstractRatiosDataModel physicalConstants,
-            boolean compiled,
-            SESARSampleMetadata mySESARSampleMetadata) {
+            int aliquotNumber, String aliquotName, AbstractRatiosDataModel physicalConstants, boolean compiled, SESARSampleMetadata mySESARSampleMetadata, String sampleAnalysisType) {
 
         return new UPbReduxAliquot(aliquotNumber, aliquotName, physicalConstants, compiled, mySESARSampleMetadata);
     }
-
-    @Override
-    public AliquotInterface generateDefaultAliquot() {
-        return new UPbReduxAliquot();
-    }
+    //
+//    
+//    @Override
+//    public AliquotInterface generateDefaultAliquot() {
+//        return new UPbReduxAliquot();
+//    }
 
     /**
      *

--- a/src/main/java/org/earthtime/UPb_Redux/utilities/ClientHttpRequest.java
+++ b/src/main/java/org/earthtime/UPb_Redux/utilities/ClientHttpRequest.java
@@ -12,7 +12,6 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-
 package org.earthtime.UPb_Redux.utilities;
 
 import java.io.*;
@@ -24,9 +23,12 @@ import java.util.Map;
 import java.util.Random;
 
 /**
- * <p>Title: Client HTTP Request class</p>
- * <p>Description: this class helps to send POST HTTP requests with various form data,
- * including files. Cookies can be added to be included in the request.</p>
+ * <p>
+ * Title: Client HTTP Request class</p>
+ * <p>
+ * Description: this class helps to send POST HTTP requests with various form
+ * data, including files. Cookies can be added to be included in the
+ * request.</p>
  *
  * @author Vlad Patryshev
  * @version 1.0
@@ -42,17 +44,20 @@ public class ClientHttpRequest {
     Map<String, String> cookies = new HashMap<String, String>();
 
     /**
-     * 
+     *
      * @throws IOException
      */
     protected void connect() throws IOException {
         if (os == null) {
+            // july 2019
+            connection.setConnectTimeout(5000);
+            connection.setReadTimeout(5000);
             os = connection.getOutputStream();
         }
     }
 
     /**
-     * 
+     *
      * @param c
      * @throws IOException
      */
@@ -62,7 +67,7 @@ public class ClientHttpRequest {
     }
 
     /**
-     * 
+     *
      * @param s
      * @throws IOException
      */
@@ -72,7 +77,7 @@ public class ClientHttpRequest {
     }
 
     /**
-     * 
+     *
      * @throws IOException
      */
     protected void newline() throws IOException {
@@ -81,7 +86,7 @@ public class ClientHttpRequest {
     }
 
     /**
-     * 
+     *
      * @param s
      * @throws IOException
      */
@@ -93,7 +98,7 @@ public class ClientHttpRequest {
     private static Random random = new Random();
 
     /**
-     * 
+     *
      * @return
      */
     protected static String randomString() {
@@ -107,13 +112,18 @@ public class ClientHttpRequest {
     }
 
     /**
-     * Creates a new multipart POST HTTP request on a freshly opened URLConnection
+     * Creates a new multipart POST HTTP request on a freshly opened
+     * URLConnection
      *
      * @param connection an already open URL connection
      * @throws IOException
      */
     public ClientHttpRequest(URLConnection connection) throws IOException {
         this.connection = connection;
+        // july 2019
+        connection.setConnectTimeout(5000);
+        connection.setReadTimeout(5000);
+
         connection.setDoOutput(true);
         connection.setRequestProperty("Content-Type",
                 "multipart/form-data; boundary=" + boundary);
@@ -157,6 +167,7 @@ public class ClientHttpRequest {
 
     /**
      * adds a cookie to the requst
+     *
      * @param name cookie name
      * @param value cookie value
      * @throws IOException
@@ -167,6 +178,7 @@ public class ClientHttpRequest {
 
     /**
      * adds cookies to the request
+     *
      * @param cookies the cookie "name-to-value" map
      * @throws IOException
      */
@@ -179,7 +191,9 @@ public class ClientHttpRequest {
 
     /**
      * adds cookies to the request
-     * @param cookies array of cookie names and values (cookies[2*i] is a name, cookies[2*i + 1] is a value)
+     *
+     * @param cookies array of cookie names and values (cookies[2*i] is a name,
+     * cookies[2*i + 1] is a value)
      * @throws IOException
      */
     public void setCookies(String[] cookies) throws IOException {
@@ -200,6 +214,7 @@ public class ClientHttpRequest {
 
     /**
      * adds a string parameter to the request
+     *
      * @param name parameter name
      * @param value parameter value
      * @throws IOException
@@ -229,6 +244,7 @@ public class ClientHttpRequest {
 
     /**
      * adds a file parameter to the request
+     *
      * @param name parameter name
      * @param filename the name of the file
      * @param is input stream to read the contents of the file from
@@ -254,6 +270,7 @@ public class ClientHttpRequest {
 
     /**
      * adds a file parameter to the request
+     *
      * @param name parameter name
      * @param file the file to upload
      * @throws IOException
@@ -263,9 +280,13 @@ public class ClientHttpRequest {
     }
 
     /**
-     * adds a parameter to the request; if the parameter is a File, the file is uploaded, otherwise the string value of the parameter is passed in the request
+     * adds a parameter to the request; if the parameter is a File, the file is
+     * uploaded, otherwise the string value of the parameter is passed in the
+     * request
+     *
      * @param name parameter name
-     * @param object parameter value, a File or anything else that can be stringified
+     * @param object parameter value, a File or anything else that can be
+     * stringified
      * @throws IOException
      */
     public void setParameter(String name, Object object) throws IOException {
@@ -278,7 +299,10 @@ public class ClientHttpRequest {
 
     /**
      * adds parameters to the request
-     * @param parameters "name-to-value" map of parameters; if a value is a file, the file is uploaded, otherwise it is stringified and sent in the request
+     *
+     * @param parameters "name-to-value" map of parameters; if a value is a
+     * file, the file is uploaded, otherwise it is stringified and sent in the
+     * request
      * @throws IOException
      */
     public void setParameters(Map parameters) throws IOException {
@@ -293,7 +317,10 @@ public class ClientHttpRequest {
 
     /**
      * adds parameters to the request
-     * @param parameters array of parameter names and values (parameters[2*i] is a name, parameters[2*i + 1] is a value); if a value is a file, the file is uploaded, otherwise it is stringified and sent in the request
+     *
+     * @param parameters array of parameter names and values (parameters[2*i] is
+     * a name, parameters[2*i + 1] is a value); if a value is a file, the file
+     * is uploaded, otherwise it is stringified and sent in the request
      * @throws IOException
      */
     public void setParameters(Object[] parameters) throws IOException {
@@ -306,7 +333,9 @@ public class ClientHttpRequest {
     }
 
     /**
-     * posts the requests to the server, with all the cookies and parameters that were added
+     * posts the requests to the server, with all the cookies and parameters
+     * that were added
+     *
      * @return input stream with the server response
      * @throws IOException
      */
@@ -314,11 +343,18 @@ public class ClientHttpRequest {
         boundary();
         writeln("--");
         os.close();
+
+        // july 2019
+        connection.setConnectTimeout(5000);
+        connection.setReadTimeout(5000);
         return connection.getInputStream();
     }
 
     /**
-     * posts the requests to the server, with all the cookies and parameters that were added before (if any), and with parameters that are passed in the argument
+     * posts the requests to the server, with all the cookies and parameters
+     * that were added before (if any), and with parameters that are passed in
+     * the argument
+     *
      * @param parameters request parameters
      * @return input stream with the server response
      * @throws IOException
@@ -330,7 +366,10 @@ public class ClientHttpRequest {
     }
 
     /**
-     * posts the requests to the server, with all the cookies and parameters that were added before (if any), and with parameters that are passed in the argument
+     * posts the requests to the server, with all the cookies and parameters
+     * that were added before (if any), and with parameters that are passed in
+     * the argument
+     *
      * @param parameters request parameters
      * @return input stream with the server response
      * @throws IOException
@@ -342,7 +381,10 @@ public class ClientHttpRequest {
     }
 
     /**
-     * posts the requests to the server, with all the cookies and parameters that were added before (if any), and with cookies and parameters that are passed in the arguments
+     * posts the requests to the server, with all the cookies and parameters
+     * that were added before (if any), and with cookies and parameters that are
+     * passed in the arguments
+     *
      * @param cookies request cookies
      * @param parameters request parameters
      * @return input stream with the server response
@@ -357,7 +399,10 @@ public class ClientHttpRequest {
     }
 
     /**
-     * posts the requests to the server, with all the cookies and parameters that were added before (if any), and with cookies and parameters that are passed in the arguments
+     * posts the requests to the server, with all the cookies and parameters
+     * that were added before (if any), and with cookies and parameters that are
+     * passed in the arguments
+     *
      * @param cookies request cookies
      * @param parameters request parameters
      * @return input stream with the server response
@@ -373,6 +418,7 @@ public class ClientHttpRequest {
 
     /**
      * post the POST request to the server, with the specified parameter
+     *
      * @param name parameter name
      * @param value parameter value
      * @return input stream with the server response
@@ -386,6 +432,7 @@ public class ClientHttpRequest {
 
     /**
      * post the POST request to the server, with the specified parameters
+     *
      * @param name1 first parameter name
      * @param value1 first parameter value
      * @param name2 second parameter name
@@ -401,6 +448,7 @@ public class ClientHttpRequest {
 
     /**
      * post the POST request to the server, with the specified parameters
+     *
      * @param name1 first parameter name
      * @param value1 first parameter value
      * @param name2 second parameter name
@@ -418,6 +466,7 @@ public class ClientHttpRequest {
 
     /**
      * post the POST request to the server, with the specified parameters
+     *
      * @param name1 first parameter name
      * @param value1 first parameter value
      * @param name2 second parameter name
@@ -436,8 +485,10 @@ public class ClientHttpRequest {
     }
 
     /**
-     * posts a new request to specified URL, with parameters that are passed in the argument
-     * @param url 
+     * posts a new request to specified URL, with parameters that are passed in
+     * the argument
+     *
+     * @param url
      * @param parameters request parameters
      * @return input stream with the server response
      * @throws IOException
@@ -448,8 +499,10 @@ public class ClientHttpRequest {
     }
 
     /**
-     * posts a new request to specified URL, with parameters that are passed in the argument
-     * @param url 
+     * posts a new request to specified URL, with parameters that are passed in
+     * the argument
+     *
+     * @param url
      * @param parameters request parameters
      * @return input stream with the server response
      * @throws IOException
@@ -460,8 +513,10 @@ public class ClientHttpRequest {
     }
 
     /**
-     * posts a new request to specified URL, with cookies and parameters that are passed in the argument
-     * @param url 
+     * posts a new request to specified URL, with cookies and parameters that
+     * are passed in the argument
+     *
+     * @param url
      * @param cookies request cookies
      * @param parameters request parameters
      * @return input stream with the server response
@@ -474,8 +529,10 @@ public class ClientHttpRequest {
     }
 
     /**
-     * posts a new request to specified URL, with cookies and parameters that are passed in the argument
-     * @param url 
+     * posts a new request to specified URL, with cookies and parameters that
+     * are passed in the argument
+     *
+     * @param url
      * @param cookies request cookies
      * @param parameters request parameters
      * @return input stream with the server response
@@ -489,9 +546,10 @@ public class ClientHttpRequest {
 
     /**
      * post the POST request specified URL, with the specified parameter
-     * @param url 
-     * @param name1 
-     * @param value1 
+     *
+     * @param url
+     * @param name1
+     * @param value1
      * @return input stream with the server response
      * @throws IOException
      * @see setParameter
@@ -502,7 +560,8 @@ public class ClientHttpRequest {
 
     /**
      * post the POST request to specified URL, with the specified parameters
-     * @param url 
+     *
+     * @param url
      * @param name1 first parameter name
      * @param value1 first parameter value
      * @param name2 second parameter name
@@ -517,7 +576,8 @@ public class ClientHttpRequest {
 
     /**
      * post the POST request to specified URL, with the specified parameters
-     * @param url 
+     *
+     * @param url
      * @param name1 first parameter name
      * @param value1 first parameter value
      * @param name2 second parameter name
@@ -534,7 +594,8 @@ public class ClientHttpRequest {
 
     /**
      * post the POST request to specified URL, with the specified parameters
-     * @param url 
+     *
+     * @param url
      * @param name1 first parameter name
      * @param value1 first parameter value
      * @param name2 second parameter name

--- a/src/main/java/org/earthtime/UPb_Redux/utilities/ClientHttpRequest.java
+++ b/src/main/java/org/earthtime/UPb_Redux/utilities/ClientHttpRequest.java
@@ -50,8 +50,8 @@ public class ClientHttpRequest {
     protected void connect() throws IOException {
         if (os == null) {
             // july 2019
-            connection.setConnectTimeout(5000);
-            connection.setReadTimeout(5000);
+            connection.setConnectTimeout(10000);
+            connection.setReadTimeout(10000);
             os = connection.getOutputStream();
         }
     }
@@ -121,8 +121,8 @@ public class ClientHttpRequest {
     public ClientHttpRequest(URLConnection connection) throws IOException {
         this.connection = connection;
         // july 2019
-        connection.setConnectTimeout(5000);
-        connection.setReadTimeout(5000);
+        connection.setConnectTimeout(10000);
+        connection.setReadTimeout(10000);
 
         connection.setDoOutput(true);
         connection.setRequestProperty("Content-Type",
@@ -345,8 +345,8 @@ public class ClientHttpRequest {
         os.close();
 
         // july 2019
-        connection.setConnectTimeout(5000);
-        connection.setReadTimeout(5000);
+        connection.setConnectTimeout(10000);
+        connection.setReadTimeout(10000);
         return connection.getInputStream();
     }
 

--- a/src/main/java/org/earthtime/UPb_Redux/valueModels/SampleDateModel.java
+++ b/src/main/java/org/earthtime/UPb_Redux/valueModels/SampleDateModel.java
@@ -1144,7 +1144,7 @@ public class SampleDateModel extends ValueModel implements
                 RadRatios ratioName = RadRatios.valueOf(radiogenicIsotopeDateName.replace("age", "r"));
 
                 SessionCorrectedUnknownsSummary sessionCorrectedUnknownsSummary
-                        =//
+                        =
                         sessionCorrectedUnknownsSummaries.get(ratioName);
 
                 Matrix unknownsAnalyticalCovarianceSu = sessionCorrectedUnknownsSummary.getUnknownsAnalyticalCovarianceSu();
@@ -1340,10 +1340,10 @@ public class SampleDateModel extends ValueModel implements
         // build vector of date values for specified date with one for each fraction
         Matrix vectorXBar = new Matrix(countOfFractions, 1);
         for (int i = 0; i < countOfFractions; i++) {
-            vectorXBar.set(//
-                    i, //
-                    0, //
-                    myFractions.get(i).getRadiogenicIsotopeDateByName(radiogenicIsotopeDateName).//
+            vectorXBar.set(
+                    i,
+                    0,
+                    myFractions.get(i).getRadiogenicIsotopeDateByName(radiogenicIsotopeDateName).
                             getValue().doubleValue());
         }
 
@@ -2080,6 +2080,14 @@ public class SampleDateModel extends ValueModel implements
         calculateWeightedMeansWithMSWDforRatioBasedData(myFractions, dateName);
     }
 
+    // June 2019 to handle open-system date
+    public void OSDate(Vector<ETFractionInterface> myFractions)
+            throws ETException {
+        ZeroAllValues();
+
+        calculateWeightedMeansWithMSWDforRatioBasedData(myFractions, dateName);
+    }
+
     /**
      * zeroes all values, sets this <code>SampleDateModel</code>'s fields to
      * those of the first <code>Fraction</code> found in argument
@@ -2796,12 +2804,9 @@ public class SampleDateModel extends ValueModel implements
 
         String contents = "";
         if ((dateName.length() > 0) && (methodName.compareToIgnoreCase("ISO238_230") != 0)) {
-            contents
-                    = //
-                    " : date = "//
-                    + fraction.getRadiogenicIsotopeDateByName(dateName)//
-                            .formatValueAndTwoSigmaForPublicationSigDigMode(//
-                                    "ABS", ReduxConstants.getUnitConversionMoveCount(unitsForYears), 2)//
+            contents = " : date = " + fraction.getRadiogenicIsotopeDateByName(dateName)
+                    .formatValueAndTwoSigmaForPublicationSigDigMode(//
+                            "ABS", ReduxConstants.getUnitConversionMoveCount(unitsForYears), 2)
                     + " " + unitsForYears + " 2\u03C3";//               " Ma 2\u03C3";
         }
 
@@ -3243,7 +3248,8 @@ public class SampleDateModel extends ValueModel implements
     }
 
     /**
-     * @param ar48icntrsDsplayAsDeltaUnits the ar48icntrsDsplayAsDeltaUnits to set
+     * @param ar48icntrsDsplayAsDeltaUnits the ar48icntrsDsplayAsDeltaUnits to
+     * set
      */
     public void setAr48icntrsDsplayAsDeltaUnits(boolean ar48icntrsDsplayAsDeltaUnits) {
         this.ar48icntrsDsplayAsDeltaUnits = ar48icntrsDsplayAsDeltaUnits;

--- a/src/main/java/org/earthtime/UPb_Redux/valueModels/SampleDateModel.java
+++ b/src/main/java/org/earthtime/UPb_Redux/valueModels/SampleDateModel.java
@@ -2076,6 +2076,9 @@ public class SampleDateModel extends ValueModel implements
     public void WMDate(Vector<ETFractionInterface> myFractions)
             throws ETException {
         ZeroAllValues();
+        
+         // TODO: make more robust
+        unitsForYears = "ka";
 
         calculateWeightedMeansWithMSWDforRatioBasedData(myFractions, dateName);
     }
@@ -2084,6 +2087,9 @@ public class SampleDateModel extends ValueModel implements
     public void OSDate(Vector<ETFractionInterface> myFractions)
             throws ETException {
         ZeroAllValues();
+        
+        // TODO: make more robust
+        unitsForYears = "ka";
 
         calculateWeightedMeansWithMSWDforRatioBasedData(myFractions, dateName);
     }

--- a/src/main/java/org/earthtime/UTh_Redux/aliquots/UThReduxAliquot.java
+++ b/src/main/java/org/earthtime/UTh_Redux/aliquots/UThReduxAliquot.java
@@ -166,11 +166,6 @@ public class UThReduxAliquot implements //
         this.laboratoryName = ReduxLabData.getInstance().getLabName();
         this.analystName = ReduxLabData.getInstance().getAnalystName();
 
-//        this.automaticDataUpdateMode = false;
-//
-//        this.containingSampleDataFolder = null;
-//
-//        this.mySESARSampleMetadata = mySESARSampleMetadata;
         this.myReduxLabData = ReduxLabData.getInstance();
 
         this.sampleAnalysisType = sampleAnalysisType;

--- a/src/main/java/org/earthtime/UTh_Redux/aliquots/UThReduxAliquot.java
+++ b/src/main/java/org/earthtime/UTh_Redux/aliquots/UThReduxAliquot.java
@@ -121,7 +121,13 @@ public class UThReduxAliquot implements //
     private Vector<ETFractionInterface> aliquotFractions;
     private transient ReduxLabData myReduxLabData;
 
+    private String sampleAnalysisType;
+
     public UThReduxAliquot() {
+    }
+    
+    public UThReduxAliquot(String sampleAnalysisType) {
+        this.sampleAnalysisType = sampleAnalysisType;
     }
 
     /**
@@ -131,6 +137,7 @@ public class UThReduxAliquot implements //
      * @param physicalConstantsModel
      * @param reduxLabData
      * @param physicalConstants
+     * @param sampleAnalysisType
      * @param compiled
      * @param mySESARSampleMetadata
      */
@@ -139,7 +146,8 @@ public class UThReduxAliquot implements //
             String aliquotName,
             AbstractRatiosDataModel physicalConstantsModel,
             boolean compiled,
-            SESARSampleMetadata mySESARSampleMetadata) {
+            SESARSampleMetadata mySESARSampleMetadata,
+            String sampleAnalysisType) {
 
         this.aliquotIGSN = ReduxConstants.DEFAULT_ALIQUOT_IGSN;
         this.aliquotName = aliquotName;
@@ -164,6 +172,8 @@ public class UThReduxAliquot implements //
 //
 //        this.mySESARSampleMetadata = mySESARSampleMetadata;
         this.myReduxLabData = ReduxLabData.getInstance();
+
+        this.sampleAnalysisType = sampleAnalysisType;
     }
 
     @Override
@@ -606,4 +616,11 @@ public class UThReduxAliquot implements //
     }
 
     // END  XML Serialization***********************************************************************************************************END
+
+    /**
+     * @return the sampleAnalysisType
+     */
+    public String getSampleAnalysisType() {
+        return sampleAnalysisType;
+    }
 }

--- a/src/main/java/org/earthtime/UTh_Redux/aliquots/UThReduxAliquotXMLConverter.java
+++ b/src/main/java/org/earthtime/UTh_Redux/aliquots/UThReduxAliquotXMLConverter.java
@@ -26,28 +26,19 @@ import com.thoughtworks.xstream.converters.MarshallingContext;
 import com.thoughtworks.xstream.converters.UnmarshallingContext;
 import com.thoughtworks.xstream.io.HierarchicalStreamReader;
 import com.thoughtworks.xstream.io.HierarchicalStreamWriter;
-import java.math.BigDecimal;
 import java.util.Vector;
 import org.earthtime.UPb_Redux.ReduxConstants.ANALYSIS_PURPOSE;
 import org.earthtime.UPb_Redux.fractions.AnalysisFraction;
 import org.earthtime.UPb_Redux.fractions.FractionI;
 import org.earthtime.UPb_Redux.mineralStandardModels.MineralStandardModel;
 import org.earthtime.UPb_Redux.mineralStandardModels.MineralStandardModelXMLConverter;
-import org.earthtime.UPb_Redux.pbBlanks.PbBlank;
-import org.earthtime.UPb_Redux.pbBlanks.PbBlankXMLConverter;
-import org.earthtime.UPb_Redux.tracers.Tracer;
-import org.earthtime.UPb_Redux.tracers.TracerXMLConverter;
 import org.earthtime.UPb_Redux.valueModels.SampleDateInterceptModel;
 import org.earthtime.UPb_Redux.valueModels.SampleDateModel;
 import org.earthtime.UPb_Redux.valueModels.ValueModel;
-import org.earthtime.physicalConstants.PhysicalConstants;
-import org.earthtime.physicalConstants.PhysicalConstantsXMLConverter;
 import org.earthtime.ratioDataModels.AbstractRatiosDataModel;
 import org.earthtime.ratioDataModels.mineralStandardModels.MineralStandardUPbModel;
 import org.earthtime.ratioDataModels.mineralStandardModels.MineralStandardUPbModelXMLConverter;
-import org.earthtime.ratioDataModels.pbBlankICModels.PbBlankICModel;
 import org.earthtime.ratioDataModels.physicalConstantsModels.PhysicalConstantsModel;
-import org.earthtime.ratioDataModels.tracers.TracerUPbModel;
 
 /**
  *

--- a/src/main/java/org/earthtime/UTh_Redux/fractions/UThFraction.java
+++ b/src/main/java/org/earthtime/UTh_Redux/fractions/UThFraction.java
@@ -782,6 +782,7 @@ public class UThFraction implements
     /**
      * @return the seaWaterInitialDelta234UTableModel
      */
+    @Override
     public SeaWaterInitialDelta234UTableModel getSeaWaterInitialDelta234UTableModel() {
         return seaWaterInitialDelta234UTableModel;
     }
@@ -789,6 +790,7 @@ public class UThFraction implements
     /**
      * @param seaWaterInitialDelta234UTableModel the seaWaterInitialDelta234UTableModel to set
      */
+    @Override
     public void setSeaWaterInitialDelta234UTableModel(SeaWaterInitialDelta234UTableModel seaWaterInitialDelta234UTableModel) {
         if (seaWaterInitialDelta234UTableModel == null){
             seaWaterInitialDelta234UTableModel = ReduxLabData.getInstance().getDefaultLabSeaWaterModel();
@@ -799,6 +801,7 @@ public class UThFraction implements
     /**
      * @return the pctLoss
      */
+    @Override
     public ValueModel getPctLoss() {
         if (pctLoss == null){
             this.pctLoss = new ValueModel("pctLoss", new BigDecimal(2.5), "ABS", BigDecimal.ONE, BigDecimal.ZERO);
@@ -809,6 +812,7 @@ public class UThFraction implements
     /**
      * @param pctLoss the pctLoss to set
      */
+    @Override
     public void setPctLoss(ValueModel pctLoss) {
         this.pctLoss = pctLoss.copy();
     }

--- a/src/main/java/org/earthtime/UTh_Redux/fractions/UThFraction.java
+++ b/src/main/java/org/earthtime/UTh_Redux/fractions/UThFraction.java
@@ -39,6 +39,7 @@ import org.earthtime.reduxLabData.ReduxLabData;
 import org.earthtime.reportViews.ReportRowGUIInterface;
 import org.earthtime.xmlUtilities.XMLSerializationI;
 import static org.earthtime.UPb_Redux.ReduxConstants.TIME_IN_MILLISECONDS_FROM_1970_TO_2000;
+import org.earthtime.plots.evolution.seaWater.SeaWaterInitialDelta234UTableModel;
 
 public class UThFraction implements
         UThFractionI,
@@ -81,6 +82,10 @@ public class UThFraction implements
 
     protected boolean filtered;
 
+    // July 2019 - see emails from Noah 20 June 2019 and following
+    protected SeaWaterInitialDelta234UTableModel seaWaterInitialDelta234UTableModel;
+    protected ValueModel pctLoss;
+
     private int rgbColor;
     private transient Path2D errorEllipsePath;
     private transient double ellipseRho;
@@ -97,20 +102,20 @@ public class UThFraction implements
         this.numberOfGrains = ReduxLabData.getInstance().getDefaultNumberOfGrains();
         this.estimatedDate = BigDecimal.ZERO;
 
-        analysisMeasures = valueModelArrayFactory(UThAnalysisMeasures.getNames(), UncertaintyTypesEnum.ABS.getName());
-        measuredRatios = new ValueModel[0];
-        fractionationCorrectedIsotopeRatios = valueModelArrayFactory(UThFractionationCorrectedIsotopicRatios.getNames(), UncertaintyTypesEnum.ABS.getName());
-        isotopeDates = valueModelArrayFactory(RadDates.getNamesSorted(), UncertaintyTypesEnum.ABS.getName());
-        compositionalMeasures = valueModelArrayFactory(UThCompositionalMeasures.getNames(), UncertaintyTypesEnum.ABS.getName());
-        sampleIsochronRatios = new ValueModel[0]; //valueModelArrayFactory(DataDictionary.SampleIsochronRatioNames, UncertaintyTypesEnum.ABS.getName());
+        this.analysisMeasures = valueModelArrayFactory(UThAnalysisMeasures.getNames(), UncertaintyTypesEnum.ABS.getName());
+        this.measuredRatios = new ValueModel[0];
+        this.fractionationCorrectedIsotopeRatios = valueModelArrayFactory(UThFractionationCorrectedIsotopicRatios.getNames(), UncertaintyTypesEnum.ABS.getName());
+        this.isotopeDates = valueModelArrayFactory(RadDates.getNamesSorted(), UncertaintyTypesEnum.ABS.getName());
+        this.compositionalMeasures = valueModelArrayFactory(UThCompositionalMeasures.getNames(), UncertaintyTypesEnum.ABS.getName());
+        this.sampleIsochronRatios = new ValueModel[0]; //valueModelArrayFactory(DataDictionary.SampleIsochronRatioNames, UncertaintyTypesEnum.ABS.getName());
 
-        physicalConstantsModel = ReduxLabData.getInstance().getDefaultPhysicalConstantsModel();
-        detritalUThModel = ReduxLabData.getInstance().getDefaultDetritalUraniumAndThoriumModel();
+        this.physicalConstantsModel = ReduxLabData.getInstance().getDefaultPhysicalConstantsModel();
+        this.detritalUThModel = ReduxLabData.getInstance().getDefaultDetritalUraniumAndThoriumModel();
 
-        dateTimeMillisecondsOfAnalysis = TIME_IN_MILLISECONDS_FROM_1970_TO_2000;
+        this.dateTimeMillisecondsOfAnalysis = TIME_IN_MILLISECONDS_FROM_1970_TO_2000;
 
-        spikeCalibrationR230_238IsSecular = false;
-        spikeCalibrationR234_238IsSecular = false;
+        this.spikeCalibrationR230_238IsSecular = false;
+        this.spikeCalibrationR234_238IsSecular = false;
         // see fraction reducer for multiplicative use
         this.r230Th_238Ufc_rectificationFactor = new ValueModel(
                 "r230Th_238Ufc_rectificationFactor",
@@ -124,16 +129,19 @@ public class UThFraction implements
                 "ABS",
                 BigDecimal.ONE,
                 BigDecimal.ONE);
-        
-        r230Th_238Ufc_referenceMaterialName = "";
-        r234U_238Ufc_referenceMaterialName = "";
-        
+
+        this.r230Th_238Ufc_referenceMaterialName = "";
+        this.r234U_238Ufc_referenceMaterialName = "";
+
         this.changed = false;
         this.deleted = false;
         this.fractionNotes = "";
         this.rejected = false;
 
-        rgbColor = 0;
+        this.rgbColor = 0;
+
+        this.seaWaterInitialDelta234UTableModel = ReduxLabData.getInstance().getDefaultLabSeaWaterModel();
+        this.pctLoss = new ValueModel("pctLoss", new BigDecimal(2.5), "ABS", BigDecimal.ONE, BigDecimal.ZERO);
 
     }
 
@@ -735,7 +743,7 @@ public class UThFraction implements
 
     /**
      * @param r234U_238Ufc_rectificationFactor the
- r234U_238Ufc_rectificationFactor to set
+     * r234U_238Ufc_rectificationFactor to set
      */
     public void setR234U_238Ufc_rectificationFactor(ValueModel r234U_238Ufc_rectificationFactor) {
         this.r234U_238Ufc_rectificationFactor = r234U_238Ufc_rectificationFactor;
@@ -749,7 +757,8 @@ public class UThFraction implements
     }
 
     /**
-     * @param r230Th_238Ufc_referenceMaterialName the r230Th_238Ufc_referenceMaterialName to set
+     * @param r230Th_238Ufc_referenceMaterialName the
+     * r230Th_238Ufc_referenceMaterialName to set
      */
     public void setR230Th_238Ufc_referenceMaterialName(String r230Th_238Ufc_referenceMaterialName) {
         this.r230Th_238Ufc_referenceMaterialName = r230Th_238Ufc_referenceMaterialName;
@@ -763,10 +772,45 @@ public class UThFraction implements
     }
 
     /**
-     * @param r234U_238Ufc_referenceMaterialName the r234U_238Ufc_referenceMaterialName to set
+     * @param r234U_238Ufc_referenceMaterialName the
+     * r234U_238Ufc_referenceMaterialName to set
      */
     public void setR234U_238Ufc_referenceMaterialName(String r234U_238Ufc_referenceMaterialName) {
         this.r234U_238Ufc_referenceMaterialName = r234U_238Ufc_referenceMaterialName;
+    }
+
+    /**
+     * @return the seaWaterInitialDelta234UTableModel
+     */
+    public SeaWaterInitialDelta234UTableModel getSeaWaterInitialDelta234UTableModel() {
+        return seaWaterInitialDelta234UTableModel;
+    }
+
+    /**
+     * @param seaWaterInitialDelta234UTableModel the seaWaterInitialDelta234UTableModel to set
+     */
+    public void setSeaWaterInitialDelta234UTableModel(SeaWaterInitialDelta234UTableModel seaWaterInitialDelta234UTableModel) {
+        if (seaWaterInitialDelta234UTableModel == null){
+            seaWaterInitialDelta234UTableModel = ReduxLabData.getInstance().getDefaultLabSeaWaterModel();
+        }
+        this.seaWaterInitialDelta234UTableModel = seaWaterInitialDelta234UTableModel;
+    }
+
+    /**
+     * @return the pctLoss
+     */
+    public ValueModel getPctLoss() {
+        if (pctLoss == null){
+            this.pctLoss = new ValueModel("pctLoss", new BigDecimal(2.5), "ABS", BigDecimal.ONE, BigDecimal.ZERO);
+        }
+        return pctLoss;
+    }
+
+    /**
+     * @param pctLoss the pctLoss to set
+     */
+    public void setPctLoss(ValueModel pctLoss) {
+        this.pctLoss = pctLoss.copy();
     }
 
 }

--- a/src/main/java/org/earthtime/UTh_Redux/fractions/UThFractionI.java
+++ b/src/main/java/org/earthtime/UTh_Redux/fractions/UThFractionI.java
@@ -20,6 +20,7 @@ package org.earthtime.UTh_Redux.fractions;
 import java.math.BigDecimal;
 import org.earthtime.UPb_Redux.valueModels.ValueModel;
 import org.earthtime.fractions.ETFractionInterface;
+import org.earthtime.plots.evolution.seaWater.SeaWaterInitialDelta234UTableModel;
 
 /**
  *
@@ -28,7 +29,7 @@ import org.earthtime.fractions.ETFractionInterface;
 public interface UThFractionI extends ETFractionInterface {
 
     abstract ValueModel[] getLegacyActivityRatios();
-    
+
     abstract void setLegacyActivityRatios(ValueModel[] compositionalMeasures);
 
     public default ValueModel getLegacyActivityRatioByName(String arName) {
@@ -65,4 +66,26 @@ public interface UThFractionI extends ETFractionInterface {
             }
         }
     }
+
+    /**
+     * @return the seaWaterInitialDelta234UTableModel
+     */
+    public SeaWaterInitialDelta234UTableModel getSeaWaterInitialDelta234UTableModel();
+
+    /**
+     * @param seaWaterInitialDelta234UTableModel the
+     * seaWaterInitialDelta234UTableModel to set
+     */
+    public void setSeaWaterInitialDelta234UTableModel(SeaWaterInitialDelta234UTableModel seaWaterInitialDelta234UTableModel);
+
+    /**
+     * @return the pctLoss
+     */
+    public ValueModel getPctLoss();
+
+    /**
+     * @param pctLoss the pctLoss to set
+     */
+    public void setPctLoss(ValueModel pctLoss);
+
 }

--- a/src/main/java/org/earthtime/UTh_Redux/fractions/fractionReduction/UThFractionReducer.java
+++ b/src/main/java/org/earthtime/UTh_Redux/fractions/fractionReduction/UThFractionReducer.java
@@ -547,12 +547,12 @@ public class UThFractionReducer extends FractionReducer {
 
             // july 2019 
             ValueModel dateOpenSys = new ValueModel(
-                        RadDates.dateOpenSys.getName(),
-                        new BigDecimal(0),
-                        "ABS",
-                        new BigDecimal(0),
-                        BigDecimal.ZERO);
-            
+                    RadDates.dateOpenSys.getName(),
+                    new BigDecimal(0),
+                    "ABS",
+                    new BigDecimal(0),
+                    BigDecimal.ZERO);
+
             if (timeUncorrected > 0.0) {
                 dateOpenSys = OpenSystemDateCalculator.calculateOpenSystemDate(
                         ((UThFraction) fraction).getPctLoss(),
@@ -560,7 +560,7 @@ public class UThFractionReducer extends FractionReducer {
                         fraction.getAnalysisMeasure(UThAnalysisMeasures.ar230Th_238Ufc.getName()),
                         ((UThFraction) fraction).getRadiogenicIsotopeDateByName(RadDates.date.getName()).getValue().doubleValue(),
                         ((UThFraction) fraction).getSeaWaterInitialDelta234UTableModel());
-            } 
+            }
 
             fraction.setRadiogenicIsotopeDateByName(RadDates.dateOpenSys, dateOpenSys);
 
@@ -868,7 +868,12 @@ public class UThFractionReducer extends FractionReducer {
                                 .multiply(lambda230.getValue(), ReduxConstants.mathContext15));
     }
 
-    public static void calculateMeasuredAtomRatiosFromLegacyActivityRatios(UThLegacyFractionI fraction) {
+    /**
+     *
+     * @param fraction the value of fraction
+     * @param isAtomic232Th238U the value of isAtomic232Th238U
+     */
+    public static void calculateMeasuredAtomRatiosFromLegacyActivityRatios(UThLegacyFractionI fraction, boolean isAtomic232Th238U) {
 
         BigDecimal myLambda226Value = fraction.getLambda226Legacy().getValue();
         BigDecimal myLambda230Value = fraction.getLambda230Legacy().getValue();
@@ -881,7 +886,9 @@ public class UThFractionReducer extends FractionReducer {
         }
 
         // check for gravimetric vs secular equilibrium for tracer
-        // UThFractionationCorrectedIsotopicRatios.r232Th_238Ufc was read in directly from csv file
+        // next line is modified July 2019 per issue 182 to allow for import of activity ratio 232/238
+        // and now signified by flag 'isAtomic232Th238U' = true or false
+        // true = UThFractionationCorrectedIsotopicRatios.r232Th_238Ufc was read in directly from csv file
         // turning into atom ratios ar = activity ratios and a = atom ratios
         // note secular (SE) atom ratios will change with physical constants and activity ratios and deltas will not
         // so under gravimetric (G) atom ratios won't change activity and delta will change with physical constants
@@ -917,7 +924,19 @@ public class UThFractionReducer extends FractionReducer {
                         .multiply(myLambda232Value)//
                         .divide(myLambda230Value, ReduxConstants.mathContext15));
 
+        // July 2019 next line logic modified per issue 182
         // DO NOT CALCULATE 232_238 AS IT IS ALREADY INPUT AS ATOM RATIO
+        if (!isAtomic232Th238U) {
+            fraction.getRadiogenicIsotopeRatioByName(UThFractionationCorrectedIsotopicRatios.r232Th_238Ufc.getName())//
+                    .setValue(fraction.getLegacyActivityRatioByName(UThAnalysisMeasures.ar232Th_238Ufc.getName()).getValue()//
+                            .multiply(myLambda238Value)//
+                            .divide(myLambda232Value, ReduxConstants.mathContext15));
+            fraction.getRadiogenicIsotopeRatioByName(UThFractionationCorrectedIsotopicRatios.r232Th_238Ufc.getName())//
+                    .setOneSigma(fraction.getLegacyActivityRatioByName(UThAnalysisMeasures.ar232Th_238Ufc.getName()).getOneSigmaAbs()//
+                            .multiply(myLambda238Value)//
+                            .divide(myLambda232Value, ReduxConstants.mathContext15));
+        }
+
         fraction.getRadiogenicIsotopeRatioByName(UThFractionationCorrectedIsotopicRatios.r238U_232Thfc.getName())//
                 .setValue(fraction.getLegacyActivityRatioByName(UThAnalysisMeasures.ar238U_232Thfc.getName()).getValue()//
                         .multiply(myLambda232Value)//
@@ -936,20 +955,6 @@ public class UThFractionReducer extends FractionReducer {
                         .multiply(myLambda230Value)//
                         .divide(myLambda226Value, ReduxConstants.mathContext15));
 
-        // see importer for this (July 2017)
-//        fraction.getRadiogenicIsotopeRatioByName(UThFractionationCorrectedIsotopicRatios.a226Rafc.getName())//
-//                .setValue(fraction.getLegacyActivityRatioByName(UThAnalysisMeasures.a226Rafc.getName()).getValue()//
-//                        .divide(myLambda226Value, ReduxConstants.mathContext15));
-//        fraction.getRadiogenicIsotopeRatioByName(UThFractionationCorrectedIsotopicRatios.a226Rafc.getName())//
-//                .setOneSigma(fraction.getLegacyActivityRatioByName(UThAnalysisMeasures.a226Rafc.getName()).getOneSigmaAbs()//
-//                        .divide(myLambda226Value, ReduxConstants.mathContext15));
-//
-//        fraction.getRadiogenicIsotopeRatioByName(UThFractionationCorrectedIsotopicRatios.a230Thfc.getName())//
-//                .setValue(fraction.getLegacyActivityRatioByName(UThAnalysisMeasures.a230Thfc.getName()).getValue()//
-//                        .divide(myLambda230Value, ReduxConstants.mathContext15));
-//        fraction.getRadiogenicIsotopeRatioByName(UThFractionationCorrectedIsotopicRatios.a230Thfc.getName())//
-//                .setOneSigma(fraction.getLegacyActivityRatioByName(UThAnalysisMeasures.a230Thfc.getName()).getOneSigmaAbs()//
-//                        .divide(myLambda230Value, ReduxConstants.mathContext15));
     }
 
 }

--- a/src/main/java/org/earthtime/UTh_Redux/fractions/fractionReduction/UThFractionReducer.java
+++ b/src/main/java/org/earthtime/UTh_Redux/fractions/fractionReduction/UThFractionReducer.java
@@ -395,15 +395,13 @@ public class UThFractionReducer extends FractionReducer {
             //Ja = [d.t_ntUncorr(2:3); d.eanegtcorr(2:3,2:3)];
             Matrix Jb = new Matrix(new double[][]{//
                 {1., 0., 0.},
-                {0., - numberAtomsTimeT.get(1, 0) / (numberAtomsTimeT.get(0, 0) * numberAtomsTimeT.get(0, 0)),
+                {0., -numberAtomsTimeT.get(1, 0) / (numberAtomsTimeT.get(0, 0) * numberAtomsTimeT.get(0, 0)),
                     1.0 / numberAtomsTimeT.get(0, 0)}});
 //            //Jb = [1 0 0; 0 -nt(2)/nt(1)^2 1/nt(1)];
             Matrix Cout2
                     = Jb.times(Ja).times(covariance_in.getMatrix(0, 1, 0, 1))
                             .times(Ja.transpose().times(Jb.transpose()));
 //            Cout2 = Jb*Ja*C.in(1:2,1:2)*Ja'*Jb';
-
-
 
 // Arrange outputs
             /**
@@ -537,14 +535,23 @@ public class UThFractionReducer extends FractionReducer {
 
             fraction.setRadiogenicIsotopeDateByName(RadDates.dateCorr, dateCorr);
 
-            ValueModel dateCorrBP = new ValueModel(//
-                    RadDates.dateCorrBP.getName(), //
-                    new BigDecimal(timeCorrected - yearsSince1950_di), ///
-                    "ABS", //
-                    new BigDecimal(correctedDateOneSigmaAbs), //
+            ValueModel dateCorrBP = new ValueModel(
+                    RadDates.dateCorrBP.getName(),
+                    new BigDecimal(timeCorrected - yearsSince1950_di),
+                    "ABS",
+                    new BigDecimal(correctedDateOneSigmaAbs),
                     BigDecimal.ZERO);
 
             fraction.setRadiogenicIsotopeDateByName(RadDates.dateCorrBP, dateCorrBP);
+
+            ValueModel dateOpenSys = new ValueModel(
+                    RadDates.dateOpenSys.getName(),
+                    new BigDecimal(11111),
+                    "ABS",
+                    new BigDecimal(correctedDateOneSigmaAbs),
+                    BigDecimal.ZERO);
+
+            fraction.setRadiogenicIsotopeDateByName(RadDates.dateOpenSys, dateOpenSys);
 
             //  initial 234U/238U not detrital corrected *************************************************************
             // ni(2)/ni(1) (line 90 MatLab code) 
@@ -557,7 +564,6 @@ public class UThFractionReducer extends FractionReducer {
             // TODO: june 2017 uncertainty math is still missing - Noah?
 //            outvec(15) = 2*sqrt(Cout2(2,2))*lambda.U234/lambda.U238 * 1000; %2-sigma abs unct in del234Uinitial (uncorrected)
 //            outvec(16) = Cout2(1,2)/sqrt(Cout2(1,1)*Cout2(2,2)); % rho date-del234Uinitial (uncorrected)
-            
             double initial234_238atomRatioUnct = Math.sqrt(Cout2.get(1, 1));
 
             if (!Double.isFinite(initial234_238atomRatioUnct)) {
@@ -567,7 +573,7 @@ public class UThFractionReducer extends FractionReducer {
             //
             double ar234_238i = initial234_238atomRatio * lambda234D / lambda238D;
             double ar234_238i_unct = initial234_238atomRatioUnct * lambda234D / lambda238D;
-            
+
             // atom ratio
             fraction.getRadiogenicIsotopeRatioByName(UThFractionationCorrectedIsotopicRatios.r234U_238Ui.getName())//
                     .setValue(new BigDecimal(initial234_238atomRatio));

--- a/src/main/java/org/earthtime/UTh_Redux/fractions/fractionReduction/UThFractionReducer.java
+++ b/src/main/java/org/earthtime/UTh_Redux/fractions/fractionReduction/UThFractionReducer.java
@@ -33,6 +33,7 @@ import org.earthtime.fractions.fractionReduction.FractionReducer;
 import org.earthtime.ratioDataModels.AbstractRatiosDataModel;
 import static org.earthtime.UPb_Redux.ReduxConstants.TIME_IN_MILLISECONDS_FROM_1970_TO_1950;
 import org.earthtime.dataDictionaries.UThCompositionalMeasures;
+import org.earthtime.plots.evolution.openSystem.OpenSystemDateCalculator;
 
 /* NOTES from Noah 28 October 2015
     So instead, here's a MATLAB file that goes with an Excel worksheet and VBA Add-In I created to calculate U-Th dates.  Here's what's going on in the code.
@@ -544,12 +545,22 @@ public class UThFractionReducer extends FractionReducer {
 
             fraction.setRadiogenicIsotopeDateByName(RadDates.dateCorrBP, dateCorrBP);
 
+            // july 2019 
             ValueModel dateOpenSys = new ValueModel(
-                    RadDates.dateOpenSys.getName(),
-                    new BigDecimal(11111),
-                    "ABS",
-                    new BigDecimal(correctedDateOneSigmaAbs),
-                    BigDecimal.ZERO);
+                        RadDates.dateOpenSys.getName(),
+                        new BigDecimal(0),
+                        "ABS",
+                        new BigDecimal(0),
+                        BigDecimal.ZERO);
+            
+            if (timeUncorrected > 0.0) {
+                dateOpenSys = OpenSystemDateCalculator.calculateOpenSystemDate(
+                        ((UThFraction) fraction).getPctLoss(),
+                        fraction.getAnalysisMeasure(UThAnalysisMeasures.ar234U_238Ufc.getName()),
+                        fraction.getAnalysisMeasure(UThAnalysisMeasures.ar230Th_238Ufc.getName()),
+                        ((UThFraction) fraction).getRadiogenicIsotopeDateByName(RadDates.date.getName()).getValue().doubleValue(),
+                        ((UThFraction) fraction).getSeaWaterInitialDelta234UTableModel());
+            } 
 
             fraction.setRadiogenicIsotopeDateByName(RadDates.dateOpenSys, dateOpenSys);
 

--- a/src/main/java/org/earthtime/UTh_Redux/samples/SampleUTh.java
+++ b/src/main/java/org/earthtime/UTh_Redux/samples/SampleUTh.java
@@ -205,21 +205,33 @@ public class SampleUTh extends ETSample implements
 //        initFilteredFractionsToAll();
     }
 
+    /**
+     *
+     * @param aliquotNumber the value of aliquotNumber
+     * @param aliquotName the value of aliquotName
+     * @param physicalConstants the value of physicalConstants
+     * @param compiled the value of compiled
+     * @param mySESARSampleMetadata the value of mySESARSampleMetadata
+     * @param sampleAnalysisType the value of sampleAnalysisType
+     */
     @Override
     public AliquotInterface generateDefaultAliquot(//
-            int aliquotNumber,
-            String aliquotName,
-            AbstractRatiosDataModel physicalConstants,
-            boolean compiled,
-            SESARSampleMetadata mySESARSampleMetadata) {
+            int aliquotNumber, 
+            String aliquotName, 
+            AbstractRatiosDataModel physicalConstants, 
+            boolean compiled, 
+            SESARSampleMetadata mySESARSampleMetadata, 
+            String sampleAnalysisType) {
 
-        return new UThReduxAliquot(aliquotNumber, aliquotName, physicalConstants, compiled, mySESARSampleMetadata);
+        return new UThReduxAliquot(
+                aliquotNumber, aliquotName, physicalConstants, compiled, mySESARSampleMetadata, sampleAnalysisType);
     }
-
-    @Override
-    public AliquotInterface generateDefaultAliquot() {
-        return new UThReduxAliquot();
-    }
+    //
+//    
+//    @Override
+//    public AliquotInterface generateDefaultAliquot() {
+//        return new UThReduxAliquot();
+//    }
 
     /**
      *
@@ -464,7 +476,7 @@ public class SampleUTh extends ETSample implements
 
     @Override
     public void setSampleAnalysisType(String sampleAnalysisType) {
-        throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+        this.sampleAnalysisType = sampleAnalysisType;
     }
 
     @Override
@@ -474,7 +486,7 @@ public class SampleUTh extends ETSample implements
 
     @Override
     public String getSampleAnalysisType() {
-        throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+        return sampleAnalysisType;
     }
 
     @Override

--- a/src/main/java/org/earthtime/aliquots/AliquotInterface.java
+++ b/src/main/java/org/earthtime/aliquots/AliquotInterface.java
@@ -29,6 +29,7 @@ import org.earthtime.UPb_Redux.valueModels.SampleDateInterceptModel;
 import org.earthtime.UPb_Redux.valueModels.SampleDateModel;
 import org.earthtime.UPb_Redux.valueModels.ValueModel;
 import org.earthtime.UTh_Redux.aliquots.UThReduxAliquot;
+import static org.earthtime.dataDictionaries.SampleAnalysisTypesEnum.USERIES_CARB;
 import org.earthtime.dataDictionaries.SampleDateTypes;
 import org.earthtime.ratioDataModels.AbstractRatiosDataModel;
 import org.earthtime.reduxLabData.ReduxLabData;
@@ -250,22 +251,45 @@ public interface AliquotInterface {
         Vector<ValueModel> retVal = new Vector<>();
         // choose models not already in use by Aliquot
         if (this instanceof UThReduxAliquot) {
-            for (int i = 0; i < SampleDateTypes.getSampleDateModelTypes().length; i++) {
-                if (getASampleDateModelByName(SampleDateTypes.getSampleDateType(i)) == null) {
-                    ValueModel tempModel = null;
-                    if (SampleDateTypes.getSampleDateType(i).endsWith("Date")) {
-                        tempModel
-                                = new SampleDateModel(//
-                                        SampleDateTypes.getSampleDateType(i),
-                                        SampleDateTypes.getSampleDateTypeMethod(i),
-                                        SampleDateTypes.getSampleDateTypeName(i),
-                                        BigDecimal.ZERO,
-                                        "ABS",
-                                        BigDecimal.ZERO);
+            if (((UThReduxAliquot) this).getSampleAnalysisType().compareToIgnoreCase(USERIES_CARB.getName()) == 0) {
+                for (int i = 0; i < SampleDateTypes.getSampleDateModelTypes().length; i++) {
+                    if (getASampleDateModelByName(SampleDateTypes.getSampleDateType(i)) == null) {
+                        ValueModel tempModel = null;
+                        if (SampleDateTypes.getSampleDateType(i).endsWith("Date")) {
+                            tempModel
+                                    = new SampleDateModel(//
+                                            SampleDateTypes.getSampleDateType(i),
+                                            SampleDateTypes.getSampleDateTypeMethod(i),
+                                            SampleDateTypes.getSampleDateTypeName(i),
+                                            BigDecimal.ZERO,
+                                            "ABS",
+                                            BigDecimal.ZERO);
+                        }
+                        if (tempModel != null) {
+                            ((SampleDateModel) tempModel).setAliquot(this);
+                            retVal.add(tempModel);
+                        }
                     }
-                    if (tempModel != null) {
-                        ((SampleDateModel) tempModel).setAliquot(this);
-                        retVal.add(tempModel);
+                }
+            } else {
+                // igneous
+                for (int i = 0; i < SampleDateTypes.getSampleDateModelTypes().length; i++) {
+                    if (getASampleDateModelByName(SampleDateTypes.getSampleDateType(i)) == null) {
+                        ValueModel tempModel = null;
+                        if (SampleDateTypes.getSampleDateType(i).endsWith("isochron")) {
+                            tempModel
+                                    = new SampleDateModel(//
+                                            SampleDateTypes.getSampleDateType(i),
+                                            SampleDateTypes.getSampleDateTypeMethod(i),
+                                            SampleDateTypes.getSampleDateTypeName(i),
+                                            BigDecimal.ZERO,
+                                            "ABS",
+                                            BigDecimal.ZERO);
+                        }
+                        if (tempModel != null) {
+                            ((SampleDateModel) tempModel).setAliquot(this);
+                            retVal.add(tempModel);
+                        }
                     }
                 }
             }

--- a/src/main/java/org/earthtime/archivingTools/URIHelper.java
+++ b/src/main/java/org/earthtime/archivingTools/URIHelper.java
@@ -77,8 +77,13 @@ public class URIHelper {
         try {
             url = new URL(fileURI);
             urlConn = url.openConnection();
+
             urlConn.setDoInput(true);
             urlConn.setUseCaches(false);
+
+            // july 2019
+            urlConn.setConnectTimeout(5000);
+            urlConn.setReadTimeout(5000);
 
             retval = urlConn.getInputStream();
 

--- a/src/main/java/org/earthtime/archivingTools/URIHelper.java
+++ b/src/main/java/org/earthtime/archivingTools/URIHelper.java
@@ -82,8 +82,8 @@ public class URIHelper {
             urlConn.setUseCaches(false);
 
             // july 2019
-            urlConn.setConnectTimeout(5000);
-            urlConn.setReadTimeout(5000);
+            urlConn.setConnectTimeout(10000);
+            urlConn.setReadTimeout(10000);
 
             retval = urlConn.getInputStream();
 

--- a/src/main/java/org/earthtime/dataDictionaries/RadDates.java
+++ b/src/main/java/org/earthtime/dataDictionaries/RadDates.java
@@ -114,7 +114,8 @@ public enum RadDates {
     date("date"),
     dateCorr("dateCorr"),
     dateBP("dateBP"),
-    dateCorrBP("dateCorrBP");
+    dateCorrBP("dateCorrBP"),
+    dateOpenSys("dateOpenSys");
 
 
     private String name;

--- a/src/main/java/org/earthtime/dataDictionaries/SampleDateTypes.java
+++ b/src/main/java/org/earthtime/dataDictionaries/SampleDateTypes.java
@@ -55,6 +55,7 @@ public final class SampleDateTypes {
         // USeries carbonate Nov 2018
         {"weighted mean Corrected Date", "WMDate", RadDates.dateCorr.getName()},
         {"weighted mean UnCorrected Date", "WMDate", RadDates.date.getName()},
+        {"open-system Date", "WMDate", RadDates.dateOpenSys.getName()},
     };
 
     /**

--- a/src/main/java/org/earthtime/dataDictionaries/reportSpecifications/ReportSpecificationsUTh_Carb.java
+++ b/src/main/java/org/earthtime/dataDictionaries/reportSpecifications/ReportSpecificationsUTh_Carb.java
@@ -130,10 +130,10 @@ public class ReportSpecificationsUTh_Carb extends ReportSpecificationsAbstract {
         },
         //
         {"[232Th/", " 238U]", "", "*1e5", "getAnalysisMeasure", UThAnalysisMeasures.ar232Th_238Ufc.getName(), "ABS",
-            "FN-1", "false", "false", "3", "true", "[232Th/238U]", "false", "false"
+            "FN-1", "true", "false", "4", "false", "[232Th/238U]", "false", "false"
         },
         {"232Th/", "238U", "", "*1e5", "getRadiogenicIsotopeRatioByName", UThFractionationCorrectedIsotopicRatios.r232Th_238Ufc.getName(), "ABS",
-            "", "false", "false", "3", "true", "232Th/238U", "false", "false"
+            "", "true", "false", "4", "false", "232Th/238U", "false", "false"
         },
         //
         {"uncorrected", "[230Th/", " 238U]", "", "getAnalysisMeasure", UThAnalysisMeasures.ar230Th_238Ufc.getName(), "ABS",

--- a/src/main/java/org/earthtime/dataDictionaries/reportSpecifications/ReportSpecificationsUTh_Carb.java
+++ b/src/main/java/org/earthtime/dataDictionaries/reportSpecifications/ReportSpecificationsUTh_Carb.java
@@ -51,6 +51,9 @@ public class ReportSpecificationsUTh_Carb extends ReportSpecificationsAbstract {
         {" BP", "corrected", "Date", "ka", "getRadiogenicIsotopeDateByName", RadDates.dateCorrBP.getName(), "ABS",
             "", "false", "false", "2", "true", "Date BP (detrital Th-corr.)", "false", "false"
         },
+        {"", "Open-System", "Date", "ka", "getRadiogenicIsotopeDateByName", RadDates.dateOpenSys.getName(), "ABS",
+            "", "false", "false", "2", "true", "", "false", "false"
+        },
         //
         {"uncorrected", "delta234U", "initial", "", "getAnalysisMeasure", UThAnalysisMeasures.delta234Ui.getName(), "ABS",
             "", "true", "false", "3", "true", "initial delta234U", "false", "false"

--- a/src/main/java/org/earthtime/dialogs/DialogEditor.java
+++ b/src/main/java/org/earthtime/dialogs/DialogEditor.java
@@ -54,7 +54,7 @@ public abstract class DialogEditor extends JDialog {
     private final static Font myScienceFont = new Font("Calibri"//Arial"
             /*
              * "Monospaced"
-             */, Font.PLAIN, 13);
+             */, Font.PLAIN, 11);//july 2019 
 
     /**
      * Creates new form DialogEditor

--- a/src/main/java/org/earthtime/dialogs/LabDataEditorDialogUPb.java
+++ b/src/main/java/org/earthtime/dialogs/LabDataEditorDialogUPb.java
@@ -2498,21 +2498,21 @@ public class LabDataEditorDialogUPb extends DialogEditor {
         defaultPbBlankMass_text.setText(
                 myLabData.getDefaultPbBlankMassInGrams().getValue().//
                         multiply(ReduxConstants.PicoGramsPerGram).//
-                        setScale(ReduxConstants.DEFAULT_MASS_DISPLAY_SCALE, RoundingMode.HALF_UP).toPlainString());
+                        setScale(ReduxConstants.DEFAULT_MASS_IN_GRAMS_DISPLAY_SCALE, RoundingMode.HALF_UP).toPlainString());
         defaultPbBlankMassOneSigma_text.setText(
                 myLabData.getDefaultPbBlankMassInGrams().getOneSigma().//
                         multiply(ReduxConstants.PicoGramsPerGram).//
-                        setScale(ReduxConstants.DEFAULT_MASS_DISPLAY_SCALE, RoundingMode.HALF_UP).toPlainString());
+                        setScale(ReduxConstants.DEFAULT_MASS_IN_GRAMS_DISPLAY_SCALE, RoundingMode.HALF_UP).toPlainString());
 
         // assumed U Blank mass
         defaultUBlankMass_text.setText(
                 myLabData.getDefaultAssumedUBlankMassInGrams().getValue().//
                         multiply(ReduxConstants.PicoGramsPerGram).//
-                        setScale(ReduxConstants.DEFAULT_MASS_DISPLAY_SCALE, RoundingMode.HALF_UP).toPlainString());
+                        setScale(ReduxConstants.DEFAULT_MASS_IN_GRAMS_DISPLAY_SCALE, RoundingMode.HALF_UP).toPlainString());
         defaultUBlankMassOneSigma_text.setText(
                 myLabData.getDefaultAssumedUBlankMassInGrams().getOneSigma().
                         multiply(ReduxConstants.PicoGramsPerGram).//
-                        setScale(ReduxConstants.DEFAULT_MASS_DISPLAY_SCALE, RoundingMode.HALF_UP).toPlainString());
+                        setScale(ReduxConstants.DEFAULT_MASS_IN_GRAMS_DISPLAY_SCALE, RoundingMode.HALF_UP).toPlainString());
 
         // default r18O_16O
         default18O_16O_text.setText(
@@ -2541,7 +2541,7 @@ public class LabDataEditorDialogUPb extends DialogEditor {
         // default tracerModel mass uncertainty
         defaultTracerMassOneSigma_text.setText(
                 myLabData.getDefaultTracerMass().getOneSigma()//
-                        .setScale(ReduxConstants.DEFAULT_MASS_DISPLAY_SCALE, RoundingMode.HALF_UP).toPlainString());
+                        .setScale(ReduxConstants.DEFAULT_MASS_IN_GRAMS_DISPLAY_SCALE, RoundingMode.HALF_UP).toPlainString());
 
         // default rTh_Umagma
         defaultRTh_Umagma_text.setText(

--- a/src/main/java/org/earthtime/plots/evolution/AgeByDelta234UPlotPanel.java
+++ b/src/main/java/org/earthtime/plots/evolution/AgeByDelta234UPlotPanel.java
@@ -28,6 +28,7 @@ import java.awt.event.ActionListener;
 import java.awt.event.MouseEvent;
 import java.awt.event.MouseWheelEvent;
 import java.awt.geom.Line2D;
+import java.awt.geom.Path2D;
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
@@ -83,6 +84,7 @@ public final class AgeByDelta234UPlotPanel extends AbstractDataView implements P
 
     private double[] arrayOfSeaWaterModelDates;
     private double[] arrayOfSeaWaterModelDeltas;
+    private double[] arrayOfSeaWaterModelDeltasUnct;
 
     private double movingUpperBoundaryPointFromX;
     private double movingLowerBoundaryPointFromX;
@@ -161,6 +163,64 @@ public final class AgeByDelta234UPlotPanel extends AbstractDataView implements P
             g2d.setPaint(Color.black);
             g2d.drawRect(leftMargin, topMargin, (int) graphWidth - 1, (int) graphHeight - 1);
 
+            // runthrough models opensystem models
+            if (!openSystemIsochronModelsList.isEmpty()) {
+                for (OpenSystemIsochronTableModel ositm : openSystemIsochronModelsList) {
+                    if (ositm.isShowSeawaterModel()) {
+                        arrayOfSeaWaterModelDates = ositm.getSeaWaterInitialDelta234UTableModel().getArrayOfDatesInKa();
+                        arrayOfSeaWaterModelDeltas = ositm.getSeaWaterInitialDelta234UTableModel().getArrayOfDeltas();
+                        arrayOfSeaWaterModelDeltasUnct = ositm.getSeaWaterInitialDelta234UTableModel().getArrayOfDeltasUnct();
+
+                        g2d.setStroke(new BasicStroke(1.5f));
+
+                        for (int i = 0; i < arrayOfSeaWaterModelDates.length; i++) {
+                            Shape rawRatioPoint = new java.awt.geom.Ellipse2D.Double(
+                                    mapX(arrayOfSeaWaterModelDates[i]) - 3,
+                                    mapY(arrayOfSeaWaterModelDeltas[i]) - 3, 6, 6);
+
+                            g2d.draw(rawRatioPoint);
+                            g2d.fill(rawRatioPoint);
+
+                            if (i > 0) {
+                                // upper envelope
+                                Line2D lineU = new Line2D.Double(
+                                        mapX(arrayOfSeaWaterModelDates[i - 1]),
+                                        mapY(arrayOfSeaWaterModelDeltas[i - 1] + arrayOfSeaWaterModelDeltasUnct[i - 1]),
+                                        mapX(arrayOfSeaWaterModelDates[i]),
+                                        mapY(arrayOfSeaWaterModelDeltas[i] + arrayOfSeaWaterModelDeltasUnct[i]));
+
+                                // lower envelope
+                                Line2D lineL = new Line2D.Double(
+                                        mapX(arrayOfSeaWaterModelDates[i - 1]),
+                                        mapY(arrayOfSeaWaterModelDeltas[i - 1] - arrayOfSeaWaterModelDeltasUnct[i - 1]),
+                                        mapX(arrayOfSeaWaterModelDates[i]),
+                                        mapY(arrayOfSeaWaterModelDeltas[i] - arrayOfSeaWaterModelDeltasUnct[i]));
+
+                                // draw envelope
+                                g2d.setPaint(new Color(213, 255, 232));
+                                int[] xPoints = new int[]{(int) lineU.getX1(), (int) lineU.getX2(), (int) lineL.getX2(), (int) lineL.getX1()};
+                                int[] yPoints = new int[]{(int) lineU.getY1(), (int) lineU.getY2(), (int) lineL.getY2(), (int) lineL.getY1()};
+                                g2d.fillPolygon(
+                                        xPoints,
+                                        yPoints,
+                                        4);
+
+                                // draw seawater
+                                Line2D line = new Line2D.Double(
+                                        mapX(arrayOfSeaWaterModelDates[i - 1]),
+                                        mapY(arrayOfSeaWaterModelDeltas[i - 1]),
+                                        mapX(arrayOfSeaWaterModelDates[i]),
+                                        mapY(arrayOfSeaWaterModelDeltas[i]));
+
+                                g2d.setStroke(new BasicStroke(2.0f));
+                                g2d.setPaint(SEAWATER_GREEN);
+                                g2d.draw(line);
+                            }
+                        }
+                    }
+                }
+            }
+
             g2d.setPaint(Color.black);
 
             Color includedBorderColor = Color.BLACK;
@@ -198,9 +258,6 @@ public final class AgeByDelta234UPlotPanel extends AbstractDataView implements P
                     }
                 }
             }
-
-            double rangeX = (getMaxX_Display() - getMinX_Display());
-            double rangeY = (getMaxY_Display() - getMinY_Display());
 
             // paint partitions
             if (upperBoundary.size() > 0) {
@@ -263,39 +320,6 @@ public final class AgeByDelta234UPlotPanel extends AbstractDataView implements P
                         Math.min(zoomMaxY, zoomMinY),
                         Math.abs(zoomMaxX - zoomMinX),
                         Math.abs(zoomMinY - zoomMaxY));
-            }
-
-            // runthrough models opensystem models
-            if (!openSystemIsochronModelsList.isEmpty()) {
-                for (OpenSystemIsochronTableModel ositm : openSystemIsochronModelsList) {
-                    if (ositm.isShowSeawaterModel()) {
-                        arrayOfSeaWaterModelDates = ositm.getSeaWaterInitialDelta234UTableModel().getArrayOfDatesInKa();
-                        arrayOfSeaWaterModelDeltas = ositm.getSeaWaterInitialDelta234UTableModel().getArrayOfDeltas();
-
-                        g2d.setPaint(SEAWATER_GREEN);
-                        g2d.setStroke(new BasicStroke(1.5f));
-
-                        for (int i = 0; i < arrayOfSeaWaterModelDates.length; i++) {
-                            Shape rawRatioPoint = new java.awt.geom.Ellipse2D.Double(
-                                    mapX(arrayOfSeaWaterModelDates[i]) - 3,
-                                    mapY(arrayOfSeaWaterModelDeltas[i]) - 3, 6, 6);
-
-                            g2d.draw(rawRatioPoint);
-                            g2d.fill(rawRatioPoint);
-
-                            if (i > 0) {
-                                // draw line
-                                Line2D line = new Line2D.Double(
-                                        mapX(arrayOfSeaWaterModelDates[i - 1]),
-                                        mapY(arrayOfSeaWaterModelDeltas[i - 1]),
-                                        mapX(arrayOfSeaWaterModelDates[i]),
-                                        mapY(arrayOfSeaWaterModelDeltas[i]));
-                                g2d.setStroke(new BasicStroke(2.0f));
-                                g2d.draw(line);
-                            }
-                        }
-                    }
-                }
             }
 
             if (imageMode == "BOUNDARY") {
@@ -557,9 +581,13 @@ public final class AgeByDelta234UPlotPanel extends AbstractDataView implements P
             double notches = e.getPreciseWheelRotation();
             if (true) {//(notches == Math.rint(notches)) {
                 if (notches < 0) {// zoom in
-                    if (zoomCount >=0){    minX += getRangeX_Display() / ZOOM_FACTOR;}
+                    if (zoomCount >= 0) {
+                        minX += getRangeX_Display() / ZOOM_FACTOR;
+                    }
                     maxX -= getRangeX_Display() / ZOOM_FACTOR;
-                    if (zoomCount >=0){  minY += getRangeY_Display() / ZOOM_FACTOR;}
+                    if (zoomCount >= 0) {
+                        minY += getRangeY_Display() / ZOOM_FACTOR;
+                    }
                     maxY -= getRangeY_Display() / ZOOM_FACTOR;
 
                     zoomCount++;

--- a/src/main/java/org/earthtime/plots/evolution/AgeByDelta234UPlotPanel.java
+++ b/src/main/java/org/earthtime/plots/evolution/AgeByDelta234UPlotPanel.java
@@ -399,7 +399,7 @@ public final class AgeByDelta234UPlotPanel extends AbstractDataView implements P
     }
 
     @Override
-    public void preparePanel(boolean doReset ) {
+    public void preparePanel(boolean doReset) {
         setOpenSystemIsochronModelsList(((ProjectSample) mySample).updateListOfOpenIsochronModels());
         if (doReset) {
 
@@ -557,9 +557,9 @@ public final class AgeByDelta234UPlotPanel extends AbstractDataView implements P
             double notches = e.getPreciseWheelRotation();
             if (true) {//(notches == Math.rint(notches)) {
                 if (notches < 0) {// zoom in
-                    minX += getRangeX_Display() / ZOOM_FACTOR;
+                    if (zoomCount >=0){    minX += getRangeX_Display() / ZOOM_FACTOR;}
                     maxX -= getRangeX_Display() / ZOOM_FACTOR;
-                    minY += getRangeY_Display() / ZOOM_FACTOR;
+                    if (zoomCount >=0){  minY += getRangeY_Display() / ZOOM_FACTOR;}
                     maxY -= getRangeY_Display() / ZOOM_FACTOR;
 
                     zoomCount++;
@@ -573,13 +573,28 @@ public final class AgeByDelta234UPlotPanel extends AbstractDataView implements P
 
                     zoomCount--;
                     // stop zoom out
-                    // if (minX * minY > 0.0) {
+                    if (minX * minY > 0.0) {
+                        maxX += getRangeX_Display() / ZOOM_FACTOR;
+                        maxY += getRangeY_Display() / ZOOM_FACTOR;
+                        zoomCount = 0;
 
-                    maxX += getRangeX_Display() / ZOOM_FACTOR;
+                    } else {
+                        minX = 0.0;
+                        minY = 0.0;
 
-                    maxY += getRangeY_Display() / ZOOM_FACTOR;
-                    //  }
+                        maxX += getRangeX_Display() / ZOOM_FACTOR;
+                        maxY += getRangeY_Display() / ZOOM_FACTOR;
+                    }
 
+                }
+                if (minX <= 0.0) {
+                    minX = 0.0;
+                    displayOffsetX = 0.0;
+
+                }
+                if (minY <= 0.0) {
+                    minY = 0.0;
+                    displayOffsetY = 0.0;
                 }
 
                 zoomMinX = zoomMaxX;

--- a/src/main/java/org/earthtime/plots/evolution/EvolutionPlotPanel.java
+++ b/src/main/java/org/earthtime/plots/evolution/EvolutionPlotPanel.java
@@ -901,7 +901,7 @@ public final class EvolutionPlotPanel extends AbstractDataView implements Plotti
         Calculate the initial seawater 234U/238U activity ratio ar234U_238Uisw for the input age t using the user-input seawater model.  
         This is an activity ratio, so a typical number would be 1.145.
         Calculate f234 =  1 – pctLoss / 100
-        Calculate f230 = ((f234 - 1) * (4.754 * 234 / 4.184 / 230) + 1)
+        Calculate f230 = ((f234 - 1) * (4.754 * 234 / 4.184 / 230) + 1 + f234)/2
         Calculate ar234U_238U = (1 + R * (1 – f234)) * (1 – EXP(–lambda234 * t)) + ar234U_238Uisw *EXP(–lambda234 * t)
         Calculate ar230Th_238U = (1 + R * (1 – f234 * f230)) * (1 – lambda230/( lambda230- lambda234) * EXP(–lambda234 * t) + lambda234/( lambda230 - lambda234) * EXP(–lambda230 * t))+(1 + R * (1 - f230)) * (lambda230 / (lambda230 - lambda234) * ar234U_238Uisw * (EXP(–lambda234* t) - EXP(–lambda230 * t)))
 
@@ -913,7 +913,7 @@ public final class EvolutionPlotPanel extends AbstractDataView implements Plotti
         double ar230Th_238U;
 
         double f234 = 1.0 - (pctLoss / 100.0);
-        double f230 = ((f234 - 1.0) * (4.754 * 234.0 / 4.184 / 230.0) + 1.0);
+        double f230 = ((f234 - 1.0) * (4.754 * 234.0 / 4.184 / 230.0) + 1.0 + f234)/2;
 
         ar234U_238U = (1.0 + rValue * (1.0 - f234)) * (1.0 - Math.exp(-lambda234D * age)) + ar234U_238Uisw * Math.exp(-lambda234D * age);
         ar230Th_238U

--- a/src/main/java/org/earthtime/plots/evolution/EvolutionPlotPanel.java
+++ b/src/main/java/org/earthtime/plots/evolution/EvolutionPlotPanel.java
@@ -265,56 +265,6 @@ public final class EvolutionPlotPanel extends AbstractDataView implements Plotti
                 }
             }
 
-            g2d.setPaint(Color.black);
-
-            Color includedBorderColor = Color.BLACK;
-            Color includedCenterColor = new Color(255, 0, 0);
-            float includedCenterSize = 3.0f;
-            String ellipseLabelFont = "Monospaced";
-            String ellipseLabelFontSize = "12";
-
-            for (ETFractionInterface f : selectedFractions) {
-                if (!f.isRejected()) {
-                    generateEllipsePathIII(//
-                            f,
-                            f.getAnalysisMeasure(UThAnalysisMeasures.ar230Th_238Ufc.getName()),
-                            f.getAnalysisMeasure(UThAnalysisMeasures.ar234U_238Ufc.getName()),
-                            2.0f);
-                    if (f.getErrorEllipsePath() != null) {
-                        boolean included
-                                = ((ProjectSample) sample).calculateIfEllipseIncluded(
-                                        f.getRadiogenicIsotopeDateByName(RadDates.date.getName()).getValue().movePointLeft(3).doubleValue(),
-                                        f.getAnalysisMeasure(UThAnalysisMeasures.delta234Ui.getName()).getValue().doubleValue());
-                        plotAFraction(g2d,
-                                svgStyle,
-                                f,
-                                includedBorderColor,
-                                0.5f,
-                                included ? includedCenterColor : new Color(211, 211, 211),
-                                includedCenterSize,
-                                ellipseLabelFont,
-                                ellipseLabelFontSize,
-                                showCenters,
-                                showLabels);
-                    }
-                }
-            }
-
-            double rangeX = (getMaxX_Display() - getMinX_Display());
-            double rangeY = (getMaxY_Display() - getMinY_Display());
-
-            // draw zoom box if in use
-            if (isInImageModeZoom()
-                    && (Math.abs(zoomMaxX - zoomMinX) * Math.abs(zoomMinY - zoomMaxY)) > 0) {
-                g2d.setStroke(new BasicStroke(2.0f));
-                g2d.setColor(Color.red);
-                g2d.drawRect(//
-                        Math.min(zoomMinX, zoomMaxX),
-                        Math.min(zoomMaxY, zoomMinY),
-                        Math.abs(zoomMaxX - zoomMinX),
-                        Math.abs(zoomMinY - zoomMaxY));
-            }
-
             // opensystem isochrons
             if (!openSystemIsochronModelsList.isEmpty()) {
                 //LinearInterpolator linearInterpolator = new LinearInterpolator();
@@ -353,7 +303,8 @@ public final class EvolutionPlotPanel extends AbstractDataView implements Plotti
 
                     if (ositm.isShowSeawaterModel()) {
 
-                        buildSeawaterModelPlot(ositm.getSeaWaterInitialDelta234UTableModel());
+                        // uppper envelope
+                        buildSeawaterModelPlot(ositm.getSeaWaterInitialDelta234UTableModel(), 1);
                         Path2D curvedP = new Path2D.Double(Path2D.WIND_NON_ZERO);
                         curvedP.moveTo(
                                 (float) mapX(xysw[0][0][0]),
@@ -370,14 +321,109 @@ public final class EvolutionPlotPanel extends AbstractDataView implements Plotti
                                     (float) mapX(xysw[0][0][j]),
                                     (float) mapY(xysw[0][1][j]));
                         }
+
+                        // lower envelope
+                        buildSeawaterModelPlot(ositm.getSeaWaterInitialDelta234UTableModel(), -1);
+                        //curvedP = new Path2D.Double(Path2D.WIND_NON_ZERO);
+                        int hiIndex = tvsw[0].length - 1;
+                        curvedP.lineTo(
+                                (float) mapX(xysw[0][0][hiIndex]),
+                                (float) mapY(xysw[0][1][hiIndex]));
+
+                        for (int j = hiIndex - 1; j >= 0; j--) {
+                            double deltaTOver3 = (tvsw[0][j + 1] - tvsw[0][j]) / 3;
+
+                            curvedP.curveTo(//
+                                    (float) mapX(xysw[0][0][j + 1] + deltaTOver3 * dardtsw[0][0][j + 1]),
+                                    (float) mapY(xysw[0][1][j + 1] + deltaTOver3 * dardtsw[0][1][j + 1]),
+                                    (float) mapX(xysw[0][0][j] - deltaTOver3 * dardtsw[0][0][j]),
+                                    (float) mapY(xysw[0][1][j] - deltaTOver3 * dardtsw[0][1][j]),
+                                    (float) mapX(xysw[0][0][j]),
+                                    (float) mapY(xysw[0][1][j]));
+                        }
+                        
+                        curvedP.closePath();
+                        
+                        g2d.setPaint(new Color(213, 255, 232));
+                        g2d.setStroke(new BasicStroke(1.5f));
+                        g2d.fill(curvedP);
+
+                        // seawater
+                        buildSeawaterModelPlot(ositm.getSeaWaterInitialDelta234UTableModel(), 0);
+                        curvedP = new Path2D.Double(Path2D.WIND_NON_ZERO);
+                        curvedP.moveTo(
+                                (float) mapX(xysw[0][0][0]),
+                                (float) mapY(xysw[0][1][0]));
+
+                        for (int j = 1; j < tvsw[0].length; j++) {
+                            double deltaTOver3 = (tvsw[0][j] - tvsw[0][j - 1]) / 3;
+
+                            curvedP.curveTo(//
+                                    (float) mapX(xysw[0][0][j - 1] + deltaTOver3 * dardtsw[0][0][j - 1]),
+                                    (float) mapY(xysw[0][1][j - 1] + deltaTOver3 * dardtsw[0][1][j - 1]),
+                                    (float) mapX(xysw[0][0][j] - deltaTOver3 * dardtsw[0][0][j]),
+                                    (float) mapY(xysw[0][1][j] - deltaTOver3 * dardtsw[0][1][j]),
+                                    (float) mapX(xysw[0][0][j]),
+                                    (float) mapY(xysw[0][1][j]));
+                        }
                         g2d.setPaint(SEAWATER_GREEN);
-                        g2d.setStroke(new BasicStroke(1.75f));
+                        g2d.setStroke(new BasicStroke(2.f));
                         g2d.draw(curvedP);
+
                     }
                 }
             }
 
-            // END opensystem isochrons
+            // END opensystem isochrons            
+            // ellipses
+            g2d.setPaint(Color.black);
+
+            Color includedBorderColor = Color.BLACK;
+            Color includedCenterColor = new Color(255, 0, 0);
+            float includedCenterSize = 3.0f;
+            String ellipseLabelFont = "Monospaced";
+            String ellipseLabelFontSize = "12";
+
+            for (ETFractionInterface f : selectedFractions) {
+                if (!f.isRejected()) {
+                    generateEllipsePathIII(//
+                            f,
+                            f.getAnalysisMeasure(UThAnalysisMeasures.ar230Th_238Ufc.getName()),
+                            f.getAnalysisMeasure(UThAnalysisMeasures.ar234U_238Ufc.getName()),
+                            2.0f);
+                    if (f.getErrorEllipsePath() != null) {
+                        boolean included
+                                = ((ProjectSample) sample).calculateIfEllipseIncluded(
+                                        f.getRadiogenicIsotopeDateByName(RadDates.date.getName()).getValue().movePointLeft(3).doubleValue(),
+                                        f.getAnalysisMeasure(UThAnalysisMeasures.delta234Ui.getName()).getValue().doubleValue());
+                        plotAFraction(g2d,
+                                svgStyle,
+                                f,
+                                includedBorderColor,
+                                0.5f,
+                                included ? includedCenterColor : new Color(211, 211, 211),
+                                includedCenterSize,
+                                ellipseLabelFont,
+                                ellipseLabelFontSize,
+                                showCenters,
+                                showLabels);
+                    }
+                }
+            }
+
+            // draw zoom box if in use
+            if (isInImageModeZoom()
+                    && (Math.abs(zoomMaxX - zoomMinX) * Math.abs(zoomMinY - zoomMaxY)) > 0) {
+                g2d.setStroke(new BasicStroke(2.0f));
+                g2d.setColor(Color.red);
+                g2d.drawRect(//
+                        Math.min(zoomMinX, zoomMaxX),
+                        Math.min(zoomMaxY, zoomMinY),
+                        Math.abs(zoomMaxX - zoomMinX),
+                        Math.abs(zoomMinY - zoomMaxY));
+            }
+
+
             // resets clipping
             try {
                 drawAxesAndTics(g2d, yAxisDisplayAsDeltaUnits);
@@ -784,11 +830,14 @@ public final class EvolutionPlotPanel extends AbstractDataView implements Plotti
         }
     }
 
-    private void buildSeawaterModelPlot(SeaWaterInitialDelta234UTableModel seaWaterInitialDelta234UTableModel) {
-        //LinearInterpolator linearInterpolator = new LinearInterpolator();
+    /**
+     *
+     * @param seaWaterInitialDelta234UTableModel
+     * @param limit limit negative = lower envelope, 0 = seawater, >0 = upper
+     * envelope
+     */
+    private void buildSeawaterModelPlot(SeaWaterInitialDelta234UTableModel seaWaterInitialDelta234UTableModel, int limit) {
         double[] dates = seaWaterInitialDelta234UTableModel.getArrayOfDates();
-        //double[] deltas = seaWaterInitialDelta234UTableModel.getArrayOfDeltasAsRatios();
-        //PolynomialSplineFunction psf = linearInterpolator.interpolate(dates, deltas);
 
         int countOfPoints = 100;
         double step = (dates[dates.length - 1] - dates[0]) / countOfPoints;
@@ -797,7 +846,8 @@ public final class EvolutionPlotPanel extends AbstractDataView implements Plotti
 
         for (int i = 0; i < countOfPoints; i++) {
             tvsw[0][i] = dates[0] + i * step;
-            ar48isw[i] = seaWaterInitialDelta234UTableModel.calculateAr234U_238Uisw(tvsw[0][i]);
+            ar48isw[i] = seaWaterInitialDelta234UTableModel.calculateAr234U_238Uisw(tvsw[0][i])
+                    + Math.signum(limit) * seaWaterInitialDelta234UTableModel.calculateAr234U_238UiswUnct(tvsw[0][i]);
         }
 
         xysw = new double[1][2][ar48isw.length];
@@ -913,7 +963,7 @@ public final class EvolutionPlotPanel extends AbstractDataView implements Plotti
         double ar230Th_238U;
 
         double f234 = 1.0 - (pctLoss / 100.0);
-        double f230 = ((f234 - 1.0) * (4.754 * 234.0 / 4.184 / 230.0) + 1.0 + f234)/2;
+        double f230 = ((f234 - 1.0) * (4.754 * 234.0 / 4.184 / 230.0) + 1.0 + f234) / 2;
 
         ar234U_238U = (1.0 + rValue * (1.0 - f234)) * (1.0 - Math.exp(-lambda234D * age)) + ar234U_238Uisw * Math.exp(-lambda234D * age);
         ar230Th_238U

--- a/src/main/java/org/earthtime/plots/evolution/EvolutionPlotPanel.java
+++ b/src/main/java/org/earthtime/plots/evolution/EvolutionPlotPanel.java
@@ -317,18 +317,18 @@ public final class EvolutionPlotPanel extends AbstractDataView implements Plotti
 
             // opensystem isochrons
             if (!openSystemIsochronModelsList.isEmpty()) {
-                LinearInterpolator linearInterpolator = new LinearInterpolator();
+                //LinearInterpolator linearInterpolator = new LinearInterpolator();
 
                 for (OpenSystemIsochronTableModel ositm : openSystemIsochronModelsList) {
                     // for each model, we use the seawaater model to calculate the open isochrons
                     if (ositm.isShowOpenIsochrons()) {
-                        double[] dates = ositm.getSeaWaterInitialDelta234UTableModel().getArrayOfDates();
-                        double[] deltas = ositm.getSeaWaterInitialDelta234UTableModel().getArrayOfDeltasAsRatios();
-                        PolynomialSplineFunction psfSeaWater = linearInterpolator.interpolate(dates, deltas);
+                        //double[] dates = ositm.getSeaWaterInitialDelta234UTableModel().getArrayOfDates();
+                        //double[] deltas = ositm.getSeaWaterInitialDelta234UTableModel().getArrayOfDeltasAsRatios();
+                        //PolynomialSplineFunction psfSeaWater = linearInterpolator.interpolate(dates, deltas);
 
                         for (OpenSystemIsochronModelEntry osime : ositm.getEntryList()) {
                             double age = osime.getAgeInKa() * 1000.0;
-                            double ar234U_238Uisw = psfSeaWater.value(age);
+                            double ar234U_238Uisw = ositm.getSeaWaterInitialDelta234UTableModel().calculateAr234U_238Uisw(age);
                             double isoPctLoss = osime.getPctLoss();
                             double isoStartR = osime.getrStart();
                             double isoEndR = osime.getrEnd();
@@ -785,10 +785,10 @@ public final class EvolutionPlotPanel extends AbstractDataView implements Plotti
     }
 
     private void buildSeawaterModelPlot(SeaWaterInitialDelta234UTableModel seaWaterInitialDelta234UTableModel) {
-        LinearInterpolator linearInterpolator = new LinearInterpolator();
+        //LinearInterpolator linearInterpolator = new LinearInterpolator();
         double[] dates = seaWaterInitialDelta234UTableModel.getArrayOfDates();
-        double[] deltas = seaWaterInitialDelta234UTableModel.getArrayOfDeltasAsRatios();
-        PolynomialSplineFunction psf = linearInterpolator.interpolate(dates, deltas);
+        //double[] deltas = seaWaterInitialDelta234UTableModel.getArrayOfDeltasAsRatios();
+        //PolynomialSplineFunction psf = linearInterpolator.interpolate(dates, deltas);
 
         int countOfPoints = 100;
         double step = (dates[dates.length - 1] - dates[0]) / countOfPoints;
@@ -797,7 +797,7 @@ public final class EvolutionPlotPanel extends AbstractDataView implements Plotti
 
         for (int i = 0; i < countOfPoints; i++) {
             tvsw[0][i] = dates[0] + i * step;
-            ar48isw[i] = psf.value(tvsw[0][i]);
+            ar48isw[i] = seaWaterInitialDelta234UTableModel.calculateAr234U_238Uisw(tvsw[0][i]);
         }
 
         xysw = new double[1][2][ar48isw.length];

--- a/src/main/java/org/earthtime/plots/evolution/openSystem/OpenSystemDateCalculator.java
+++ b/src/main/java/org/earthtime/plots/evolution/openSystem/OpenSystemDateCalculator.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2019 CIRDLES.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.earthtime.plots.evolution.openSystem;
+
+/**
+ *
+ * @author James F. Bowring, CIRDLES.org, and Earth-Time.org
+ */
+public class OpenSystemDateCalculator {
+
+    //         % physical constants 
+    static private double lambda234 = 0.00000282206; //% physical constants v 1.1
+    static private double lambda230 = 0.0000091705;// % physical constants v 1.1
+
+//        % user / sample inputs 
+    static private double pctLoss = 2.5;// % percent loss, percent 
+    static private double ar234U238Umeas = 1.1154;// % measured activity ratio from Blanchon dataset 
+    static private double ar230Th238Umeas = 0.7490; //% measured activity ratio from Blanchon dataset 
+    static private double uncorrectedDate = 118000; //% uncorrected U - Th date, in years
+
+    public static double calculateOpenSystemDate() {
+
+//        % calculate constants f234 and f230 
+        double f234 = 1 - pctLoss / 100;
+        double f230 = ((f234 - 1) * (4.754 * 234 / 4.184 / 230) + 1 + f234) / 2;
+        
+        double tol = 1e-3; //% convergence criterion - tolerance for t
+        int maxIterations = 100; //  % maximum iterations before hard loop exit
+
+//        % initial values
+        double t_n = 0;
+        double t_previous = 1e12;
+        double iterations = 0;
+        double t_nMinus1 = uncorrectedDate - 1000;
+        double t_nMinus2 = uncorrectedDate;
+        
+        while (Math.abs(t_n - t_previous) > tol) {
+            
+            iterations = iterations + 1;
+            
+            if (iterations > maxIterations) {
+                System.out.println("error: maximum iterations reached");
+                break;
+            }
+            
+            t_previous = t_n;
+            
+            t_n = t_nMinus1 - f(t_nMinus1, f234, f230) * (t_nMinus1 - t_nMinus2)
+                    / (f(t_nMinus1, f234, f230) - f(t_nMinus2, f234, f230));
+            
+            t_nMinus2 = t_nMinus1;
+            t_nMinus1 = t_n;
+        }
+
+//        % output t_n as the open system date (in years)
+        return t_n;
+//        % for provided inputs, should get t_n = 1.12440999e+05
+
+    }
+    
+    private static double ar234U238Ui(double t) {
+        return 1.145 + 2e-8 * t;
+    }
+    
+    private static double m(double t, double f234, double f230) {
+//            % Equation 2 of Thompson et al. (2003)
+        return (1 - f234) * (1 - Math.exp(-lambda234 * t))
+                / ((1 - f234 * f230) * (1 - lambda230 / (lambda230 - lambda234) * Math.exp(-lambda234 * t) + lambda234 / (lambda230 - lambda234) * Math.exp(-lambda230 * t))
+                + (1 - f230) * lambda230 / (lambda230 - lambda234) * ar234U238Ui(t) * (Math.exp(-lambda234 * t) - Math.exp(-lambda230 * t)));
+    }
+    
+    private static double f(double t, double f234, double f230) {
+//        % Equation 1 of Thompson et al. (2003)
+        return 1 - Math.exp(-lambda230 * t) + lambda230 / (lambda230 - lambda234) * (ar234U238Ui(t) - 1) * (Math.exp(-lambda234 * t) - Math.exp(-lambda230 * t))
+                + 1 / m(t, f234, f230) * (ar234U238Umeas - ((ar234U238Ui(t) - 1) * Math.exp(-lambda234 * t) + 1)) - ar230Th238Umeas;
+    }
+    public static void main(String[] args) {
+        System.out.println(calculateOpenSystemDate());
+    }
+}

--- a/src/main/java/org/earthtime/plots/evolution/openSystem/OpenSystemDateCalculator.java
+++ b/src/main/java/org/earthtime/plots/evolution/openSystem/OpenSystemDateCalculator.java
@@ -15,79 +15,206 @@
  */
 package org.earthtime.plots.evolution.openSystem;
 
+import Jama.Matrix;
+import java.math.BigDecimal;
+import java.text.DecimalFormat;
+import org.earthtime.UPb_Redux.valueModels.ValueModel;
+import org.earthtime.dataDictionaries.Lambdas;
+import org.earthtime.dataDictionaries.RadDates;
+import org.earthtime.plots.evolution.seaWater.SeaWaterInitialDelta234UTableModel;
+import org.earthtime.reduxLabData.ReduxLabData;
+
 /**
  *
  * @author James F. Bowring, CIRDLES.org, and Earth-Time.org
  */
 public class OpenSystemDateCalculator {
 
-    //         % physical constants 
-    static private double lambda234 = 0.00000282206; //% physical constants v 1.1
-    static private double lambda230 = 0.0000091705;// % physical constants v 1.1
+    //  physical constants 
+    static private double lambda234
+            = ReduxLabData.getInstance().getDefaultPhysicalConstantsModel().getDatumByName(Lambdas.lambda234.getName()).getValue().doubleValue();     // 0.00000282206; //% physical constants v 1.1
+    static private double lambda230
+            = ReduxLabData.getInstance().getDefaultPhysicalConstantsModel().getDatumByName(Lambdas.lambda230.getName()).getValue().doubleValue();     //0.0000091705;// % physical constants v 1.1
 
-//        % user / sample inputs 
-    static private double pctLoss = 2.5;// % percent loss, percent 
-    static private double ar234U238Umeas = 1.1154;// % measured activity ratio from Blanchon dataset 
-    static private double ar230Th238Umeas = 0.7490; //% measured activity ratio from Blanchon dataset 
-    static private double uncorrectedDate = 118000; //% uncorrected U - Th date, in years
+    public static ValueModel calculateOpenSystemDate(
+            ValueModel pctLossVM,
+            ValueModel ar234U238UmeasVM,
+            ValueModel ar230Th238UmeasVM,
+            double uncorrectedDate,
+            SeaWaterInitialDelta234UTableModel seaWaterInitialDelta234UTableModel) {
 
-    public static double calculateOpenSystemDate() {
+        double pctLoss = pctLossVM.getValue().doubleValue();
+        double ar234U238Umeas = ar234U238UmeasVM.getValue().doubleValue();
+        double ar230Th238Umeas = ar230Th238UmeasVM.getValue().doubleValue();
 
-//        % calculate constants f234 and f230 
-        double f234 = 1 - pctLoss / 100;
-        double f230 = ((f234 - 1) * (4.754 * 234 / 4.184 / 230) + 1 + f234) / 2;
-        
-        double tol = 1e-3; //% convergence criterion - tolerance for t
+        // calculate constants f234 and f230 
+        double f234 = 1.0 - pctLoss / 100.0;
+        double f230 = ((f234 - 1.0) * (4.754 * 234 / 4.184 / 230.0) + 1.0 + f234) / 2.0;
+
+        double tol = 1.0e-3; //% convergence criterion - tolerance for t
         int maxIterations = 100; //  % maximum iterations before hard loop exit
 
-//        % initial values
-        double t_n = 0;
-        double t_previous = 1e12;
-        double iterations = 0;
-        double t_nMinus1 = uncorrectedDate - 1000;
+        // % initial values
+        double t_n = 0.0;
+        double t_previous = 1.0e12;
+        double iterations = 0.0;
+        double t_nMinus1 = uncorrectedDate - 1000.0;
         double t_nMinus2 = uncorrectedDate;
-        
+
         while (Math.abs(t_n - t_previous) > tol) {
-            
+
             iterations = iterations + 1;
-            
+
             if (iterations > maxIterations) {
                 System.out.println("error: maximum iterations reached");
                 break;
             }
-            
+
             t_previous = t_n;
-            
-            t_n = t_nMinus1 - f(t_nMinus1, f234, f230) * (t_nMinus1 - t_nMinus2)
-                    / (f(t_nMinus1, f234, f230) - f(t_nMinus2, f234, f230));
-            
+
+            t_n = t_nMinus1 - f(t_nMinus1, f234, f230, ar234U238Umeas, ar230Th238Umeas, seaWaterInitialDelta234UTableModel) * (t_nMinus1 - t_nMinus2)
+                    / (f(t_nMinus1, f234, f230, ar234U238Umeas, ar230Th238Umeas, seaWaterInitialDelta234UTableModel)
+                    - f(t_nMinus2, f234, f230, ar234U238Umeas, ar230Th238Umeas, seaWaterInitialDelta234UTableModel));
+
             t_nMinus2 = t_nMinus1;
             t_nMinus1 = t_n;
         }
 
-//        % output t_n as the open system date (in years)
-        return t_n;
-//        % for provided inputs, should get t_n = 1.12440999e+05
+        // uncertainty calcs per email from Noah July 2019
+        // output t_n as the open system date (in years)
+        double t = t_n;
+        double openSystemDate_oneSigmaAbs = 0.0;
+        if (t > 0) {
+            double ar234U238Ui = ar234U238Uisw(t, seaWaterInitialDelta234UTableModel);
+            double dfdt = lambda230 * Math.exp(-lambda230 * t)
+                    + (100
+                    * (((lambda230 * lambda234 * Math.exp(-lambda230 * t))
+                    / (lambda230 - lambda234) - (lambda230 * lambda234 * Math.exp(-lambda234 * t))
+                    / (lambda230 - lambda234))
+                    * (((388389323654697.0 * pctLoss) / 36028797018963968.0 - 1.0)
+                    * (pctLoss / 100.0 - 1.0) - 1.0) + (388389323654697.0 * ar234U238Ui * lambda230 * pctLoss
+                    * (lambda230 * Math.exp(-lambda230 * t) - lambda234 * Math.exp(-lambda234 * t)))
+                    / (36028797018963968.0 * (lambda230 - lambda234))) * (Math.exp(-lambda234 * t) * (ar234U238Ui - 1) - ar234U238Umeas + 1.0))
+                    / (pctLoss * (Math.exp(-lambda234 * t) - 1.0))
+                    + (lambda230 * (lambda230 * Math.exp(-lambda230 * t) - lambda234 * Math.exp(-lambda234 * t))
+                    * (ar234U238Ui - 1.0)) / (lambda230 - lambda234) - (100.0 * lambda234 * Math.exp(-lambda234 * t)
+                    * ((((388389323654697.0 * pctLoss) / 36028797018963968.0 - 1.0) * (pctLoss / 100.0 - 1.0) - 1.0)
+                    * ((lambda234 * Math.exp(-lambda230 * t)) / (lambda230 - lambda234)
+                    - (lambda230 * Math.exp(-lambda234 * t)) / (lambda230 - lambda234) + 1.0)
+                    + (388389323654697.0 * ar234U238Ui * lambda230 * pctLoss
+                    * (Math.exp(-lambda230 * t) - Math.exp(-lambda234 * t)))
+                    / (36028797018963968.0 * (lambda230 - lambda234)))
+                    * (Math.exp(-lambda234 * t) * (ar234U238Ui - 1.0) - ar234U238Umeas + 1.0))
+                    / (pctLoss * Math.pow(Math.exp(-lambda234 * t) - 1.0, 2.0)) + (100.0 * lambda234 * Math.exp(-lambda234 * t)
+                    * ((((388389323654697.0 * pctLoss) / 36028797018963968.0 - 1.0) * (pctLoss / 100.0 - 1.0) - 1.0)
+                    * ((lambda234 * Math.exp(-lambda230 * t)) / (lambda230 - lambda234) - (lambda230 * Math.exp(-lambda234 * t))
+                    / (lambda230 - lambda234) + 1) + (388389323654697.0 * ar234U238Ui * lambda230 * pctLoss
+                    * (Math.exp(-lambda230 * t) - Math.exp(-lambda234 * t)))
+                    / (36028797018963968.0 * (lambda230 - lambda234))) * (ar234U238Ui - 1.0)) / (pctLoss * (Math.exp(-lambda234 * t) - 1.0));
+
+            double dfdvar00 = (100.0 * ((((388389323654697.0 * pctLoss) / 36028797018963968.0 - 1.0)
+                    * (pctLoss / 100.0 - 1.0) - 1.0) * ((lambda234 * Math.exp(-lambda230 * t)) / (lambda230 - lambda234)
+                    - (lambda230 * Math.exp(-lambda234 * t)) / (lambda230 - lambda234) + 1) + (388389323654697.0 * ar234U238Ui
+                    * lambda230 * pctLoss * (Math.exp(-lambda230 * t) - Math.exp(-lambda234 * t))) / (36028797018963968.0
+                    * (lambda230 - lambda234))) * (Math.exp(-lambda234 * t) * (ar234U238Ui - 1.0) - ar234U238Umeas + 1))
+                    / (pctLoss * pctLoss * (Math.exp(-lambda234 * t) - 1.0))
+                    - (100.0 * (((388389323654697.0 * pctLoss) / 1801439850948198400.0 - 18716932346108417.0 / 900719925474099200.0)
+                    * ((lambda234 * Math.exp(-lambda230 * t)) / (lambda230 - lambda234) - (lambda230 * Math.exp(-lambda234 * t))
+                    / (lambda230 - lambda234) + 1.0) + (388389323654697.0 * ar234U238Ui * lambda230
+                    * (Math.exp(-lambda230 * t) - Math.exp(-lambda234 * t))) / (36028797018963968.0 * (lambda230 - lambda234)))
+                    * (Math.exp(-lambda234 * t) * (ar234U238Ui - 1) - ar234U238Umeas + 1)) / (pctLoss * (Math.exp(-lambda234 * t) - 1));
+
+            double dfdvar01 = -(lambda230 * (Math.exp(-lambda230 * t) - Math.exp(-lambda234 * t))) / (lambda230 - lambda234)
+                    - (100.0 * Math.exp(-lambda234 * t) * ((((388389323654697.0 * pctLoss) / 36028797018963968.0 - 1)
+                    * (pctLoss / 100 - 1) - 1) * ((lambda234 * Math.exp(-lambda230 * t))
+                    / (lambda230 - lambda234) - (lambda230 * Math.exp(-lambda234 * t))
+                    / (lambda230 - lambda234) + 1) + (388389323654697.0 * ar234U238Ui * lambda230 * pctLoss
+                    * (Math.exp(-lambda230 * t) - Math.exp(-lambda234 * t))) / (36028797018963968.0
+                    * (lambda230 - lambda234)))) / (pctLoss * (Math.exp(-lambda234 * t) - 1.0))
+                    - (9709733091367425.0 * lambda230 * (Math.exp(-lambda230 * t) - Math.exp(-lambda234 * t))
+                    * (Math.exp(-lambda234 * t) * (ar234U238Ui - 1) - ar234U238Umeas + 1))
+                    / (9007199254740992.0 * (Math.exp(-lambda234 * t) - 1) * (lambda230 - lambda234));
+
+            double dfdvar02 = (100.0 * ((((388389323654697.0 * pctLoss) / 36028797018963968.0 - 1)
+                    * (pctLoss / 100.0 - 1.0) - 1.0) * ((lambda234 * Math.exp(-lambda230 * t))
+                    / (lambda230 - lambda234) - (lambda230 * Math.exp(-lambda234 * t))
+                    / (lambda230 - lambda234) + 1.0) + (388389323654697.0 * ar234U238Ui
+                    * lambda230 * pctLoss * (Math.exp(-lambda230 * t) - Math.exp(-lambda234 * t)))
+                    / (36028797018963968.0 * (lambda230 - lambda234)))) / (pctLoss * (Math.exp(-lambda234 * t) - 1.0));
+
+            double dfdvar03 = -1.0;
+
+            Matrix dfdvar = new Matrix(new double[][]{//
+                {dfdvar00, dfdvar01, dfdvar02, dfdvar03}});
+
+            Matrix dtdvar = new Matrix(new double[][]{//
+                {-dfdvar00 / dfdt, -dfdvar01 / dfdt, -dfdvar02 / dfdt, -dfdvar03 / dfdt}});
+
+            //First, assemble a four row by four column covariance matrix with the oneSigmaAbs uncertainties SQUARED = VARIANCE
+            // for pctLoss, ar234U238Ui, ar234U238Umeas, and ar230Th238Umeas, in that order, on the diagonal.
+            Matrix covMat = new Matrix(new double[][]{//
+                {pctLossVM.getOneSigmaAbs().pow(2).doubleValue(), 0., 0., 0.},
+                {0., Math.pow(seaWaterInitialDelta234UTableModel.calculateAr234U_238UiswUnct(t), 2.0), 0., 0.},
+                {0., 0., ar234U238UmeasVM.getOneSigmaAbs().pow(2).doubleValue(), 0.},
+                {0., 0., 0., ar230Th238UmeasVM.getOneSigmaAbs().pow(2).doubleValue()}});
+
+            openSystemDate_oneSigmaAbs = Math.sqrt(dtdvar.times(covMat).times(dtdvar.transpose()).get(0, 0));
+
+//            System.out.println("dfdt = " + dfdt);
+//            System.out.println("dfdvar = ");
+//            dfdvar.print(new DecimalFormat("0.000000E00"), 14);
+//            System.out.println("dtdvar = ");
+//            dtdvar.print(new DecimalFormat("0.000000E00"), 14);
+//            System.out.println("covMat = ");
+//            covMat.print(new DecimalFormat("0.000000E00"), 14);
+        }
+
+        ValueModel dateOpenSys = new ValueModel(
+                RadDates.dateOpenSys.getName(),
+                new BigDecimal(t),
+                "ABS",
+                new BigDecimal(openSystemDate_oneSigmaAbs),
+                BigDecimal.ZERO);
+
+        return dateOpenSys;
 
     }
-    
-    private static double ar234U238Ui(double t) {
-        return 1.145 + 2e-8 * t;
+
+    // seawater model
+    private static double ar234U238Uisw(double t, SeaWaterInitialDelta234UTableModel seaWaterInitialDelta234UTableModel) {
+        return seaWaterInitialDelta234UTableModel.calculateAr234U_238Uisw(t);//               1.145 + 2e-8 * t;
     }
-    
-    private static double m(double t, double f234, double f230) {
-//            % Equation 2 of Thompson et al. (2003)
+
+    private static double m(double t, double f234, double f230, SeaWaterInitialDelta234UTableModel seaWaterInitialDelta234UTableModel) {
+        //   Equation 2 of Thompson et al. (2003)
         return (1 - f234) * (1 - Math.exp(-lambda234 * t))
                 / ((1 - f234 * f230) * (1 - lambda230 / (lambda230 - lambda234) * Math.exp(-lambda234 * t) + lambda234 / (lambda230 - lambda234) * Math.exp(-lambda230 * t))
-                + (1 - f230) * lambda230 / (lambda230 - lambda234) * ar234U238Ui(t) * (Math.exp(-lambda234 * t) - Math.exp(-lambda230 * t)));
+                + (1 - f230) * lambda230 / (lambda230 - lambda234)
+                * ar234U238Uisw(t, seaWaterInitialDelta234UTableModel) * (Math.exp(-lambda234 * t) - Math.exp(-lambda230 * t)));
     }
-    
-    private static double f(double t, double f234, double f230) {
-//        % Equation 1 of Thompson et al. (2003)
-        return 1 - Math.exp(-lambda230 * t) + lambda230 / (lambda230 - lambda234) * (ar234U238Ui(t) - 1) * (Math.exp(-lambda234 * t) - Math.exp(-lambda230 * t))
-                + 1 / m(t, f234, f230) * (ar234U238Umeas - ((ar234U238Ui(t) - 1) * Math.exp(-lambda234 * t) + 1)) - ar230Th238Umeas;
+
+    private static double f(double t, double f234, double f230, double ar234U238Umeas, double ar230Th238Umeas, SeaWaterInitialDelta234UTableModel seaWaterInitialDelta234UTableModel) {
+        //  Equation 1 of Thompson et al. (2003)
+        return 1 - Math.exp(-lambda230 * t) + lambda230 / (lambda230 - lambda234) * (ar234U238Uisw(t, seaWaterInitialDelta234UTableModel) - 1)
+                * (Math.exp(-lambda234 * t) - Math.exp(-lambda230 * t))
+                + 1 / m(t, f234, f230, seaWaterInitialDelta234UTableModel) * (ar234U238Umeas - ((ar234U238Uisw(t, seaWaterInitialDelta234UTableModel) - 1) * Math.exp(-lambda234 * t) + 1)) - ar230Th238Umeas;
     }
+
     public static void main(String[] args) {
-        System.out.println(calculateOpenSystemDate());
+
+        //    user sample inputs 
+        //    pctLoss = 2.5;// % percent loss, percent 
+        //    ar234U238Umeas = 1.1154;// % measured activity ratio from Blanchon dataset ;1 sig abs = 0.001
+        //    ar230Th238Umeas = 0.7490; //% measured activity ratio from Blanchon dataset ;1 sig abs = 0.00395
+        //    uncorrectedDate = 118000; //% uncorrected U - Th date, in years ;1 sig abs = 1.1
+        // for provided inputs, should get t_n = 1.12440999e+05
+        ValueModel dos = calculateOpenSystemDate(
+                new ValueModel("pctLoss", new BigDecimal(2.5), "ABS", BigDecimal.ONE, BigDecimal.ZERO),
+                new ValueModel("ar234U238Umeas", new BigDecimal(1.1154), "ABS", new BigDecimal(0.001), BigDecimal.ZERO),
+                new ValueModel("ar230Th238Umeas", new BigDecimal(0.7490), "ABS", new BigDecimal(0.00395), BigDecimal.ZERO),
+                118000,
+                ReduxLabData.getInstance().getDefaultSeaWaterInitialDelta234UTableModel());
+
+        System.out.println(dos.getValue().doubleValue() + "    " + dos.getOneSigmaAbs().doubleValue());
     }
 }

--- a/src/main/java/org/earthtime/plots/evolution/openSystem/OpenSystemDateCalculator.java
+++ b/src/main/java/org/earthtime/plots/evolution/openSystem/OpenSystemDateCalculator.java
@@ -169,12 +169,22 @@ public class OpenSystemDateCalculator {
 //            covMat.print(new DecimalFormat("0.000000E00"), 14);
         }
 
-        ValueModel dateOpenSys = new ValueModel(
-                RadDates.dateOpenSys.getName(),
-                new BigDecimal(t),
-                "ABS",
-                new BigDecimal(openSystemDate_oneSigmaAbs),
-                BigDecimal.ZERO);
+        ValueModel dateOpenSys = null;
+        try {
+            dateOpenSys = new ValueModel(
+                    RadDates.dateOpenSys.getName(),
+                    new BigDecimal(t),
+                    "ABS",
+                    new BigDecimal(openSystemDate_oneSigmaAbs),
+                    BigDecimal.ZERO);
+        } catch (Exception e) {
+            dateOpenSys = new ValueModel(
+                    RadDates.dateOpenSys.getName(),
+                    BigDecimal.ZERO,
+                    "ABS",
+                    BigDecimal.ZERO,
+                    BigDecimal.ZERO);
+        }
 
         return dateOpenSys;
 

--- a/src/main/java/org/earthtime/plots/evolution/openSystem/OpenSystemModelsManager.java
+++ b/src/main/java/org/earthtime/plots/evolution/openSystem/OpenSystemModelsManager.java
@@ -59,6 +59,7 @@ public class OpenSystemModelsManager extends DialogEditor {
     private void initModels() {
         setSize(375, openModels.size() * 265 + 50);
         setTitle("Manage Plots Seawater/Open Sys Isochrons");
+        setAlwaysOnTop(true);
 
         JPanel modelsPanel = new JPanel(null);
         modelsPanel.setSize(300, openModels.size() * 250);

--- a/src/main/java/org/earthtime/plots/evolution/seaWater/SeaWaterInitialDelta234UTableModel.java
+++ b/src/main/java/org/earthtime/plots/evolution/seaWater/SeaWaterInitialDelta234UTableModel.java
@@ -60,8 +60,8 @@ public class SeaWaterInitialDelta234UTableModel extends AbstractTableModel imple
 
     private void initializeModel() {
         SeaWaterDelta234UModelEntry row1 = new SeaWaterDelta234UModelEntry(0, 145, 1);
-        SeaWaterDelta234UModelEntry row2 = new SeaWaterDelta234UModelEntry(500, 155, 1);
-        SeaWaterDelta234UModelEntry row3 = new SeaWaterDelta234UModelEntry(1000, 165, 1);
+        SeaWaterDelta234UModelEntry row2 = new SeaWaterDelta234UModelEntry(500, 145, 1);
+        SeaWaterDelta234UModelEntry row3 = new SeaWaterDelta234UModelEntry(1000, 145, 1);
 
         //build the list
         modelName = "Default";
@@ -125,6 +125,13 @@ public class SeaWaterInitialDelta234UTableModel extends AbstractTableModel imple
     public String getNameAndVersion() {
         return makeNameAndVersion(modelName, versionNumber, minorVersionNumber);
     }
+
+    @Override
+    public String toString() {
+        return getNameAndVersion();
+    }
+    
+
 
     private static String makeNameAndVersion(String name, int version, int minorVersionNumber) {
         return name.trim()//

--- a/src/main/java/org/earthtime/plots/evolution/seaWater/SeaWaterInitialDelta234UTableModel.java
+++ b/src/main/java/org/earthtime/plots/evolution/seaWater/SeaWaterInitialDelta234UTableModel.java
@@ -130,8 +130,6 @@ public class SeaWaterInitialDelta234UTableModel extends AbstractTableModel imple
     public String toString() {
         return getNameAndVersion();
     }
-    
-
 
     private static String makeNameAndVersion(String name, int version, int minorVersionNumber) {
         return name.trim()//
@@ -310,6 +308,15 @@ public class SeaWaterInitialDelta234UTableModel extends AbstractTableModel imple
         }
 
         return deltasArray;
+    }
+
+    public double[] getArrayOfDeltasUnct() {
+        double[] deltasUnctArray = new double[entryList.size()];
+        for (int i = 0; i < entryList.size(); i++) {
+            deltasUnctArray[i] = entryList.get(i).oneSigmaAbsUnct;
+        }
+
+        return deltasUnctArray;
     }
 
     /**

--- a/src/main/java/org/earthtime/plots/evolution/seaWater/SeaWaterInitialDelta234UTableModel.java
+++ b/src/main/java/org/earthtime/plots/evolution/seaWater/SeaWaterInitialDelta234UTableModel.java
@@ -243,7 +243,8 @@ public class SeaWaterInitialDelta234UTableModel extends AbstractTableModel imple
         try {
             retVal = psfSeaWater.value(ageInYears);
         } catch (Exception e) {
-            System.out.println("calculateAr234U_238Uisw error with age = " + ageInYears);
+//            System.out.println("calculateAr234U_238Uisw error with age = " + ageInYears);
+            retVal = 0;
         }
 
         return retVal;
@@ -259,7 +260,8 @@ public class SeaWaterInitialDelta234UTableModel extends AbstractTableModel imple
         try {
             retVal = psfSeaWaterUnct.value(ageInYears);
         } catch (Exception e) {
-            System.out.println("calculateAr234U_238UiswUnct error with age = " + ageInYears);
+//            System.out.println("calculateAr234U_238UiswUnct error with age = " + ageInYears);
+            retVal = 0;
         }
 
         return retVal;

--- a/src/main/java/org/earthtime/plots/evolution/seaWater/SeawaterModelAssignmentManager.form
+++ b/src/main/java/org/earthtime/plots/evolution/seaWater/SeawaterModelAssignmentManager.form
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+
+<Form version="1.3" maxVersion="1.3" type="org.netbeans.modules.form.forminfo.JDialogFormInfo">
+  <Properties>
+    <Property name="defaultCloseOperation" type="int" value="2"/>
+    <Property name="background" type="java.awt.Color" editor="org.netbeans.beaninfo.editors.ColorEditor">
+      <Color blue="ff" green="ff" red="cc" type="rgb"/>
+    </Property>
+  </Properties>
+  <SyntheticProperties>
+    <SyntheticProperty name="formSizePolicy" type="int" value="1"/>
+    <SyntheticProperty name="generateCenter" type="boolean" value="false"/>
+  </SyntheticProperties>
+  <AuxValues>
+    <AuxValue name="FormSettings_autoResourcing" type="java.lang.Integer" value="0"/>
+    <AuxValue name="FormSettings_autoSetComponentName" type="java.lang.Boolean" value="false"/>
+    <AuxValue name="FormSettings_generateFQN" type="java.lang.Boolean" value="true"/>
+    <AuxValue name="FormSettings_generateMnemonicsCode" type="java.lang.Boolean" value="false"/>
+    <AuxValue name="FormSettings_i18nAutoMode" type="java.lang.Boolean" value="false"/>
+    <AuxValue name="FormSettings_layoutCodeTarget" type="java.lang.Integer" value="2"/>
+    <AuxValue name="FormSettings_listenerGenerationStyle" type="java.lang.Integer" value="0"/>
+    <AuxValue name="FormSettings_variablesLocal" type="java.lang.Boolean" value="false"/>
+    <AuxValue name="FormSettings_variablesModifier" type="java.lang.Integer" value="2"/>
+    <AuxValue name="designerSize" type="java.awt.Dimension" value="-84,-19,0,5,115,114,0,18,106,97,118,97,46,97,119,116,46,68,105,109,101,110,115,105,111,110,65,-114,-39,-41,-84,95,68,20,2,0,2,73,0,6,104,101,105,103,104,116,73,0,5,119,105,100,116,104,120,112,0,0,1,44,0,0,1,-112"/>
+  </AuxValues>
+
+  <Layout class="org.netbeans.modules.form.compat2.layouts.DesignAbsoluteLayout">
+    <Property name="useNullLayout" type="boolean" value="true"/>
+  </Layout>
+</Form>

--- a/src/main/java/org/earthtime/plots/evolution/seaWater/SeawaterModelAssignmentManager.java
+++ b/src/main/java/org/earthtime/plots/evolution/seaWater/SeawaterModelAssignmentManager.java
@@ -1,0 +1,358 @@
+/*
+ * Copyright 2019 CIRDLES.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.earthtime.plots.evolution.seaWater;
+
+import java.awt.Color;
+import java.awt.Dimension;
+import java.awt.HeadlessException;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+import java.awt.event.FocusEvent;
+import java.awt.event.FocusListener;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Vector;
+import javax.swing.JButton;
+import javax.swing.JComboBox;
+import javax.swing.JLabel;
+import javax.swing.JPanel;
+import javax.swing.JScrollPane;
+import javax.swing.JTextField;
+import org.earthtime.ETReduxFrame;
+import org.earthtime.UPb_Redux.ReduxConstants;
+import org.earthtime.UPb_Redux.exceptions.BadLabDataException;
+import org.earthtime.UTh_Redux.fractions.UThFractionI;
+import org.earthtime.UTh_Redux.fractions.UThLegacyFraction;
+import org.earthtime.UTh_Redux.fractions.UThLegacyFractionI;
+import org.earthtime.UTh_Redux.fractions.fractionReduction.UThFractionReducer;
+import org.earthtime.beans.ET_JButton;
+import static org.earthtime.dataDictionaries.SampleAnalysisTypesEnum.USERIES_CARB;
+import org.earthtime.dataDictionaries.SampleTypesEnum;
+import org.earthtime.dialogs.DialogEditor;
+import org.earthtime.fractions.ETFractionInterface;
+import org.earthtime.projects.ProjectSample;
+import org.earthtime.samples.SampleInterface;
+
+/**
+ *
+ * @author James F. Bowring, CIRDLES.org, and Earth-Time.org
+ */
+public class SeawaterModelAssignmentManager extends DialogEditor {
+
+    private SampleInterface projectSample;
+    private ETReduxFrame parentFrame;
+
+    /**
+     * @return the projectSample
+     */
+    public SampleInterface getProjectSample() {
+        return projectSample;
+    }
+
+    /**
+     * @param projectSample the projectSample to set
+     */
+    public void setProjectSample(SampleInterface projectSample) {
+        this.projectSample = projectSample;
+    }
+
+    private static final int FRACTION_COL_X = 15;
+    private static final int SEAWATER_COL_X = 150;
+    private static final int PCTLOSS_COL_X = 400;
+    private static final int PCTLOSSUNCT_COL_X = 500;
+    private static final int START_DATA_Y = 120;
+    private static int DISPLAY_WIDTH = 600;
+
+    private Vector<ETFractionInterface> fractions;
+    private JLabel[] fractionNames;
+    private JComboBox<SeaWaterInitialDelta234UTableModel>[] seawaterModelChoices;
+    private JTextField[] pctLoss;
+    private JTextField[] pctLossUnct;
+
+    /**
+     * Creates new form OpenSystemModelsManager
+     */
+    private SeawaterModelAssignmentManager() throws BadLabDataException {
+        this(null, true, null);
+    }
+
+    public SeawaterModelAssignmentManager(java.awt.Frame parent,
+            boolean modal, SampleInterface projectSample) throws HeadlessException {
+        super(parent, modal);
+
+        this.parentFrame = (ETReduxFrame) parent;
+        this.projectSample = projectSample;
+
+        initComponents();
+
+        fractions = projectSample.getFractions();
+        Collections.sort(fractions, new Comparator<ETFractionInterface>() {
+            @Override
+            public int compare(ETFractionInterface f1, ETFractionInterface f2) {
+                return Integer.compare(f1.getAliquotNumber(), f2.getAliquotNumber());
+            }
+        });
+
+        fractionNames = new JLabel[projectSample.getFractions().size()];
+        seawaterModelChoices = new JComboBox[projectSample.getFractions().size()];
+        pctLoss = new JTextField[projectSample.getFractions().size()];
+        pctLossUnct = new JTextField[projectSample.getFractions().size()];
+
+        initFractionsDisplay();
+    }
+
+    private void initFractionsDisplay() {
+        setSize(DISPLAY_WIDTH + 25, 500);
+        setTitle("Assign Seawater Models to fractions");
+        setAlwaysOnTop(true);
+
+        JPanel modelsPanel = new JPanel(null);
+        modelsPanel.setSize(DISPLAY_WIDTH, 250);
+        modelsPanel.setBackground(new Color(240, 255, 255));
+
+        JLabel fractionHeaderLabel = new JLabel("Fraction");
+        fractionHeaderLabel.setBounds(FRACTION_COL_X, 15, 100, 25);
+        modelsPanel.add(fractionHeaderLabel);
+
+        JLabel seawaterHeaderLabel = new JLabel("Seawater Model");
+        seawaterHeaderLabel.setBounds(SEAWATER_COL_X, 15, 100, 25);
+        modelsPanel.add(seawaterHeaderLabel);
+
+        JLabel pctLossHeaderLabel = new JLabel("% Loss");
+        pctLossHeaderLabel.setBounds(PCTLOSS_COL_X, 15, 100, 25);
+        modelsPanel.add(pctLossHeaderLabel);
+
+        JTextField pctLossFillValue = new JTextField();
+        pctLossFillValue.setDocument(new DoubleDocument(pctLossFillValue, true));
+        pctLossFillValue.setHorizontalAlignment(JTextField.RIGHT);
+        pctLossFillValue.setText("2.5");
+        pctLossFillValue.setBounds(PCTLOSS_COL_X, 40, 50, 25);
+        modelsPanel.add(pctLossFillValue);
+
+        JButton pctLossFillButton = new ET_JButton("Fill");
+        pctLossFillButton.setBounds(PCTLOSS_COL_X, 65, 40, 25);
+        pctLossFillButton.addActionListener(new ActionListener() {
+            @Override
+            public void actionPerformed(ActionEvent e) {
+                double pctLossValue = (double) Double.parseDouble(pctLossFillValue.getText());
+                for (int i = 0; i < fractions.size(); i++) {
+                    ((UThFractionI) fractions.get(i)).getPctLoss().setValue(pctLossValue);
+                    pctLoss[i].setText(String.valueOf(pctLossValue));
+                }
+                parentFrame.updateReportTable();
+            }
+        });
+        modelsPanel.add(pctLossFillButton);
+
+        JLabel pctLossUnctHeaderLabel = new JLabel("1-sigma abs");
+        pctLossUnctHeaderLabel.setBounds(PCTLOSSUNCT_COL_X, 15, 100, 25);
+        modelsPanel.add(pctLossUnctHeaderLabel);
+
+        JTextField pctLossUnctFillValue = new JTextField();
+        pctLossUnctFillValue.setDocument(new DoubleDocument(pctLossUnctFillValue, true));
+        pctLossUnctFillValue.setHorizontalAlignment(JTextField.RIGHT);
+        pctLossUnctFillValue.setText("1.0");
+        pctLossUnctFillValue.setBounds(PCTLOSSUNCT_COL_X, 40, 50, 25);
+        modelsPanel.add(pctLossUnctFillValue);
+
+        List<SeaWaterInitialDelta234UTableModel> seawaterModelsList = projectSample.getSeaWaterInitialDelta234UTableModels();
+
+        int rowY = 0;
+        for (int i = 0; i < projectSample.getFractions().size(); i++) {
+            rowY = START_DATA_Y + i * 25;
+            fractionNames[i] = new JLabel(projectSample.getFractions().get(i).getFractionID());
+            fractionNames[i].setBounds(FRACTION_COL_X, rowY, 100, 25);
+            modelsPanel.add(fractionNames[i]);
+
+            seawaterModelChoices[i]
+                    = new JComboBox<>(
+                            seawaterModelsList.toArray(new SeaWaterInitialDelta234UTableModel[seawaterModelsList.size()]));
+            seawaterModelChoices[i].setBounds(SEAWATER_COL_X, rowY, 200, 25);
+            seawaterModelChoices[i].setSelectedItem(((UThFractionI) projectSample.getFractions().get(i)).getSeaWaterInitialDelta234UTableModel());
+            seawaterModelChoices[i].addActionListener(
+                    new SeawaterModelActionListener(((UThFractionI) projectSample.getFractions().get(i))));
+            modelsPanel.add(seawaterModelChoices[i]);
+
+            pctLoss[i] = new JTextField();
+            pctLoss[i].setDocument(new DoubleDocument(pctLoss[i], true));
+            pctLoss[i].setHorizontalAlignment(JTextField.RIGHT);
+            pctLoss[i].setText(String.valueOf(((UThFractionI) projectSample.getFractions().get(i)).getPctLoss().getValue().doubleValue()));
+            pctLoss[i].setBounds(PCTLOSS_COL_X, rowY, 50, 25);
+            pctLoss[i].addFocusListener(
+                    new PctLossFocusListener(((UThFractionI) projectSample.getFractions().get(i))));
+            modelsPanel.add(pctLoss[i]);
+
+            pctLossUnct[i] = new JTextField();
+            pctLossUnct[i].setDocument(new DoubleDocument(pctLossUnct[i], true));
+            pctLossUnct[i].setHorizontalAlignment(JTextField.RIGHT);
+            pctLossUnct[i].setText(String.valueOf(((UThFractionI) projectSample.getFractions().get(i)).getPctLoss().getOneSigmaAbs().doubleValue()));
+            pctLossUnct[i].setBounds(PCTLOSSUNCT_COL_X, rowY, 50, 25);
+            pctLossUnct[i].addFocusListener(
+                    new PctLossUnctFocusListener(((UThFractionI) projectSample.getFractions().get(i))));
+            modelsPanel.add(pctLossUnct[i]);
+
+        }
+
+        JButton okButton = new ET_JButton("OK");
+        okButton.setBounds(FRACTION_COL_X, rowY + 50, 500, 25);
+        okButton.addActionListener((ActionEvent e) -> {
+            parentFrame.updateReportTable();
+            dispose();
+        });
+        modelsPanel.add(okButton);
+
+        modelsPanel.setPreferredSize(new Dimension(DISPLAY_WIDTH, rowY + 100));
+        JScrollPane modelsScroll = new JScrollPane(modelsPanel);
+        modelsScroll.setSize(DISPLAY_WIDTH, rowY + 100);
+
+        setContentPane(modelsScroll);
+    }
+
+    class SeawaterModelActionListener implements ActionListener {
+
+        private UThFractionI fraction;
+
+        public SeawaterModelActionListener(UThFractionI fraction) {
+            this.fraction = fraction;
+        }
+
+        @Override
+        public void actionPerformed(ActionEvent e) {
+            SeaWaterInitialDelta234UTableModel model = (SeaWaterInitialDelta234UTableModel) ((JComboBox) e.getSource()).getSelectedItem();
+            fraction.setSeaWaterInitialDelta234UTableModel(model);
+            UThFractionReducer.reduceFraction((UThLegacyFractionI) fraction, false);
+            parentFrame.updateReportTable();
+        }
+    }
+
+    class PctLossFocusListener implements FocusListener {
+
+        private UThFractionI fraction;
+
+        public PctLossFocusListener(UThFractionI fraction) {
+            this.fraction = fraction;
+        }
+
+        @Override
+        public void focusGained(FocusEvent e) {
+            // do nothing
+        }
+
+        @Override
+        public void focusLost(FocusEvent e) {
+            double pctLossValue = (double) Double.parseDouble(((JTextField) e.getSource()).getText());
+            fraction.getPctLoss().setValue(pctLossValue);
+            UThFractionReducer.reduceFraction((UThLegacyFractionI) fraction, false);
+            parentFrame.updateReportTable();
+        }
+    }
+
+    class PctLossUnctFocusListener implements FocusListener {
+
+        private UThFractionI fraction;
+
+        public PctLossUnctFocusListener(UThFractionI fraction) {
+            this.fraction = fraction;
+        }
+
+        @Override
+        public void focusGained(FocusEvent e) {
+            // do nothing
+        }
+
+        @Override
+        public void focusLost(FocusEvent e) {
+            double pctLossUnct = (double) Double.parseDouble(((JTextField) e.getSource()).getText());
+            fraction.getPctLoss().setOneSigma(pctLossUnct);
+            UThFractionReducer.reduceFraction((UThLegacyFractionI) fraction, false);
+            parentFrame.updateReportTable();
+        }
+    }
+
+    /**
+     * This method is called from within the constructor to initialize the form.
+     * WARNING: Do NOT modify this code. The content of this method is always
+     * regenerated by the Form Editor.
+     */
+    @SuppressWarnings("unchecked")
+    // <editor-fold defaultstate="collapsed" desc="Generated Code">//GEN-BEGIN:initComponents
+    private void initComponents() {
+
+        setDefaultCloseOperation(javax.swing.WindowConstants.DISPOSE_ON_CLOSE);
+        setBackground(new java.awt.Color(204, 255, 255));
+        getContentPane().setLayout(null);
+
+        pack();
+    }// </editor-fold>//GEN-END:initComponents
+
+    /**
+     * @param args the command line arguments
+     */
+    public static void main(String args[]) {
+        /* Set the Nimbus look and feel */
+        //<editor-fold defaultstate="collapsed" desc=" Look and feel setting code (optional) ">
+        /* If Nimbus (introduced in Java SE 6) is not available, stay with the default look and feel.
+         * For details see http://download.oracle.com/javase/tutorial/uiswing/lookandfeel/plaf.html 
+         */
+        try {
+            for (javax.swing.UIManager.LookAndFeelInfo info : javax.swing.UIManager.getInstalledLookAndFeels()) {
+                if ("Nimbus".equals(info.getName())) {
+                    javax.swing.UIManager.setLookAndFeel(info.getClassName());
+                    break;
+                }
+            }
+        } catch (ClassNotFoundException ex) {
+            java.util.logging.Logger.getLogger(SeawaterModelAssignmentManager.class.getName()).log(java.util.logging.Level.SEVERE, null, ex);
+        } catch (InstantiationException ex) {
+            java.util.logging.Logger.getLogger(SeawaterModelAssignmentManager.class.getName()).log(java.util.logging.Level.SEVERE, null, ex);
+        } catch (IllegalAccessException ex) {
+            java.util.logging.Logger.getLogger(SeawaterModelAssignmentManager.class.getName()).log(java.util.logging.Level.SEVERE, null, ex);
+        } catch (javax.swing.UnsupportedLookAndFeelException ex) {
+            java.util.logging.Logger.getLogger(SeawaterModelAssignmentManager.class.getName()).log(java.util.logging.Level.SEVERE, null, ex);
+        }
+        //</editor-fold>
+        //</editor-fold>
+        //</editor-fold>
+        //</editor-fold>
+
+        /* Create and display the form */
+        java.awt.EventQueue.invokeLater(() -> {
+            try {
+
+                ProjectSample projectSample = new ProjectSample(
+                        SampleTypesEnum.PROJECT.getName(),
+                        SampleTypesEnum.COMPILATION.getName(),
+                        USERIES_CARB.getName(),
+                        ReduxConstants.ANALYSIS_PURPOSE.NONE,
+                        true,
+                        USERIES_CARB.getIsotypeSystem(),
+                        USERIES_CARB.getDefaultReportSpecsType());
+
+                UThLegacyFractionI myFraction = new UThLegacyFraction();
+                myFraction.setFractionID("TEST Fraction");
+                projectSample.addFraction(myFraction);
+
+                SeawaterModelAssignmentManager test = new SeawaterModelAssignmentManager(null, true, projectSample);
+                test.setVisible(true);
+            } catch (BadLabDataException badLabDataException) {
+            }
+        });
+    }
+
+    // Variables declaration - do not modify//GEN-BEGIN:variables
+    // End of variables declaration//GEN-END:variables
+}

--- a/src/main/java/org/earthtime/plots/evolution/seaWater/SeawaterModelAssignmentManager.java
+++ b/src/main/java/org/earthtime/plots/evolution/seaWater/SeawaterModelAssignmentManager.java
@@ -74,11 +74,12 @@ public class SeawaterModelAssignmentManager extends DialogEditor {
     private static final int SEAWATER_COL_X = 150;
     private static final int PCTLOSS_COL_X = 400;
     private static final int PCTLOSSUNCT_COL_X = 500;
-    private static final int START_DATA_Y = 120;
+    private static final int START_DATA_Y = 100;
     private static int DISPLAY_WIDTH = 600;
 
     private Vector<ETFractionInterface> fractions;
     private JLabel[] fractionNames;
+    private JComboBox<SeaWaterInitialDelta234UTableModel> seawaterModelChoicesMaster;
     private JComboBox<SeaWaterInitialDelta234UTableModel>[] seawaterModelChoices;
     private JTextField[] pctLoss;
     private JTextField[] pctLossUnct;
@@ -132,6 +133,32 @@ public class SeawaterModelAssignmentManager extends DialogEditor {
         seawaterHeaderLabel.setBounds(SEAWATER_COL_X, 15, 100, 25);
         modelsPanel.add(seawaterHeaderLabel);
 
+        List<SeaWaterInitialDelta234UTableModel> seawaterModelsList = projectSample.getSeaWaterInitialDelta234UTableModels();
+
+        seawaterModelChoicesMaster
+                = new JComboBox<>(
+                        seawaterModelsList.toArray(new SeaWaterInitialDelta234UTableModel[seawaterModelsList.size()]));
+        seawaterModelChoicesMaster.setBounds(SEAWATER_COL_X, 40, 200, 25);
+        seawaterModelChoicesMaster.setSelectedIndex(0);
+        modelsPanel.add(seawaterModelChoicesMaster);
+
+        JButton seaWaterFillButton = new ET_JButton("Fill");
+        seaWaterFillButton.setBounds(SEAWATER_COL_X, 65, 200, 25);
+        seaWaterFillButton.addActionListener(new ActionListener() {
+            @Override
+            public void actionPerformed(ActionEvent e) {
+                SeaWaterInitialDelta234UTableModel seaWaterInitialDelta234UTableModel 
+                        = (SeaWaterInitialDelta234UTableModel)seawaterModelChoicesMaster.getSelectedItem();
+                for (int i = 0; i < fractions.size(); i++) {
+                    ((UThFractionI) fractions.get(i)).setSeaWaterInitialDelta234UTableModel(seaWaterInitialDelta234UTableModel);
+                    seawaterModelChoices[i].setSelectedItem(seaWaterInitialDelta234UTableModel);
+                    UThFractionReducer.reduceFraction((UThLegacyFractionI) fractions.get(i), false);
+                }
+                parentFrame.updateReportTable();
+            }
+        });
+        modelsPanel.add(seaWaterFillButton);
+
         JLabel pctLossHeaderLabel = new JLabel("% Loss");
         pctLossHeaderLabel.setBounds(PCTLOSS_COL_X, 15, 100, 25);
         modelsPanel.add(pctLossHeaderLabel);
@@ -144,7 +171,7 @@ public class SeawaterModelAssignmentManager extends DialogEditor {
         modelsPanel.add(pctLossFillValue);
 
         JButton pctLossFillButton = new ET_JButton("Fill");
-        pctLossFillButton.setBounds(PCTLOSS_COL_X, 65, 40, 25);
+        pctLossFillButton.setBounds(PCTLOSS_COL_X, 65, 50, 25);
         pctLossFillButton.addActionListener(new ActionListener() {
             @Override
             public void actionPerformed(ActionEvent e) {
@@ -152,6 +179,7 @@ public class SeawaterModelAssignmentManager extends DialogEditor {
                 for (int i = 0; i < fractions.size(); i++) {
                     ((UThFractionI) fractions.get(i)).getPctLoss().setValue(pctLossValue);
                     pctLoss[i].setText(String.valueOf(pctLossValue));
+                    UThFractionReducer.reduceFraction((UThLegacyFractionI) fractions.get(i), false);
                 }
                 parentFrame.updateReportTable();
             }
@@ -169,7 +197,21 @@ public class SeawaterModelAssignmentManager extends DialogEditor {
         pctLossUnctFillValue.setBounds(PCTLOSSUNCT_COL_X, 40, 50, 25);
         modelsPanel.add(pctLossUnctFillValue);
 
-        List<SeaWaterInitialDelta234UTableModel> seawaterModelsList = projectSample.getSeaWaterInitialDelta234UTableModels();
+        JButton pctLossUnctFillButton = new ET_JButton("Fill");
+        pctLossUnctFillButton.setBounds(PCTLOSSUNCT_COL_X, 65, 50, 25);
+        pctLossUnctFillButton.addActionListener(new ActionListener() {
+            @Override
+            public void actionPerformed(ActionEvent e) {
+                double pctLossUnctValue = (double) Double.parseDouble(pctLossUnctFillValue.getText());
+                for (int i = 0; i < fractions.size(); i++) {
+                    ((UThFractionI) fractions.get(i)).getPctLoss().setOneSigma(pctLossUnctValue);
+                    pctLossUnct[i].setText(String.valueOf(pctLossUnctValue));
+                    UThFractionReducer.reduceFraction((UThLegacyFractionI) fractions.get(i), false);
+                }
+                parentFrame.updateReportTable();
+            }
+        });
+        modelsPanel.add(pctLossUnctFillButton);
 
         int rowY = 0;
         for (int i = 0; i < projectSample.getFractions().size(); i++) {
@@ -208,7 +250,7 @@ public class SeawaterModelAssignmentManager extends DialogEditor {
         }
 
         JButton okButton = new ET_JButton("OK");
-        okButton.setBounds(FRACTION_COL_X, rowY + 50, 500, 25);
+        okButton.setBounds(FRACTION_COL_X, rowY + 50, 550, 25);
         okButton.addActionListener((ActionEvent e) -> {
             parentFrame.updateReportTable();
             dispose();

--- a/src/main/java/org/earthtime/plots/isochrons/IsochronsSelectorDialog.form
+++ b/src/main/java/org/earthtime/plots/isochrons/IsochronsSelectorDialog.form
@@ -3,7 +3,7 @@
 <Form version="1.9" maxVersion="1.9" type="org.netbeans.modules.form.forminfo.JDialogFormInfo">
   <Properties>
     <Property name="defaultCloseOperation" type="int" value="2"/>
-    <Property name="title" type="java.lang.String" value="Available Sample Date Interpretation Models"/>
+    <Property name="title" type="java.lang.String" value="Available Isochrons"/>
     <Property name="alwaysOnTop" type="boolean" value="true"/>
     <Property name="background" type="java.awt.Color" editor="org.netbeans.beaninfo.editors.ColorEditor">
       <Color blue="ce" green="ec" red="f5" type="rgb"/>

--- a/src/main/java/org/earthtime/plots/isochrons/IsochronsSelectorDialog.java
+++ b/src/main/java/org/earthtime/plots/isochrons/IsochronsSelectorDialog.java
@@ -141,7 +141,7 @@ public class IsochronsSelectorDialog extends DialogEditor {
         displayedList = new javax.swing.JList<>();
 
         setDefaultCloseOperation(javax.swing.WindowConstants.DISPOSE_ON_CLOSE);
-        setTitle("Available Sample Date Interpretation Models");
+        setTitle("Available Isochrons");
         setAlwaysOnTop(true);
         setBackground(new java.awt.Color(245, 236, 206));
         setForeground(java.awt.Color.white);

--- a/src/main/java/org/earthtime/projects/ProjectSample.java
+++ b/src/main/java/org/earthtime/projects/ProjectSample.java
@@ -676,7 +676,9 @@ public class ProjectSample implements//
                 SeaWaterInitialDelta234UTableModel swm = ReduxLabData.getInstance().getASeaWaterModel(entry.getKey());
                 entry.getValue().setSeaWaterInitialDelta234UTableModel(swm);
                 models.add(entry.getValue());
-                seaWaterInitialDelta234UTableModels.add(swm);
+                if (!seaWaterInitialDelta234UTableModels.contains(swm)) {
+                    seaWaterInitialDelta234UTableModels.add(swm);
+                }
             } catch (BadLabDataException badLabDataException) {
                 badModels.add(entry.getKey());
             }

--- a/src/main/java/org/earthtime/projects/ProjectSample.java
+++ b/src/main/java/org/earthtime/projects/ProjectSample.java
@@ -181,16 +181,26 @@ public class ProjectSample implements//
         return retVal;
     }
 
+    /**
+     *
+     * @param aliquotNumber the value of aliquotNumber
+     * @param aliquotName the value of aliquotName
+     * @param physicalConstants the value of physicalConstants
+     * @param compiled the value of compiled
+     * @param mySESARSampleMetadata the value of mySESARSampleMetadata
+     * @param sampleAnalysisType the value of sampleAnalysisType
+     */
     @Override
     public AliquotInterface generateDefaultAliquot(//
-            int aliquotNumber, String aliquotName, AbstractRatiosDataModel physicalConstants, boolean compiled, SESARSampleMetadata mySESARSampleMetadata) {
+            int aliquotNumber, String aliquotName, AbstractRatiosDataModel physicalConstants, boolean compiled, SESARSampleMetadata mySESARSampleMetadata, String sampleAnalysisType) {
         throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
     }
-
-    @Override
-    public AliquotInterface generateDefaultAliquot() {
-        throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
-    }
+    //
+    
+//    @Override
+//    public AliquotInterface generateDefaultAliquot() {
+//        throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+//    }
 
     @Override
     public void setUpSample() {

--- a/src/main/java/org/earthtime/projects/ProjectSample.java
+++ b/src/main/java/org/earthtime/projects/ProjectSample.java
@@ -620,6 +620,7 @@ public class ProjectSample implements//
     /**
      * @return the seaWaterInitialDelta234UTableModel
      */
+    @Override
     public List<SeaWaterInitialDelta234UTableModel> getSeaWaterInitialDelta234UTableModels() {
         if (seaWaterInitialDelta234UTableModels == null) {
             this.seaWaterInitialDelta234UTableModels = ReduxLabData.getInstance().getSeaWaterModels();

--- a/src/main/java/org/earthtime/projects/projectImporters/UThProjectImporters/ProjectOfLegacySamplesImporterFromTSVFileUseries_Ign.java
+++ b/src/main/java/org/earthtime/projects/projectImporters/UThProjectImporters/ProjectOfLegacySamplesImporterFromTSVFileUseries_Ign.java
@@ -290,7 +290,7 @@ public class ProjectOfLegacySamplesImporterFromTSVFileUseries_Ign extends Abstra
                         ((UThFraction) myFraction).setR230Th_238Ufc_referenceMaterialName("");
                         ((UThFraction) myFraction).setR234U_238Ufc_referenceMaterialName("");
 
-                        UThFractionReducer.calculateMeasuredAtomRatiosFromLegacyActivityRatios(myFraction);
+                        UThFractionReducer.calculateMeasuredAtomRatiosFromLegacyActivityRatios(myFraction, true);
 
                     }
                 }
@@ -314,7 +314,10 @@ public class ProjectOfLegacySamplesImporterFromTSVFileUseries_Ign extends Abstra
         AliquotInterface existingSuperSampleAliquot
                 = superSample.getAliquotByNameForProjectSuperSample(currentSample.getSampleName() + "::" + currentAliquot.getAliquotName());
         if (existingSuperSampleAliquot == null) {
-            SampleInterface.copyAliquotIntoSample(superSample, currentSample.getAliquotByNameForProjectSuperSample(currentAliquot.getAliquotName()), new UThReduxAliquot());
+            SampleInterface.copyAliquotIntoSample(
+                    superSample, 
+                    currentSample.getAliquotByNameForProjectSuperSample(currentAliquot.getAliquotName()), 
+                    new UThReduxAliquot(currentSample.getSampleAnalysisType()));
         } else {
             for (ETFractionInterface fraction : ((ReduxAliquotInterface) currentAliquot).getAliquotFractions()) {
                 if (!((ReduxAliquotInterface) existingSuperSampleAliquot).getAliquotFractions().contains(fraction)) {

--- a/src/main/java/org/earthtime/reduxLabData/ReduxLabData.java
+++ b/src/main/java/org/earthtime/reduxLabData/ReduxLabData.java
@@ -1424,7 +1424,10 @@ public final class ReduxLabData implements Serializable {
         if (seaWaterModels.isEmpty()) {
             addSeaWaterModel(getDefaultLabSeaWaterModel());
         }
-        return seaWaterModels;
+
+        ArrayList<SeaWaterInitialDelta234UTableModel> retVal = new ArrayList<>();
+        retVal.addAll(seaWaterModels);
+        return retVal;
     }
 
     /**
@@ -1499,7 +1502,7 @@ public final class ReduxLabData implements Serializable {
         if (!seaWaterModels.contains(seaWaterUModel)) {
             seaWaterModels.add(seaWaterUModel);
         }
-        Collections.sort(getSeaWaterModels());
+        Collections.sort(seaWaterModels);
     }
 
     /**

--- a/src/main/java/org/earthtime/reportViews/ReportAliquotFractionsView.java
+++ b/src/main/java/org/earthtime/reportViews/ReportAliquotFractionsView.java
@@ -80,6 +80,7 @@ import org.earthtime.aliquots.ReduxAliquotInterface;
 import org.earthtime.beans.ET_JButton;
 import org.earthtime.exceptions.ETException;
 import org.earthtime.fractions.ETFractionInterface;
+import org.earthtime.plots.evolution.seaWater.SeawaterModelAssignmentManager;
 import org.earthtime.samples.SampleInterface;
 import org.earthtime.utilities.FileHelper;
 import org.w3c.dom.DOMImplementation;
@@ -491,14 +492,16 @@ public class ReportAliquotFractionsView extends JLayeredPane implements ReportUp
             } else {
                 showAliquotBars = true;
             }
-            
+
             // July 2019 add button upper left to access seawater assignment in support of USeries
             showSeawaterAssignmentsButton = new ET_JButton("Assign SeawaterModels");
             showSeawaterAssignmentsButton.setFont(ReduxConstants.sansSerif_10_Bold);
             showSeawaterAssignmentsButton.addActionListener(new ActionListener() {
                 @Override
                 public void actionPerformed(ActionEvent e) {
-                    //parentFrame.loadAndShowReportTableData("");
+                    SeawaterModelAssignmentManager seawaterModelAssignmentManager 
+                            = new SeawaterModelAssignmentManager(parentFrame, true, sample);
+                    seawaterModelAssignmentManager.setVisible(true);
                 }
             });
             if (reportFractions[1][0].contains("UTh")) {
@@ -506,7 +509,6 @@ public class ReportAliquotFractionsView extends JLayeredPane implements ReportUp
             } else {
                 showAliquotBars = true;
             }
-            
 
             reSizeSortButtons();
 

--- a/src/main/java/org/earthtime/reportViews/ReportAliquotFractionsView.java
+++ b/src/main/java/org/earthtime/reportViews/ReportAliquotFractionsView.java
@@ -78,6 +78,7 @@ import org.earthtime.UPb_Redux.utilities.comparators.IntuitiveStringComparator;
 import org.earthtime.aliquots.AliquotInterface;
 import org.earthtime.aliquots.ReduxAliquotInterface;
 import org.earthtime.beans.ET_JButton;
+import org.earthtime.dataDictionaries.SampleAnalysisTypesEnum;
 import org.earthtime.exceptions.ETException;
 import org.earthtime.fractions.ETFractionInterface;
 import org.earthtime.plots.evolution.seaWater.SeawaterModelAssignmentManager;
@@ -373,19 +374,21 @@ public class ReportAliquotFractionsView extends JLayeredPane implements ReportUp
 
     /**
      *
+     * @param sampleAnalysisType the value of sampleAnalysisType
      */
-    public void refreshPanel() {
-        preparePanel();
+    public void refreshPanel(String sampleAnalysisType) {
+        preparePanel(sampleAnalysisType);
         reSizeScrollPanes();
     }
 
     /**
+     * @param sampleAnalysisType
      *
      */
-    public void preparePanel() {
+    public void preparePanel(String sampleAnalysisType) {
 
-        int saveVerticalScrollPosition = 0;
-        int saveHorizontalScrollPosition = 0;
+        int saveVerticalScrollPosition;
+        int saveHorizontalScrollPosition;
         try {
             saveVerticalScrollPosition = reportBodyScrollPane.getVerticalScrollBar().getValue();
             saveHorizontalScrollPosition = reportBodyScrollPane.getHorizontalScrollBar().getValue();
@@ -499,16 +502,16 @@ public class ReportAliquotFractionsView extends JLayeredPane implements ReportUp
             showSeawaterAssignmentsButton.addActionListener(new ActionListener() {
                 @Override
                 public void actionPerformed(ActionEvent e) {
-                    SeawaterModelAssignmentManager seawaterModelAssignmentManager 
+                    SeawaterModelAssignmentManager seawaterModelAssignmentManager
                             = new SeawaterModelAssignmentManager(parentFrame, true, sample);
                     seawaterModelAssignmentManager.setVisible(true);
                 }
             });
             if (reportFractions[1][0].contains("UTh")) {
-                upperLeftCorner.add(showSeawaterAssignmentsButton, JLayeredPane.PALETTE_LAYER);
-            } else {
-                showAliquotBars = true;
-            }
+                if (sampleAnalysisType.compareToIgnoreCase(SampleAnalysisTypesEnum.USERIES_CARB.getName()) == 0) { 
+                    upperLeftCorner.add(showSeawaterAssignmentsButton, JLayeredPane.PALETTE_LAYER);
+                }
+            } 
 
             reSizeSortButtons();
 

--- a/src/main/java/org/earthtime/reportViews/ReportAliquotFractionsView.java
+++ b/src/main/java/org/earthtime/reportViews/ReportAliquotFractionsView.java
@@ -112,6 +112,7 @@ public class ReportAliquotFractionsView extends JLayeredPane implements ReportUp
     private JButton sortFractionsButton;
     private JButton toggleMeasuredRatiosButton;
     private JButton toggleAliquotBarsButton;
+    private JButton showSeawaterAssignmentsButton;
     public static boolean showAliquotBars = false;
     private ArrayList<JButton> sortButtons;
     private static TableRowObject lastAquiredTableRowObject;
@@ -325,6 +326,7 @@ public class ReportAliquotFractionsView extends JLayeredPane implements ReportUp
             sortFractionsButton.setBounds(1, DATATABLE_TOP_HEIGHT - lineHeight - 1, fractionColumnWidth - 3, lineHeight - 3);
             toggleMeasuredRatiosButton.setBounds(1, 2, fractionColumnWidth - 3, lineHeight - 3);
             toggleAliquotBarsButton.setBounds(1, 2, fractionColumnWidth - 3, lineHeight - 3);
+            showSeawaterAssignmentsButton.setBounds(1, 2 + lineHeight - 3, fractionColumnWidth - 3, lineHeight - 3);
 
             int drawnWidth = 3;
             // oct 2016 added -1 for filtering cell added
@@ -489,6 +491,22 @@ public class ReportAliquotFractionsView extends JLayeredPane implements ReportUp
             } else {
                 showAliquotBars = true;
             }
+            
+            // July 2019 add button upper left to access seawater assignment in support of USeries
+            showSeawaterAssignmentsButton = new ET_JButton("Assign SeawaterModels");
+            showSeawaterAssignmentsButton.setFont(ReduxConstants.sansSerif_10_Bold);
+            showSeawaterAssignmentsButton.addActionListener(new ActionListener() {
+                @Override
+                public void actionPerformed(ActionEvent e) {
+                    //parentFrame.loadAndShowReportTableData("");
+                }
+            });
+            if (reportFractions[1][0].contains("UTh")) {
+                upperLeftCorner.add(showSeawaterAssignmentsButton, JLayeredPane.PALETTE_LAYER);
+            } else {
+                showAliquotBars = true;
+            }
+            
 
             reSizeSortButtons();
 

--- a/src/main/java/org/earthtime/reportViews/TabbedReportViews.java
+++ b/src/main/java/org/earthtime/reportViews/TabbedReportViews.java
@@ -111,10 +111,10 @@ public class TabbedReportViews extends JTabbedPane {
      */
     public void refreshTabs() {
         if (sample != null) {
-            ((ReportAliquotFractionsView) viewTabulatedAliquotActiveFractions).refreshPanel();
+            ((ReportAliquotFractionsView) viewTabulatedAliquotActiveFractions).refreshPanel(sample.getSampleAnalysisType());
             this.setTitleAt(0, "Active Fractions (" + Integer.toString(((ReportAliquotFractionsView) viewTabulatedAliquotActiveFractions).getReportFractions().length - ReportSettingsInterface.FRACTION_DATA_START_ROW) + ")");
 
-            ((ReportAliquotFractionsView) viewTabulatedAliquotRejectedFractions).refreshPanel();
+            ((ReportAliquotFractionsView) viewTabulatedAliquotRejectedFractions).refreshPanel(sample.getSampleAnalysisType());
             this.setTitleAt(1, "Rejected Fractions (" + Integer.toString(((ReportAliquotFractionsView) viewTabulatedAliquotRejectedFractions).getReportFractions().length - ReportSettingsInterface.FRACTION_DATA_START_ROW) + ")");
         }
     }

--- a/src/main/java/org/earthtime/reports/ReportSettingsInterface.java
+++ b/src/main/java/org/earthtime/reports/ReportSettingsInterface.java
@@ -1057,16 +1057,28 @@ public interface ReportSettingsInterface extends Comparable<ReportSettingsInterf
         }
 
         // walk the column and trim the strings
+//        for (int f = FRACTION_DATA_START_ROW; f
+//                < retVal.length; f++) {
+//            if (retVal[f][columnCount] != null) {
+//                retVal[f][columnCount] = retVal[f][columnCount].substring(minLeading);
+//                retVal[f][columnCount]
+//                        = retVal[f][columnCount].substring(//
+//                                0, retVal[f][columnCount].length() - minTrailing);
+//
+//            }
+//
+//        }
+        // july 2019 from Squid
         for (int f = FRACTION_DATA_START_ROW; f
                 < retVal.length; f++) {
-            if (retVal[f][columnCount] != null) {
+            if ((retVal[f][columnCount] != null) && (retVal[f][columnCount].length() > 0)) {
                 retVal[f][columnCount] = retVal[f][columnCount].substring(minLeading);
-                retVal[f][columnCount]
-                        = retVal[f][columnCount].substring(//
-                                0, retVal[f][columnCount].length() - minTrailing);
-
+                if (retVal[f][columnCount].length() >= minTrailing) {
+                    retVal[f][columnCount]
+                            = retVal[f][columnCount].substring(//
+                                    0, retVal[f][columnCount].length() - minTrailing);
+                }
             }
-
         }
 
         // walk the column and padleft to meet width of displayname the strings

--- a/src/main/java/org/earthtime/samples/ETSample.java
+++ b/src/main/java/org/earthtime/samples/ETSample.java
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.earthtime.samples;
 
 import org.earthtime.metadata.SampleMetaData;
@@ -23,6 +22,7 @@ import org.earthtime.metadata.SampleMetaData;
  * @author James F. Bowring <bowring at gmail.com>
  */
 public abstract class ETSample {
+
     protected SampleMetaData metaData;
 
 }

--- a/src/main/java/org/earthtime/samples/SampleInterface.java
+++ b/src/main/java/org/earthtime/samples/SampleInterface.java
@@ -2123,6 +2123,7 @@ public interface SampleInterface {
     public List<SeaWaterInitialDelta234UTableModel> getSeaWaterInitialDelta234UTableModels();
 
     /**
+     * @param seaWaterInitialDelta234UTableModels
      * @param seaWaterInitialDelta234UTableModel the
      * seaWaterInitialDelta234UTableModel to set
      */

--- a/src/main/java/org/earthtime/samples/SampleInterface.java
+++ b/src/main/java/org/earthtime/samples/SampleInterface.java
@@ -31,6 +31,7 @@ import java.util.Vector;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.swing.JFrame;
+import javax.swing.JOptionPane;
 import javax.swing.filechooser.FileFilter;
 import org.earthtime.UPb_Redux.ReduxConstants;
 import org.earthtime.UPb_Redux.aliquots.UPbReduxAliquot;
@@ -1013,6 +1014,11 @@ public interface SampleInterface {
                     ((UPbSampleInterface) sample).processXMLFractionFile(returnFile[i], aliquotNumber, true, doValidate);
                     successCount++;
                 } catch (ETException ex) {
+                    JOptionPane.showMessageDialog(
+                            null,
+                            ex.getMessage(),
+                            "ET Redux Warning",
+                            JOptionPane.WARNING_MESSAGE);
                 }
             }
             // return folder for persistent state 

--- a/src/main/java/org/earthtime/samples/SampleInterface.java
+++ b/src/main/java/org/earthtime/samples/SampleInterface.java
@@ -649,14 +649,26 @@ public interface SampleInterface {
         }
     }
 
+    /**
+     *
+     * @param aliquotNumber the value of aliquotNumber
+     * @param aliquotName the value of aliquotName
+     * @param physicalConstants the value of physicalConstants
+     * @param compiled the value of compiled
+     * @param mySESARSampleMetadata the value of mySESARSampleMetadata
+     * @param sampleAnalysisType the value of sampleAnalysisType
+     * @return 
+     */
     public AliquotInterface generateDefaultAliquot(//
-            int aliquotNumber,
-            String aliquotName,
+            int aliquotNumber, 
+            String aliquotName, 
             AbstractRatiosDataModel physicalConstants,
-            boolean compiled,
-            SESARSampleMetadata mySESARSampleMetadata);
+            boolean compiled, 
+            SESARSampleMetadata mySESARSampleMetadata,
+            String sampleAnalysisType);
+    //
 
-    public AliquotInterface generateDefaultAliquot();
+////    public AliquotInterface generateDefaultAliquot();
 
     /**
      * adds an <code>Aliquot</code> to <code>aliquots</code>. It is created with
@@ -683,7 +695,8 @@ public interface SampleInterface {
                             "Aliquot-" + Integer.toString(getAliquots().size() + 1),
                             getPhysicalConstantsModel(),
                             isAnalyzed(),
-                            getMySESARSampleMetadata());
+                            getMySESARSampleMetadata(), 
+                            getSampleAnalysisType());
 
 //                    = new UPbReduxAliquot(
 //                            getAliquots().size() + 1,

--- a/src/test/java/org/earthtime/UPb_Redux/valueModels/SampleDateModelTest.java
+++ b/src/test/java/org/earthtime/UPb_Redux/valueModels/SampleDateModelTest.java
@@ -18,7 +18,6 @@
  *
  *
  */
-
 package org.earthtime.UPb_Redux.valueModels;
 
 import java.io.File;
@@ -40,70 +39,54 @@ import org.junit.Test;
  * @author patrickbrewer
  */
 public class SampleDateModelTest {
-    
-    
-    
+
     /////////////////////////
     ////Constructor Tests////
     /////////////////////////     
-    
-    
+    /**
+     * Test of SampleDateModel() method, of class SampleDateModel.
+     */
+    @Test
+    public void test_constructor_0() {
+        System.out.println("Testing SampleDateModel's SampleDateModel()");
+        //Tests if values are correct
+        SampleDateModel hi = new SampleDateModel();
+        assertEquals("NONE", hi.name);
+        assertEquals("", hi.getMethodName());
+        assertEquals("", hi.getDateName());
+        assertEquals(new BigDecimal("0"), hi.value);
+        assertEquals("NONE", hi.uncertaintyType);
+        assertEquals(new BigDecimal("0"), hi.oneSigma);
 
-    
-    
-    
-     /**
+    }
+
+    /**
      * Test of SampleDateModel() method, of class SampleDateModel.
      */
     @Test
-    public void test_constructor_0(){
-	System.out.println("Testing SampleDateModel's SampleDateModel()");
+    public void test_constructor_1() {
+        System.out.println("Testing SampleDateModel's SampleDateModel(String name,String methodName,String dateName,BigDecimal value,String uncertaintyType,BigDecimal oneSigma)");
         //Tests if values are correct
-        SampleDateModel hi=new SampleDateModel();
-        assertEquals("NONE",hi.name);
-        assertEquals("",hi.getMethodName());
-        assertEquals("",hi.getDateName());
-        assertEquals(new BigDecimal("0"),hi.value);
-        assertEquals("NONE",hi.uncertaintyType);
-        assertEquals(new BigDecimal("0"),hi.oneSigma);
-        
-        }          
-    
-    
-     /**
-     * Test of SampleDateModel() method, of class SampleDateModel.
-     */
-    @Test
-    public void test_constructor_1(){
-	System.out.println("Testing SampleDateModel's SampleDateModel(String name,String methodName,String dateName,BigDecimal value,String uncertaintyType,BigDecimal oneSigma)");
-        //Tests if values are correct
-        SampleDateModel hi=new SampleDateModel("hello","there","silly",new BigDecimal("430"),"ABS",new BigDecimal("51"));
-        assertEquals("hello",hi.name);
-        assertEquals("there",hi.getMethodName());
-        assertEquals("silly",hi.getDateName());
-        assertEquals(new BigDecimal("430"),hi.value);
-        assertEquals("ABS",hi.uncertaintyType);
-        assertEquals(new BigDecimal("51"),hi.oneSigma);        
-        }                
-        
-    
-    
-    
+        SampleDateModel hi = new SampleDateModel("hello", "there", "silly", new BigDecimal("430"), "ABS", new BigDecimal("51"));
+        assertEquals("hello", hi.name);
+        assertEquals("there", hi.getMethodName());
+        assertEquals("silly", hi.getDateName());
+        assertEquals(new BigDecimal("430"), hi.value);
+        assertEquals("ABS", hi.uncertaintyType);
+        assertEquals(new BigDecimal("51"), hi.oneSigma);
+    }
+
     ////////////////////
     ////Method Tests////
     ////////////////////         
-    
-    
-    
-    
     /**
      * Test of copy method, of class SampleDateModel.
-    */ 
+     */
     @Test
     public void test_Copy() {
         System.out.println("Testing SampleDateModel's copy()");
-        SampleDateModel instance=new SampleDateModel("hello","there","silly",new BigDecimal("430"),"ABS",new BigDecimal("51"));
-        
+        SampleDateModel instance = new SampleDateModel("hello", "there", "silly", new BigDecimal("430"), "ABS", new BigDecimal("51"));
+
         instance.setMeanSquaredWeightedDeviation(new BigDecimal("51238"));
         instance.setInternalTwoSigmaUnct(new BigDecimal("51238"));
         instance.setInternalTwoSigmaUnctWithTracerCalibrationUnct(new BigDecimal("51238"));
@@ -111,65 +94,64 @@ public class SampleDateModelTest {
         instance.setExplanation("ave!");
         instance.setComment("ave!");
         instance.setPreferred(true);
-        
+
         SampleDateModel result = instance.copy();
-        
-        assertEquals("hello",result.name);
-        assertEquals("there",result.getMethodName());
-        assertEquals("silly",result.getDateName());
-        assertEquals(new BigDecimal("430"),result.value);
-        assertEquals("ABS",result.uncertaintyType);
-        assertEquals(new BigDecimal("51"),result.oneSigma); 
-        assertEquals(new BigDecimal("51238"),result.getMeanSquaredWeightedDeviation()); 
-        assertEquals(new BigDecimal("51238"),result.getInternalTwoSigmaUnct()); 
-        assertEquals(new BigDecimal("51238"),result.getInternalTwoSigmaUnctWithTracerCalibrationUnct()); 
-        assertEquals(new BigDecimal("51238"),result.getInternalTwoSigmaUnctWithTracerCalibrationAndDecayConstantUnct()); 
-        assertEquals("ave!",result.getExplanation());
-        assertEquals("ave!",result.getComment());
-        assertEquals(true,result.isPreferred());        
-        
+
+        assertEquals("hello", result.name);
+        assertEquals("there", result.getMethodName());
+        assertEquals("silly", result.getDateName());
+        assertEquals(new BigDecimal("430"), result.value);
+        assertEquals("ABS", result.uncertaintyType);
+        assertEquals(new BigDecimal("51"), result.oneSigma);
+        assertEquals(new BigDecimal("51238"), result.getMeanSquaredWeightedDeviation());
+        assertEquals(new BigDecimal("51238"), result.getInternalTwoSigmaUnct());
+        assertEquals(new BigDecimal("51238"), result.getInternalTwoSigmaUnctWithTracerCalibrationUnct());
+        assertEquals(new BigDecimal("51238"), result.getInternalTwoSigmaUnctWithTracerCalibrationAndDecayConstantUnct());
+        assertEquals("ave!", result.getExplanation());
+        assertEquals("ave!", result.getComment());
+        assertEquals(true, result.isPreferred());
+
     }
 
-        /**
+    /**
      * Test of compareTo method, of class SampleDateModel.
      */
     @Test
     public void test_CompareTo() {
         System.out.println("Testing SampleDateModel's compareTo(SampleDateModel comparedTo)");
-        SampleDateModel instance0=new SampleDateModel("hello","there","silly",new BigDecimal("430"),"ABS",new BigDecimal("51"));
+        SampleDateModel instance0 = new SampleDateModel("hello", "there", "silly", new BigDecimal("430"), "ABS", new BigDecimal("51"));
         SampleDateModel instance = new SampleDateModel();
-        SampleDateModel instance2=new SampleDateModel("hello","there","silly",new BigDecimal("430"),"ABS",new BigDecimal("51"));
-        
+        SampleDateModel instance2 = new SampleDateModel("hello", "there", "silly", new BigDecimal("430"), "ABS", new BigDecimal("51"));
+
         int result = instance.compareTo(instance0);
-        assertEquals(6,result);
+        assertEquals(6, result);
 
         result = instance2.compareTo(instance0);
-        assertEquals(0,result);
-        
+        assertEquals(0, result);
+
         result = instance2.compareTo(instance);
-        assertEquals(-6,result);
-        
+        assertEquals(-6, result);
+
     }
 
-        /**
+    /**
      * Test of equals method, of class SampleDateModel.
-     */ 
+     */
     @Test
     public void test_Equals() {
         System.out.println("Testing SampleDateModel's equals(SampleDateModel equals)");
-        SampleDateModel instance0=new SampleDateModel("hello","there","silly",new BigDecimal("430"),"ABS",new BigDecimal("51"));
+        SampleDateModel instance0 = new SampleDateModel("hello", "there", "silly", new BigDecimal("430"), "ABS", new BigDecimal("51"));
         SampleDateModel instance = new SampleDateModel();
-        SampleDateModel instance2=new SampleDateModel("hello","there","silly",new BigDecimal("430"),"ABS",new BigDecimal("51"));
+        SampleDateModel instance2 = new SampleDateModel("hello", "there", "silly", new BigDecimal("430"), "ABS", new BigDecimal("51"));
 
-        
         boolean result = instance.equals(instance0);
         assertEquals(false, result);
 
-        result=instance0.equals(instance2);
-        assertEquals(true,result);
+        result = instance0.equals(instance2);
+        assertEquals(true, result);
     }
 
-        /**
+    /**
      * Test of hashCode method, of class SampleDateModel.
      */
     @Test
@@ -179,30 +161,28 @@ public class SampleDateModelTest {
         int result = instance.hashCode();
         assertEquals(0, result);
 
-        
     }
 
-        /**
+    /**
      * Test of toString method, of class SampleDateModel.
      */
     @Test
     public void test_ToString() {
         System.out.println("Testing SampleDateModel's toString()");
         SampleDateModel instance = new SampleDateModel();
-        SampleDateModel instance2=new SampleDateModel("hello","there","silly",new BigDecimal("430"),"ABS",new BigDecimal("51"));
-        
+        SampleDateModel instance2 = new SampleDateModel("hello", "there", "silly", new BigDecimal("430"), "ABS", new BigDecimal("51"));
+
         String expResult = "NONE";
         String result = instance.toString();
-        
-        
+
         assertEquals(expResult, result);
         result = instance2.toString();
-        
-        expResult="hello";
+
+        expResult = "hello";
         assertEquals(expResult, result);
     }
 
-        /**
+    /**
      * Test of getMeanSquaredWeightedDeviation method, of class SampleDateModel.
      */
     @Test
@@ -213,13 +193,13 @@ public class SampleDateModelTest {
         BigDecimal result = instance.getMeanSquaredWeightedDeviation();
         assertEquals(expResult, result);
 
-        expResult=new BigDecimal("51");
+        expResult = new BigDecimal("51");
         instance.setMeanSquaredWeightedDeviation(expResult);
-        result=instance.getMeanSquaredWeightedDeviation();
+        result = instance.getMeanSquaredWeightedDeviation();
         assertEquals(expResult, result);
     }
 
-        /**
+    /**
      * Test of setMeanSquaredWeightedDeviation method, of class SampleDateModel.
      */
     @Test
@@ -230,14 +210,15 @@ public class SampleDateModelTest {
         BigDecimal result = instance.getMeanSquaredWeightedDeviation();
         assertEquals(expResult, result);
 
-        expResult=new BigDecimal("51");
+        expResult = new BigDecimal("51");
         instance.setMeanSquaredWeightedDeviation(expResult);
-        result=instance.getMeanSquaredWeightedDeviation();
+        result = instance.getMeanSquaredWeightedDeviation();
         assertEquals(expResult, result);
     }
-    
-        /**
-     * Test of getInternalTwoSigmaUnctWithTracerCalibrationUnct method, of class SampleDateModel.
+
+    /**
+     * Test of getInternalTwoSigmaUnctWithTracerCalibrationUnct method, of class
+     * SampleDateModel.
      */
     @Test
     public void test_GetInternalTwoSigmaUnctWithTracerCalibrationUnct() {
@@ -247,14 +228,15 @@ public class SampleDateModelTest {
         BigDecimal result = instance.getInternalTwoSigmaUnctWithTracerCalibrationUnct();
         assertEquals(expResult, result);
 
-        expResult=new BigDecimal("51");
+        expResult = new BigDecimal("51");
         instance.setInternalTwoSigmaUnctWithTracerCalibrationUnct(expResult);
-        result=instance.getInternalTwoSigmaUnctWithTracerCalibrationUnct();
+        result = instance.getInternalTwoSigmaUnctWithTracerCalibrationUnct();
         assertEquals(expResult, result);
     }
-    
-        /**
-     * Test of setInternalTwoSigmaUnctWithTracerCalibrationUnct method, of class SampleDateModel.
+
+    /**
+     * Test of setInternalTwoSigmaUnctWithTracerCalibrationUnct method, of class
+     * SampleDateModel.
      */
     @Test
     public void test_SetInternalTwoSigmaUnctWithTracerCalibrationUnct() {
@@ -264,15 +246,16 @@ public class SampleDateModelTest {
         BigDecimal result = instance.getInternalTwoSigmaUnctWithTracerCalibrationUnct();
         assertEquals(expResult, result);
 
-        expResult=new BigDecimal("51");
+        expResult = new BigDecimal("51");
         instance.setInternalTwoSigmaUnctWithTracerCalibrationUnct(expResult);
-        result=instance.getInternalTwoSigmaUnctWithTracerCalibrationUnct();
-        assertEquals(expResult, result);  
+        result = instance.getInternalTwoSigmaUnctWithTracerCalibrationUnct();
+        assertEquals(expResult, result);
     }
-    
-        /**
-     * Test of getInternalTwoSigmaUnctWithTracerCalibrationAndDecayConstantUnct method, of class SampleDateModel.
-    */
+
+    /**
+     * Test of getInternalTwoSigmaUnctWithTracerCalibrationAndDecayConstantUnct
+     * method, of class SampleDateModel.
+     */
     @Test
     public void test_GetInternalTwoSigmaUnctWithTracerCalibrationAndDecayConstantUnct() {
         System.out.println("Testing SampleDateModel's getInternalTwoSigmaUnctWithTracerCalibrationAndDecayConstantUnct()");
@@ -281,15 +264,16 @@ public class SampleDateModelTest {
         BigDecimal result = instance.getInternalTwoSigmaUnctWithTracerCalibrationAndDecayConstantUnct();
         assertEquals(expResult, result);
 
-        expResult=new BigDecimal("51");
+        expResult = new BigDecimal("51");
         instance.setInternalTwoSigmaUnctWithTracerCalibrationAndDecayConstantUnct(expResult);
-        result=instance.getInternalTwoSigmaUnctWithTracerCalibrationAndDecayConstantUnct();
-        assertEquals(expResult, result);  
-        
+        result = instance.getInternalTwoSigmaUnctWithTracerCalibrationAndDecayConstantUnct();
+        assertEquals(expResult, result);
+
     }
-    
-        /**
-     * Test of setInternalTwoSigmaUnctWithTracerCalibrationAndDecayConstantUnct method, of class SampleDateModel.
+
+    /**
+     * Test of setInternalTwoSigmaUnctWithTracerCalibrationAndDecayConstantUnct
+     * method, of class SampleDateModel.
      */
     @Test
     public void test_SetInternalTwoSigmaUnctWithTracerCalibrationAndDecayConstantUnct() {
@@ -299,14 +283,14 @@ public class SampleDateModelTest {
         BigDecimal result = instance.getInternalTwoSigmaUnctWithTracerCalibrationAndDecayConstantUnct();
         assertEquals(expResult, result);
 
-        expResult=new BigDecimal("51");
+        expResult = new BigDecimal("51");
         instance.setInternalTwoSigmaUnctWithTracerCalibrationAndDecayConstantUnct(expResult);
-        result=instance.getInternalTwoSigmaUnctWithTracerCalibrationAndDecayConstantUnct();
-        assertEquals(expResult, result); 
-        
+        result = instance.getInternalTwoSigmaUnctWithTracerCalibrationAndDecayConstantUnct();
+        assertEquals(expResult, result);
+
     }
 
-        /**
+    /**
      * Test of getExplanation method, of class SampleDateModel.
      */
     @Test
@@ -317,13 +301,13 @@ public class SampleDateModelTest {
         String result = instance.getExplanation();
         assertEquals(expResult, result);
 
-        expResult="sieg";
+        expResult = "sieg";
         instance.setExplanation(expResult);
-        result=instance.getExplanation();
-        assertEquals(expResult, result);   
-    
+        result = instance.getExplanation();
+        assertEquals(expResult, result);
+
     }
-    
+
     /**
      * Test of setExplanation method, of class SampleDateModel.
      */
@@ -335,13 +319,13 @@ public class SampleDateModelTest {
         String result = instance.getExplanation();
         assertEquals(expResult, result);
 
-        expResult="sieg";
+        expResult = "sieg";
         instance.setExplanation(expResult);
-        result=instance.getExplanation();
-        assertEquals(expResult, result);   
-       
+        result = instance.getExplanation();
+        assertEquals(expResult, result);
+
     }
-    
+
     /**
      * Test of getComment method, of class SampleDateModel.
      */
@@ -353,13 +337,13 @@ public class SampleDateModelTest {
         String result = instance.getComment();
         assertEquals(expResult, result);
 
-        expResult="sieg";
+        expResult = "sieg";
         instance.setComment(expResult);
-        result=instance.getComment();
-        assertEquals(expResult, result);   
-       
+        result = instance.getComment();
+        assertEquals(expResult, result);
+
     }
-    
+
     /**
      * Test of setComment method, of class SampleDateModel.
      */
@@ -371,14 +355,14 @@ public class SampleDateModelTest {
         String result = instance.getComment();
         assertEquals(expResult, result);
 
-        expResult="sieg";
+        expResult = "sieg";
         instance.setComment(expResult);
-        result=instance.getComment();
-        assertEquals(expResult, result);   
-       
+        result = instance.getComment();
+        assertEquals(expResult, result);
+
     }
-    
-        /**
+
+    /**
      * Test of isPreferred method, of class SampleDateModel.
      */
     @Test
@@ -389,12 +373,12 @@ public class SampleDateModelTest {
         boolean result = instance.isPreferred();
         assertEquals(expResult, result);
 
-        expResult=true;
+        expResult = true;
         instance.setPreferred(expResult);
-        result=instance.isPreferred();
+        result = instance.isPreferred();
         assertEquals(expResult, result);
     }
-    
+
     /**
      * Test of setPreferred method, of class SampleDateModel.
      */
@@ -406,12 +390,12 @@ public class SampleDateModelTest {
         boolean result = instance.isPreferred();
         assertEquals(expResult, result);
 
-        expResult=true;
+        expResult = true;
         instance.setPreferred(expResult);
-        result=instance.isPreferred();
-        assertEquals(expResult, result); 
+        result = instance.isPreferred();
+        assertEquals(expResult, result);
     }
-    
+
     /**
      * Test of getInternalTwoSigmaUnct method, of class SampleDateModel.
      */
@@ -423,16 +407,16 @@ public class SampleDateModelTest {
         BigDecimal result = instance.getInternalTwoSigmaUnct();
         assertEquals(expResult, result);
 
-        expResult=new BigDecimal("51");
+        expResult = new BigDecimal("51");
         instance.setInternalTwoSigmaUnct(expResult);
-        result=instance.getInternalTwoSigmaUnct();
-        assertEquals(expResult, result); 
-        
+        result = instance.getInternalTwoSigmaUnct();
+        assertEquals(expResult, result);
+
     }
-    
+
     /**
      * Test of setInternalTwoSigmaUnct method, of class SampleDateModel.
-    */
+     */
     @Test
     public void test_SetInternalTwoSigmaUnct() {
         System.out.println("Testing SampleDateModel's setInternalTwoSigmaUnct(BigDecimal internalTwoSigmaUnct)");
@@ -441,13 +425,13 @@ public class SampleDateModelTest {
         BigDecimal result = instance.getInternalTwoSigmaUnct();
         assertEquals(expResult, result);
 
-        expResult=new BigDecimal("51");
+        expResult = new BigDecimal("51");
         instance.setInternalTwoSigmaUnct(expResult);
-        result=instance.getInternalTwoSigmaUnct();
-        assertEquals(expResult, result); 
-        
+        result = instance.getInternalTwoSigmaUnct();
+        assertEquals(expResult, result);
+
     }
-    
+
     /**
      * Test of getIncludedFractionIDsVector method, of class SampleDateModel.
      */
@@ -455,14 +439,14 @@ public class SampleDateModelTest {
     public void test_GetIncludedFractionIDsVector() {
         System.out.println("Testing SampleDateModel's getIncludedFractionIDsVector()");
         SampleDateModel instance = new SampleDateModel();
-        Vector<String> bob=new Vector<>(51);
+        Vector<String> bob = new Vector<>(51);
         bob.add("hello");
         instance.setIncludedFractionIDsVector(bob);
         Vector<String> result = instance.getIncludedFractionIDsVector();
         assertEquals("hello", result.get(0));
 
     }
-    
+
     /**
      * Test of setIncludedFractionIDsVector method, of class SampleDateModel.
      */
@@ -470,15 +454,15 @@ public class SampleDateModelTest {
     public void test_SetIncludedFractionIDsVector() {
         System.out.println("Testing SampleDateModel's setIncludedFractionIDsVector(Vector<String> includedFractionIDsVector)");
         SampleDateModel instance = new SampleDateModel();
-        Vector<String> bob=new Vector<>(51);
+        Vector<String> bob = new Vector<>(51);
         bob.add("hello");
         instance.setIncludedFractionIDsVector(bob);
         Vector<String> result = instance.getIncludedFractionIDsVector();
         assertEquals("hello", result.get(0));
-   
+
     }
 
-        /**
+    /**
      * Test of includesFractionByName method, of class SampleDateModel.
      */
     @Test
@@ -489,17 +473,17 @@ public class SampleDateModelTest {
         boolean expResult = false;
         boolean result = instance.includesFractionByName(fractionID);
         assertEquals(expResult, result);
-        
-        expResult=true;
-        Vector<String> bob=new Vector<>(51);
+
+        expResult = true;
+        Vector<String> bob = new Vector<>(51);
         bob.add("hello");
         instance.setIncludedFractionIDsVector(bob);
-        fractionID="hello";
+        fractionID = "hello";
         result = instance.includesFractionByName(fractionID);
-        assertEquals(expResult, result);    
-    
+        assertEquals(expResult, result);
+
     }
-    
+
     /**
      * Test of ToggleAliquotFractionByName method, of class SampleDateModel.
      */
@@ -509,19 +493,19 @@ public class SampleDateModelTest {
         System.out.println("Testing SampleDateModel's ToggleAliquotFractionByName(String fractionID)");
         String fractionID = "hello";
         SampleDateModel instance = new SampleDateModel();
-        
-        Vector<String> bob=new Vector<>(51);
+
+        Vector<String> bob = new Vector<>(51);
         bob.add("hello");
-        instance.setIncludedFractionIDsVector(bob);        
-        
-        assertEquals("[hello]",instance.getIncludedFractionIDsVector().toString());
-   
+        instance.setIncludedFractionIDsVector(bob);
+
+        assertEquals("[hello]", instance.getIncludedFractionIDsVector().toString());
+
         instance.ToggleAliquotFractionByName(fractionID);
 
-        assertEquals("[]",instance.getIncludedFractionIDsVector().toString());
-        
+        assertEquals("[]", instance.getIncludedFractionIDsVector().toString());
+
     }
-    
+
     /**
      * Test of ToggleSampleFractionByName method, of class SampleDateModel.
      */
@@ -531,21 +515,22 @@ public class SampleDateModelTest {
         System.out.println("Testing SampleDateModel's ToggleSampleFractionByName(String fractionID)");
         String fractionID = "hello";
         SampleDateModel instance = new SampleDateModel();
-        
-        Vector<String> bob=new Vector<>(51);
+
+        Vector<String> bob = new Vector<>(51);
         bob.add("hello");
-        instance.setIncludedFractionIDsVector(bob);        
-        
-        assertEquals("[hello]",instance.getIncludedFractionIDsVector().toString());
-   
+        instance.setIncludedFractionIDsVector(bob);
+
+        assertEquals("[hello]", instance.getIncludedFractionIDsVector().toString());
+
         instance.ToggleSampleFractionByName(fractionID);
 
-        assertEquals("[]",instance.getIncludedFractionIDsVector().toString());
-        
+        assertEquals("[]", instance.getIncludedFractionIDsVector().toString());
+
     }
-    
+
     /**
-     * Test of getInternalTwoSigmaUnctWithStandardRatioVarUnct method, of class SampleDateModel.
+     * Test of getInternalTwoSigmaUnctWithStandardRatioVarUnct method, of class
+     * SampleDateModel.
      */
     @Test
     public void test_GetInternalTwoSigmaUnctWithStandardRatioVarUnct() {
@@ -555,14 +540,15 @@ public class SampleDateModelTest {
         BigDecimal result = instance.getInternalTwoSigmaUnctWithStandardRatioVarUnct();
         assertEquals(expResult, result);
 
-        expResult=new BigDecimal("51");
+        expResult = new BigDecimal("51");
         instance.setInternalTwoSigmaUnctWithStandardRatioVarUnct(expResult);
-        result=instance.getInternalTwoSigmaUnctWithStandardRatioVarUnct();
-        assertEquals(expResult, result); 
+        result = instance.getInternalTwoSigmaUnctWithStandardRatioVarUnct();
+        assertEquals(expResult, result);
     }
-    
+
     /**
-     * Test of setInternalTwoSigmaUnctWithStandardRatioVarUnct method, of class SampleDateModel.
+     * Test of setInternalTwoSigmaUnctWithStandardRatioVarUnct method, of class
+     * SampleDateModel.
      */
     @Test
     public void test_SetInternalTwoSigmaUnctWithStandardRatioVarUnct() {
@@ -572,12 +558,12 @@ public class SampleDateModelTest {
         BigDecimal result = instance.getInternalTwoSigmaUnctWithStandardRatioVarUnct();
         assertEquals(expResult, result);
 
-        expResult=new BigDecimal("51");
+        expResult = new BigDecimal("51");
         instance.setInternalTwoSigmaUnctWithStandardRatioVarUnct(expResult);
-        result=instance.getInternalTwoSigmaUnctWithStandardRatioVarUnct();
-        assertEquals(expResult, result); 
+        result = instance.getInternalTwoSigmaUnctWithStandardRatioVarUnct();
+        assertEquals(expResult, result);
     }
-    
+
     /**
      * Test of getMethodName method, of class SampleDateModel.
      */
@@ -589,13 +575,13 @@ public class SampleDateModelTest {
         String result = instance.getMethodName();
         assertEquals(expResult, result);
 
-        expResult="sieg";
+        expResult = "sieg";
         instance.setMethodName(expResult);
-        result=instance.getMethodName();
-        assertEquals(expResult, result);   
-       
+        result = instance.getMethodName();
+        assertEquals(expResult, result);
+
     }
-    
+
     /**
      * Test of setMethodName method, of class SampleDateModel.
      */
@@ -607,13 +593,13 @@ public class SampleDateModelTest {
         String result = instance.getMethodName();
         assertEquals(expResult, result);
 
-        expResult="sieg";
+        expResult = "sieg";
         instance.setMethodName(expResult);
-        result=instance.getMethodName();
-        assertEquals(expResult, result);   
-       
+        result = instance.getMethodName();
+        assertEquals(expResult, result);
+
     }
-    
+
     /**
      * Test of showFractionIdWithDateAndUnct method, of class SampleDateModel.
      */
@@ -621,26 +607,24 @@ public class SampleDateModelTest {
     public void test_ShowFractionIdWithDateAndUnct() {
         System.out.println("Testing SampleDateModel's showFractionIdWithDateAndUnct(Fraction fraction, String dateUnit)");
         FractionI fraction = new UPbFraction();
-        
+
         String dateUnit = "";
         SampleDateModel instance = new SampleDateModel();
         String expResult = "NONE";
         String result = instance.showFractionIdWithDateAndUnct(fraction);
-        
-        
-        assertEquals(expResult, result);
-        
-        fraction = new UPbFraction("hello");
-        dateUnit = "hell";
-        expResult="hello";
-        
-        result = instance.showFractionIdWithDateAndUnct(fraction);
-        
+
         assertEquals(expResult, result);
 
-        
+        fraction = new UPbFraction("hello");
+        dateUnit = "hell";
+        expResult = "hello";
+
+        result = instance.showFractionIdWithDateAndUnct(fraction);
+
+        assertEquals(expResult, result);
+
     }
-    
+
     /**
      * Test of ShowCustomDateNode method, of class SampleDateModel.
      */
@@ -650,18 +634,17 @@ public class SampleDateModelTest {
         SampleDateModel instance = new SampleDateModel();
         String expResult = "date = 0 ± 0/0.00/0.00 Ma 2σ";
         String result = instance.ShowCustomDateNode();
-        
-        assertEquals(expResult, result);
-        
-        instance=new SampleDateModel("hello","there","silly",new BigDecimal("430"),"ABS",new BigDecimal("51"));        
-        result = instance.ShowCustomDateNode();
-        expResult="date = 0.00043 ± 0.00010/0.00/0.00 Ma 2σ";
-        
+
         assertEquals(expResult, result);
 
-        
+        instance = new SampleDateModel("hello", "there", "silly", new BigDecimal("430"), "ABS", new BigDecimal("51"));
+        result = instance.ShowCustomDateNode();
+        expResult = "date = 0.00043 ± 0.00010/0.00/0.00 Ma 2σ";
+
+        assertEquals(expResult, result);
+
     }
-    
+
     /**
      * Test of ShowCustomMSWDwithN method, of class SampleDateModel.
      */
@@ -671,49 +654,49 @@ public class SampleDateModelTest {
         SampleDateModel instance = new SampleDateModel();
         String expResult = "MSWD = 0, n = 0";
         String result = instance.ShowCustomMSWDwithN();
-        
+
         assertEquals(expResult, result);
-        
-        instance=new SampleDateModel("hello","there","silly",new BigDecimal("6666666"),"ABS",new BigDecimal("84984"));  
+
+        instance = new SampleDateModel("hello", "there", "silly", new BigDecimal("6666666"), "ABS", new BigDecimal("84984"));
         instance.setMeanSquaredWeightedDeviation(new BigDecimal("51"));
-        Vector<String> bob=new Vector<>(51);
+        Vector<String> bob = new Vector<>(51);
         bob.add("ave");
         instance.setIncludedFractionIDsVector(bob);
-        
+
         expResult = "MSWD = 51, n = 1";
-        
+
         result = instance.ShowCustomMSWDwithN();
-        
+
         assertEquals(expResult, result);
 
     }
-    
+
     /**
      * Test of ShowCustomMSWD method, of class SampleDateModel.
-    */
+     */
     @Test
     public void test_ShowCustomMSWD() {
         System.out.println("Testing SampleDateModel's ShowCustomMSWD()");
         SampleDateModel instance = new SampleDateModel();
         String expResult = "MSWD = 0";
         String result = instance.ShowCustomMSWD();
-        
+
         assertEquals(expResult, result);
-        
-        instance=new SampleDateModel("hello","there","silly",new BigDecimal("6666666"),"ABS",new BigDecimal("84984"));  
+
+        instance = new SampleDateModel("hello", "there", "silly", new BigDecimal("6666666"), "ABS", new BigDecimal("84984"));
         instance.setMeanSquaredWeightedDeviation(new BigDecimal("51"));
-        Vector<String> bob=new Vector<>(51);
+        Vector<String> bob = new Vector<>(51);
         bob.add("ave");
         instance.setIncludedFractionIDsVector(bob);
-        
+
         expResult = "MSWD = 51";
-        
+
         result = instance.ShowCustomMSWD();
-        
+
         assertEquals(expResult, result);
 
     }
-    
+
     /**
      * Test of ShowCustomN method, of class SampleDateModel.
      */
@@ -723,23 +706,23 @@ public class SampleDateModelTest {
         SampleDateModel instance = new SampleDateModel();
         String expResult = "n = 0";
         String result = instance.ShowCustomN();
-        
+
         assertEquals(expResult, result);
-        
-        instance=new SampleDateModel("hello","there","silly",new BigDecimal("6666666"),"ABS",new BigDecimal("84984"));  
+
+        instance = new SampleDateModel("hello", "there", "silly", new BigDecimal("6666666"), "ABS", new BigDecimal("84984"));
         instance.setMeanSquaredWeightedDeviation(new BigDecimal("51"));
-        Vector<String> bob=new Vector<>(51);
+        Vector<String> bob = new Vector<>(51);
         bob.add("ave");
         instance.setIncludedFractionIDsVector(bob);
-        
+
         expResult = "n = 1";
-        
+
         result = instance.ShowCustomN();
-        
+
         assertEquals(expResult, result);
 
     }
-    
+
     /**
      * Test of ShowCustomFractionCountNode method, of class SampleDateModel.
      */
@@ -749,24 +732,26 @@ public class SampleDateModelTest {
         SampleDateModel instance = new SampleDateModel();
         String expResult = "n = 0";
         String result = instance.ShowCustomFractionCountNode();
-        
+
         assertEquals(expResult, result);
-        
-        instance=new SampleDateModel("hello","there","silly",new BigDecimal("6666666"),"ABS",new BigDecimal("84984"));  
+
+        instance = new SampleDateModel("hello", "there", "silly", new BigDecimal("6666666"), "ABS", new BigDecimal("84984"));
         instance.setMeanSquaredWeightedDeviation(new BigDecimal("51"));
-        Vector<String> bob=new Vector<>(51);
+        Vector<String> bob = new Vector<>(51);
         bob.add("ave");
         instance.setIncludedFractionIDsVector(bob);
-        
+
         expResult = "n = 1";
-        
+
         result = instance.ShowCustomFractionCountNode();
-        
+
         assertEquals(expResult, result);
-        
+
     }
+
     /**
-     * Test of FormatValueAndTwoSigmaABSThreeWaysForPublication method, of class SampleDateModel.
+     * Test of FormatValueAndTwoSigmaABSThreeWaysForPublication method, of class
+     * SampleDateModel.
      */
     @Test
     public void test_FormatValueAndTwoSigmaABSThreeWaysForPublication() {
@@ -777,19 +762,20 @@ public class SampleDateModelTest {
         String expResult = "0 ± 0/0.00/0.00";
         String result = instance.FormatValueAndTwoSigmaABSThreeWaysForPublication(divideByPowerOfTen, uncertaintySigDigits);
         assertEquals(expResult, result);
-        
-        instance=new SampleDateModel("hello","there","silly",new BigDecimal("6666666"),"ABS",new BigDecimal("84984"));  
+
+        instance = new SampleDateModel("hello", "there", "silly", new BigDecimal("6666666"), "ABS", new BigDecimal("84984"));
         instance.setMeanSquaredWeightedDeviation(new BigDecimal("51"));
-        Vector<String> bob=new Vector<>(51);
+        Vector<String> bob = new Vector<>(51);
         bob.add("ave");
         instance.setIncludedFractionIDsVector(bob);
-        
+
         expResult = "6.67 ± 0.17/0.00/0.00";
-        
+
         result = instance.FormatValueAndTwoSigmaABSThreeWaysForPublication(divideByPowerOfTen, uncertaintySigDigits);
-        
-        assertEquals(expResult, result);    }
-    
+
+        assertEquals(expResult, result);
+    }
+
     /**
      * Test of getDateName method, of class SampleDateModel.
      */
@@ -801,12 +787,12 @@ public class SampleDateModelTest {
         String result = instance.getDateName();
         assertEquals(expResult, result);
 
-        expResult="sieg";
+        expResult = "sieg";
         instance.setDateName(expResult);
-        result=instance.getDateName();
-        assertEquals(expResult, result);   
+        result = instance.getDateName();
+        assertEquals(expResult, result);
     }
-    
+
     /**
      * Test of setDateName method, of class SampleDateModel.
      */
@@ -818,12 +804,12 @@ public class SampleDateModelTest {
         String result = instance.getDateName();
         assertEquals(expResult, result);
 
-        expResult="sieg";
+        expResult = "sieg";
         instance.setDateName(expResult);
-        result=instance.getDateName();
-        assertEquals(expResult, result);   
+        result = instance.getDateName();
+        assertEquals(expResult, result);
     }
-    
+
     /**
      * Test of getAliquot method, of class SampleDateModel.
      */
@@ -835,14 +821,14 @@ public class SampleDateModelTest {
         AliquotInterface result = instance.getAliquot();
         assertEquals(null, result);
 
-        expResult=null;
+        expResult = null;
         instance.setAliquot(expResult);
-        result=instance.getAliquot();
-        assertEquals(expResult, result); 
-        
+        result = instance.getAliquot();
+        assertEquals(expResult, result);
+
     }
-    
-        /**
+
+    /**
      * Test of setAliquot method, of class SampleDateModel.
      */
     @Test
@@ -853,12 +839,12 @@ public class SampleDateModelTest {
         AliquotInterface result = instance.getAliquot();
         assertEquals(null, result);
 
-        expResult=null;
+        expResult = null;
         instance.setAliquot(expResult);
-        result=instance.getAliquot();
-        assertEquals(expResult, result); 
+        result = instance.getAliquot();
+        assertEquals(expResult, result);
     }
-    
+
     /**
      * Test of getYorkLineFit method, of class SampleDateModel.
      */
@@ -870,12 +856,12 @@ public class SampleDateModelTest {
         YorkLineFit result = instance.getYorkLineFit();
         assertEquals(null, result);
 
-        expResult=null;
+        expResult = null;
         instance.setYorkLineFit(expResult);
-        result=instance.getYorkLineFit();
-        assertEquals(expResult, result); 
+        result = instance.getYorkLineFit();
+        assertEquals(expResult, result);
     }
-    
+
     /**
      * Test of setYorkLineFit method, of class SampleDateModel.
      */
@@ -887,12 +873,12 @@ public class SampleDateModelTest {
         YorkLineFit result = instance.getYorkLineFit();
         assertEquals(null, result);
 
-        expResult=null;
+        expResult = null;
         instance.setYorkLineFit(expResult);
-        result=instance.getYorkLineFit();
-        assertEquals(expResult, result); 
+        result = instance.getYorkLineFit();
+        assertEquals(expResult, result);
     }
-    
+
     /**
      * Test of getSample method, of class SampleDateModel.
      */
@@ -904,12 +890,12 @@ public class SampleDateModelTest {
         SampleInterface result = instance.getSample();
         assertEquals(null, result);
 
-        expResult=null;
+        expResult = null;
         instance.setSample(expResult);
-        result=instance.getSample();
-        assertEquals(expResult, result); 
+        result = instance.getSample();
+        assertEquals(expResult, result);
     }
-    
+
     /**
      * Test of setSample method, of class SampleDateModel.
      */
@@ -921,12 +907,12 @@ public class SampleDateModelTest {
         SampleInterface result = instance.getSample();
         assertEquals(null, result);
 
-        expResult=null;
+        expResult = null;
         instance.setSample(expResult);
-        result=instance.getSample();
-        assertEquals(expResult, result); 
+        result = instance.getSample();
+        assertEquals(expResult, result);
     }
-    
+
     /**
      * Test of isDisplayedAsGraph method, of class SampleDateModel.
      */
@@ -937,14 +923,14 @@ public class SampleDateModelTest {
         boolean expResult = false;
         boolean result = instance.isDisplayedAsGraph();
         assertEquals(expResult, result);
-        
-        expResult=true;
+
+        expResult = true;
         instance.setDisplayedAsGraph(expResult);
         result = instance.isDisplayedAsGraph();
         assertEquals(expResult, result);
-    
+
     }
-    
+
     /**
      * Test of setDisplayedAsGraph method, of class SampleDateModel.
      */
@@ -955,12 +941,13 @@ public class SampleDateModelTest {
         boolean expResult = false;
         boolean result = instance.isDisplayedAsGraph();
         assertEquals(expResult, result);
-        
-        expResult=true;
+
+        expResult = true;
         instance.setDisplayedAsGraph(expResult);
         result = instance.isDisplayedAsGraph();
         assertEquals(expResult, result);
     }
+
     /**
      * Test of getSampleAnalysisType method, of class SampleDateModel.
      */
@@ -971,13 +958,13 @@ public class SampleDateModelTest {
         SampleAnalysisTypesEnum expResult = SampleAnalysisTypesEnum.COMPILED;
         SampleAnalysisTypesEnum result = instance.getSampleAnalysisType();
         assertEquals(expResult, result);
-        
-        expResult=SampleAnalysisTypesEnum.GENERIC_UPB;
+
+        expResult = SampleAnalysisTypesEnum.GENERIC_UPB;
         instance.setSampleAnalysisType(expResult);
         result = instance.getSampleAnalysisType();
-        assertEquals(expResult, result);    
+        assertEquals(expResult, result);
     }
-    
+
     /**
      * Test of setSampleAnalysisType method, of class SampleDateModel.
      */
@@ -988,22 +975,16 @@ public class SampleDateModelTest {
         SampleAnalysisTypesEnum expResult = SampleAnalysisTypesEnum.COMPILED;
         SampleAnalysisTypesEnum result = instance.getSampleAnalysisType();
         assertEquals(expResult, result);
-        
-        expResult=SampleAnalysisTypesEnum.GENERIC_UPB;
+
+        expResult = SampleAnalysisTypesEnum.GENERIC_UPB;
         instance.setSampleAnalysisType(expResult);
         result = instance.getSampleAnalysisType();
-        assertEquals(expResult, result);    
-    }    
-    
-    
-    
-    
-    
-    
+        assertEquals(expResult, result);
+    }
+
     ////////////////////////
     ////Unfinished Tests////
     //////////////////////// 
-    
     /*
      *
      *
@@ -1047,17 +1028,17 @@ public class SampleDateModelTest {
      *
      *
      *
-     */    
-
+     */
     /**
-     * Integration Test of class SampleDateModel
-     * Testing the writing and reading of a file
+     * Integration Test of class SampleDateModel Testing the writing and reading
+     * of a file
+     *
      * @throws Exception
      */
-    @Test    
+    @Test
     public void testSerialization() throws Exception {
 
-        try{
+        try {
             ValueModel valueModel
                     = new SampleDateModel("WM208_232", "WM208_232",//
                             "r206_204b", new BigDecimal("1234567890"), "ABS", new BigDecimal("123000"));
@@ -1069,24 +1050,24 @@ public class SampleDateModelTest {
             valueModel.serializeXMLObject(testFileName);
             //There's a Schema Problem
             //valueModel.readXMLObject(testFileName, true);
-            
-        }finally{
+
+        } finally {
             cleanFiles();
         }
     }
-    
-     /**
+
+    /**
      * Delete the files created previously
-     * @throws Exception 
+     *
+     * @throws Exception
      */
-    public void cleanFiles() throws Exception
-    {
+    public void cleanFiles() throws Exception {
         File file = new File("SampleDateModelTEST.xml"); //Get the file
-        if(!(file.delete())) //delete
+        if (!(file.delete())) //delete
         {
             //throw exception in case of error
             throw new Exception("Testing File 'SampleDateModelTEST.xml' couldn't be deleted");
         }
-    }        
-      
+    }
+
 }

--- a/src/test/java/org/earthtime/dataDictionaries/RadDatesTest.java
+++ b/src/test/java/org/earthtime/dataDictionaries/RadDatesTest.java
@@ -94,8 +94,9 @@ public class RadDatesTest {
         assertEquals("dateBP", list[17]);
         assertEquals("dateCorr", list[18]);
         assertEquals("dateCorrBP", list[19]);
-        assertEquals("percentDiscordance", list[20]);
-        assertEquals("percentDiscordance_PbcCorr", list[21]);
+        assertEquals("dateOpenSys", list[20]);
+        assertEquals("percentDiscordance", list[21]);
+        assertEquals("percentDiscordance_PbcCorr", list[22]);
 
     }
 


### PR DESCRIPTION
fixes #182 by checking for keyword atomic vs activity in the two columns of the template (P and Q);  note to @PeterChutcharavan that testing is required.

fixes #181 with various improvements to the UI

fixes #171 with better plotting

fixes #164 with switch to entry/display of fraction mass in micrograms and sorting of fraction names in sample manager

also, adds uncertainty envelope to plotted seawater curves and provides interface for assigning seawater models to individual fractions and then calculate the open-system date and uncertainty per fraction.
